### PR TITLE
Update repo links for move to hex-inc org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ VegaFusion provides serverside acceleration for the [Vega](https://vega.github.i
 
 The core VegaFusion algorithms are implemented in Rust. Python integration is provided using [PyO3](https://pyo3.rs/v0.15.1/) and JavaScript integration is provided using [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen).
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vegafusion/demos/HEAD?labpath=notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hex-inc/vegafusion-demos/HEAD?labpath=notebooks)
 
 ## Documentation
 See the documentation at https://vegafusion.io

--- a/javascript/vegafusion-embed/package.json
+++ b/javascript/vegafusion-embed/package.json
@@ -17,9 +17,9 @@
     "css/*.css",
     "images/*.svg"
   ],
-  "homepage": "https://github.com/vegafusion/vegafusion",
+  "homepage": "https://github.com/hex-inc/vegafusion",
   "bugs": {
-    "url": "https://github.com/vegafusion/vegafusion/issues"
+    "url": "https://github.com/hex-inc/vegafusion/issues"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/javascript/vegafusion-embed/package/package.json
+++ b/javascript/vegafusion-embed/package/package.json
@@ -17,9 +17,9 @@
     "css/*.css",
     "images/*.svg"
   ],
-  "homepage": "https://github.com/vegafusion/vegafusion",
+  "homepage": "https://github.com/hex-inc/vegafusion",
   "bugs": {
-    "url": "https://github.com/vegafusion/vegafusion/issues"
+    "url": "https://github.com/hex-inc/vegafusion/issues"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/python/vegafusion-jupyter/package.json
+++ b/python/vegafusion-jupyter/package.json
@@ -16,9 +16,9 @@
     "css/*.scss",
     "images/*.svg"
   ],
-  "homepage": "https://github.com/vegafusion/vegafusion",
+  "homepage": "https://github.com/hex-inc/vegafusion",
   "bugs": {
-    "url": "https://github.com/vegafusion/vegafusion/issues"
+    "url": "https://github.com/hex-inc/vegafusion/issues"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/python/vegafusion/setup.cfg
+++ b/python/vegafusion/setup.cfg
@@ -12,7 +12,7 @@ license = BSD-3-Clause
 license_file = LICENSE.txt
 python = "^3.7"
 homepage = "https://vegafusion.io"
-repository = "https://github.com/vegafusion/vegafusion"
+repository = "https://github.com/hex-inc/vegafusion"
 documentation = "https://vegafusion.io"
 classifiers = 
 	Programming Language :: Python :: 3.7

--- a/vegafusion-wasm/README.md
+++ b/vegafusion-wasm/README.md
@@ -1,4 +1,4 @@
 # vegafusion-wasm
 Wasm library for interfacing with VegaFusion
 
-For more information, see the VegaFusion repository at https://github.com/vegafusion/vegafusion
+For more information, see the VegaFusion repository at https://github.com/hex-inc/vegafusion

--- a/vegafusion-wasm/package.json
+++ b/vegafusion-wasm/package.json
@@ -13,9 +13,9 @@
     "Vega-Lite",
     "visualization"
   ],
-  "homepage": "https://github.com/vegafusion/vegafusion",
+  "homepage": "https://github.com/hex-inc/vegafusion",
   "bugs": {
-    "url": "https://github.com/vegafusion/vegafusion/issues"
+    "url": "https://github.com/hex-inc/vegafusion/issues"
   },
   "files": [
     "vegafusion_wasm_bg.wasm",


### PR DESCRIPTION
Updates various project links now that the VegaFusion repos have moved under the `hex-inc` GitHub org