### PR TITLE
Improve fidelity of distinct aggregate and pivot transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,8 +938,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -984,8 +984,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "arrow",
  "chrono",
@@ -998,8 +998,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1010,8 +1010,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1026,8 +1026,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1056,8 +1056,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1067,8 +1067,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "16.0.0"
-source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=e3f156f4acc51fc45a7aa6a99085b091f539d5fa#e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+version = "16.1.0"
+source = "git+https://github.com/jonmmease/arrow-datafusion.git?rev=1e6438de31219b284df9b83f25ca36ddb1184f22#1e6438de31219b284df9b83f25ca36ddb1184f22"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -37,9 +37,9 @@ default_features = false
 features = [ "ipc", "json",]
 
 [dependencies.datafusion-common]
-version = "~16.0.0"
+version = "~16.1.0"
 git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+rev = "1e6438de31219b284df9b83f25ca36ddb1184f22"
 
 [dependencies.pyo3]
 version = "0.17.1"

--- a/vegafusion-rt-datafusion/Cargo.toml
+++ b/vegafusion-rt-datafusion/Cargo.toml
@@ -75,14 +75,14 @@ version = "1.0.137"
 features = [ "derive",]
 
 [dependencies.datafusion]
-version = "~16.0.0"
+version = "~16.1.0"
 git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+rev = "1e6438de31219b284df9b83f25ca36ddb1184f22"
 
 [dependencies.datafusion-expr]
-version = "~16.0.0"
+version = "~16.1.0"
 git = "https://github.com/jonmmease/arrow-datafusion.git"
-rev = "e3f156f4acc51fc45a7aa6a99085b091f539d5fa"
+rev = "1e6438de31219b284df9b83f25ca36ddb1184f22"
 
 [dependencies.tokio]
 version = "1.18.1"

--- a/vegafusion-rt-datafusion/src/data/tasks.rs
+++ b/vegafusion-rt-datafusion/src/data/tasks.rs
@@ -141,7 +141,7 @@ impl TaskCall for DataUrlTask {
 
         // Construct SqlDataFrame
         let ctx = make_session_context();
-        ctx.register_table("tbl", Arc::new(df))?;
+        ctx.register_table("tbl", df.into_view())?;
         let sql_conn = DataFusionConnection::new(Arc::new(ctx));
 
         let sql_df = Arc::new(SqlDataFrame::try_new(Arc::new(sql_conn), "tbl").await?);

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -135,7 +135,11 @@ pub fn make_aggr_expr_for_named_col(
     make_agg_expr_for_col_expr(column, op, schema)
 }
 
-pub fn make_agg_expr_for_col_expr(column: Expr, op: &AggregateOp, schema: &DFSchema) -> Result<Expr> {
+pub fn make_agg_expr_for_col_expr(
+    column: Expr,
+    op: &AggregateOp,
+    schema: &DFSchema,
+) -> Result<Expr> {
     let numeric_column = || {
         to_numeric(column.clone(), schema).unwrap_or_else(|err| {
             panic!(

--- a/vegafusion-rt-datafusion/src/transform/aggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/aggregate.rs
@@ -97,7 +97,7 @@ fn get_agg_and_proj_exprs(tx: &Aggregate, schema: &DFSchema) -> Result<(Vec<Expr
     for ((col_name, op_code), alias) in agg_aliases {
         let op = AggregateOp::from_i32(op_code).unwrap();
 
-        let agg_expr = make_aggr_expr(col_name, &op, schema)?;
+        let agg_expr = make_aggr_expr_for_named_col(col_name, &op, schema)?;
 
         // Apply alias
         let agg_expr = agg_expr.alias(alias);
@@ -107,7 +107,7 @@ fn get_agg_and_proj_exprs(tx: &Aggregate, schema: &DFSchema) -> Result<(Vec<Expr
     Ok((agg_exprs, projections))
 }
 
-pub fn make_aggr_expr(
+pub fn make_aggr_expr_for_named_col(
     col_name: Option<String>,
     op: &AggregateOp,
     schema: &DFSchema,
@@ -132,6 +132,10 @@ pub fn make_aggr_expr(
         lit(0i32)
     };
 
+    make_agg_expr_for_col_expr(column, op, schema)
+}
+
+pub fn make_agg_expr_for_col_expr(column: Expr, op: &AggregateOp, schema: &DFSchema) -> Result<Expr> {
     let numeric_column = || {
         to_numeric(column.clone(), schema).unwrap_or_else(|err| {
             panic!(

--- a/vegafusion-rt-datafusion/src/transform/joinaggregate.rs
+++ b/vegafusion-rt-datafusion/src/transform/joinaggregate.rs
@@ -7,7 +7,7 @@ use datafusion::logical_expr::Expr;
 use crate::sql::compile::expr::ToSqlExpr;
 use crate::sql::compile::select::ToSqlSelectItem;
 use crate::sql::dataframe::SqlDataFrame;
-use crate::transform::aggregate::make_aggr_expr;
+use crate::transform::aggregate::make_aggr_expr_for_named_col;
 use async_trait::async_trait;
 use datafusion::common::Column;
 use sqlgen::dialect::DialectDisplay;
@@ -46,9 +46,9 @@ impl TransformTrait for JoinAggregate {
 
             let agg_expr = if matches!(op, AggregateOp::Count) {
                 // In Vega, the provided column is always ignored if op is 'count'.
-                make_aggr_expr(None, &op, &schema)?
+                make_aggr_expr_for_named_col(None, &op, &schema)?
             } else {
-                make_aggr_expr(Some(field.clone()), &op, &schema)?
+                make_aggr_expr_for_named_col(Some(field.clone()), &op, &schema)?
             };
 
             // Apply alias

--- a/vegafusion-rt-datafusion/src/transform/pivot.rs
+++ b/vegafusion-rt-datafusion/src/transform/pivot.rs
@@ -4,20 +4,30 @@ use crate::expression::escape::{flat_col, unescaped_col};
 use crate::sql::compile::expr::ToSqlExpr;
 use crate::sql::compile::select::ToSqlSelectItem;
 use crate::sql::dataframe::SqlDataFrame;
-use crate::transform::aggregate::make_aggr_expr;
+use crate::transform::aggregate::{make_agg_expr_for_col_expr, make_aggr_expr_for_named_col};
 use crate::transform::utils::RecordBatchUtils;
 use crate::transform::TransformTrait;
 use async_trait::async_trait;
 use datafusion::prelude::Column;
-use datafusion_expr::{coalesce, col, expr::Sort, lit, min, when, Expr};
+use datafusion_expr::{coalesce, expr::Sort, lit, min, when, Expr};
 use sqlgen::dialect::DialectDisplay;
 use std::sync::Arc;
 use vegafusion_core::arrow::array::StringArray;
 use vegafusion_core::arrow::datatypes::DataType;
+use vegafusion_core::data::scalar::ScalarValue;
 use vegafusion_core::data::ORDER_COL;
 use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
+use vegafusion_core::expression::escape::unescape_field;
 use vegafusion_core::proto::gen::transforms::{AggregateOp, Pivot};
 use vegafusion_core::task_graph::task_value::TaskValue;
+
+
+/// NULL_PLACEHOLDER_NAME is used for sorting to match Vega, where null always comes first for
+/// limit sorting
+const NULL_PLACEHOLDER_NAME: &str = "!!!null";
+
+/// NULL_NAME is the final column name for null columns
+const NULL_NAME: &str = "null";
 
 #[async_trait]
 impl TransformTrait for Pivot {
@@ -35,13 +45,14 @@ impl TransformTrait for Pivot {
                 .fields
                 .iter()
                 .map(|field| {
-                    if field.name() == &self.field {
-                        Ok(when(col(&self.field).eq(lit(true)), lit("true"))
+                    if field.name() == &unescape_field(&self.field)  {
+                        Ok(when(unescaped_col(&self.field).eq(lit(true)), lit("true"))
+                            .when(unescaped_col(&self.field).is_null(), lit(NULL_PLACEHOLDER_NAME))
                             .otherwise(lit("false"))
                             .expect("Failed to construct Case expression")
                             .alias(&self.field))
                     } else {
-                        Ok(unescaped_col(field.name()))
+                        Ok(flat_col(field.name()))
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -53,29 +64,39 @@ impl TransformTrait for Pivot {
                 .fields
                 .iter()
                 .map(|field| {
-                    if field.name() == &self.field {
-                        Ok(cast_to(
-                            unescaped_col(&self.field),
-                            &DataType::Utf8,
-                            &dataframe.schema_df(),
-                        )?
-                        .alias(&self.field))
+                    if field.name() == &unescape_field(&self.field)  {
+                        Ok(when(unescaped_col(&self.field).is_null(), lit(NULL_PLACEHOLDER_NAME))
+                            .otherwise(cast_to(
+                                unescaped_col(&self.field),
+                                &DataType::Utf8,
+                                &dataframe.schema_df(),
+                            )?)?
+                            .alias(&self.field))
                     } else {
-                        Ok(unescaped_col(field.name()))
+                        Ok(flat_col(field.name()))
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;
             dataframe.select(select_exprs).await?
         } else {
-            // Column type is string
-            dataframe
+            // Column type is string, just replace NULL with "null"
+            let select_exprs: Vec<_> = dataframe
+                .schema()
+                .fields
+                .iter()
+                .map(|field| {
+                    if field.name() == &unescape_field(&self.field) {
+                        Ok(coalesce(vec![unescaped_col(&self.field), lit(NULL_PLACEHOLDER_NAME)])
+                            .alias(&self.field))
+                    } else {
+                        Ok(flat_col(field.name()))
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?;
+            dataframe.select(select_exprs).await?
         };
 
-        if self.groupby.is_empty() {
-            pivot_without_grouping(self, dataframe).await
-        } else {
-            pivot_with_grouping(self, dataframe).await
-        }
+        pivot_case(self, dataframe).await
     }
 }
 
@@ -117,7 +138,7 @@ async fn extract_sorted_pivot_values(tx: &Pivot, dataframe: &SqlDataFrame) -> Re
     Ok(pivot_vec)
 }
 
-async fn pivot_without_grouping(
+async fn pivot_case(
     tx: &Pivot,
     dataframe: Arc<SqlDataFrame>,
 ) -> Result<(Arc<SqlDataFrame>, Vec<TaskValue>)> {
@@ -134,179 +155,42 @@ async fn pivot_without_grouping(
         .unwrap_or(AggregateOp::Sum);
     let fill_zero = should_fill_zero(&agg_op);
 
-    // Extract Sql Dialect that we can use to safely convert DataFusion expressions to SQL strings
-    let dialect = dataframe.dialect();
+    // Build vector of aggregates
+    let mut agg_exprs: Vec<_> = Vec::new();
 
-    // Initialize vector of final selections
-    let mut final_selections: Vec<_> = Vec::new();
-
-    // Build a vector of subqueries to be cross joined together
-    let mut subqueries = Vec::new();
     for pivot_val in pivot_vec.iter() {
-        // Build aggregate expression string
-        let agg_expr = make_aggr_expr(Some(tx.value.clone()), &agg_op, &dataframe.schema_df())?;
-        let agg = agg_expr.alias(pivot_val).to_sql_select()?.sql(dialect)?;
-
-        // Build predicate expression string
         let predicate_expr = unescaped_col(&tx.field).eq(lit(pivot_val.as_str()));
-        let predicate = predicate_expr.to_sql()?.sql(dialect)?;
+        let value_expr = unescaped_col(tx.value.as_str());
+        let agg_col = when(predicate_expr, value_expr).otherwise(lit(ScalarValue::Null))?;
 
-        // Build subquery
-        let subquery = format!(
-            "SELECT {agg} FROM {parent_name} WHERE {predicate}",
-            agg = agg,
-            parent_name = dataframe.parent_name(),
-            predicate = predicate,
-        );
-        subqueries.push(subquery);
+        let agg_expr = make_agg_expr_for_col_expr(agg_col, &agg_op, &dataframe.schema_df())?;
 
-        // Add column to final selections
-        let select_expr = if fill_zero {
-            coalesce(vec![flat_col(pivot_val), lit(0)]).alias(pivot_val)
+        // Replace null with zero for certain aggregates
+        let agg_expr = if fill_zero {
+            coalesce(vec![agg_expr, lit(0.0)])
         } else {
-            flat_col(pivot_val)
+            agg_expr
         };
-        final_selections.push(select_expr)
-    }
 
-    // Query will result in a single row, so add a constant valued ORDER_COL
-    final_selections.insert(0, lit(0u32).alias(ORDER_COL));
-
-    // Build final query
-    let final_selection_strs: Vec<_> = final_selections
-        .iter()
-        .map(|sel| sel.to_sql_select().unwrap().sql(dialect).unwrap())
-        .collect();
-    let selection_csv = final_selection_strs.join(", ");
-    let mut query_str = format!(
-        "SELECT {selection_csv} FROM \n({subquery}) as _pivot_0\n",
-        selection_csv = selection_csv,
-        subquery = subqueries[0]
-    );
-    for (i, subquery) in subqueries.iter().enumerate().skip(1) {
-        // Extend query with join
-        let subquery_name = format!("_pivot_{i}", i = i);
-        query_str.push_str(&format!(
-            "CROSS JOIN ({subquery}) as {subquery_name} \n",
-            subquery = subquery,
-            subquery_name = subquery_name,
-        ));
-    }
-
-    let dataframe_joined = dataframe.chain_query_str(&query_str).await?;
-
-    // Perform final selection
-    let selected = dataframe_joined.select(final_selections).await?;
-
-    Ok((selected, Vec::new()))
-}
-
-async fn pivot_with_grouping(
-    tx: &Pivot,
-    dataframe: Arc<SqlDataFrame>,
-) -> Result<(Arc<SqlDataFrame>, Vec<TaskValue>)> {
-    let pivot_vec = extract_sorted_pivot_values(tx, &dataframe).await?;
-
-    if pivot_vec.is_empty() {
-        return Err(VegaFusionError::internal("Unexpected empty pivot dataset"));
-    }
-
-    // Process aggregate operation
-    let agg_op: AggregateOp = tx
-        .op
-        .map(|op_code| AggregateOp::from_i32(op_code).unwrap())
-        .unwrap_or(AggregateOp::Sum);
-    let fill_zero = should_fill_zero(&agg_op);
-
-    // Extract Sql Dialect that we can use to safely convert DataFusion expressions to SQL strings
-    let dialect = dataframe.dialect();
-
-    // Create dataframe containing the unique group values
-    let groupby_cols: Vec<_> = tx
-        .groupby
-        .iter()
-        .map(|field| unescaped_col(field))
-        .collect();
-    let groupby_strs: Vec<_> = groupby_cols
-        .iter()
-        .map(|col| col.to_sql().unwrap().sql(dialect).unwrap())
-        .collect();
-    let groupby_csv = groupby_strs.join(", ");
-
-    let grouped_dataframe = dataframe
-        .aggregate(
-            groupby_cols,
-            vec![min(flat_col(ORDER_COL)).alias(ORDER_COL)],
-        )
-        .await?;
-
-    // Save off parent table names
-    let dataframe_parent_name = dataframe.parent_name();
-    let grouped_parent_name = grouped_dataframe.parent_name();
-
-    // Initialize vector of final selections
-    let mut final_selections: Vec<_> = tx.groupby.iter().map(|c| unescaped_col(c)).collect();
-    final_selections.insert(0, flat_col(ORDER_COL));
-
-    // Initialize empty query string
-    let mut query_str = String::new();
-
-    for (i, pivot_val) in pivot_vec.iter().enumerate() {
-        // Build aggregate expression string
-        let agg_expr = make_aggr_expr(Some(tx.value.clone()), &agg_op, &dataframe.schema_df())?;
-        let agg = agg_expr.alias(pivot_val).to_sql_select()?.sql(dialect)?;
-
-        // Build predicate expression string
-        let predicate_expr = unescaped_col(&tx.field).eq(lit(pivot_val.as_str()));
-        let predicate = predicate_expr.to_sql()?.sql(dialect)?;
-
-        // Build subquery
-        let subquery = format!(
-            "SELECT {groupby_csv}, {agg} FROM {parent_name} WHERE {predicate} GROUP BY {groupby_csv}",
-            groupby_csv = groupby_csv,
-            agg = agg,
-            parent_name = dataframe_parent_name,
-            predicate = predicate,
-        );
-
-        // Extend query with join
-        let subquery_name = format!("_pivot_{i}", i = i);
-        query_str.push_str(&format!(
-            "LEFT OUTER JOIN ({subquery}) as {subquery_name} USING ({groupby_csv}) ",
-            subquery = subquery,
-            subquery_name = subquery_name,
-            groupby_csv = groupby_csv,
-        ));
-
-        // Add column to final selections
-        let select_expr = if fill_zero {
-            coalesce(vec![flat_col(pivot_val), lit(0)]).alias(pivot_val)
+        // Compute pivot column name, replacing null placeholder with "null"
+        let col_name = if pivot_val == NULL_PLACEHOLDER_NAME {
+            NULL_NAME
         } else {
-            flat_col(pivot_val)
+            pivot_val.as_str()
         };
-        final_selections.push(select_expr)
+        let agg_expr = agg_expr.alias(col_name);
+
+        agg_exprs.push(agg_expr);
     }
 
-    // Prepend the initial selection
-    let final_selection_strs: Vec<_> = final_selections
-        .iter()
-        .map(|sel| sel.to_sql_select().unwrap().sql(dialect).unwrap())
-        .collect();
-    let selection_csv = final_selection_strs.join(", ");
-    query_str.insert_str(
-        0,
-        &format!(
-            "SELECT {selection_csv} FROM \"{parent_name}\"\n",
-            selection_csv = selection_csv,
-            parent_name = grouped_parent_name
-        ),
-    );
+    // Insert ordering aggregate
+    agg_exprs.insert(0, min(flat_col(ORDER_COL)).alias(ORDER_COL));
 
-    // Perform query and apply final selections
-    let dataframe_joined = grouped_dataframe.chain_query_str(&query_str).await?;
-    let selected = dataframe_joined.select(final_selections).await?;
+    // Build vector of groupby expressions
+    let group_expr: Vec<_> = tx.groupby.iter().map(|c| unescaped_col(c)).collect();
 
-    Ok((selected, Vec::new()))
+    let pivoted = dataframe.aggregate(group_expr, agg_exprs).await?;
+    Ok((pivoted, Default::default()))
 }
 
 /// Test whether null values should be replaced by zero for the specified aggregation

--- a/vegafusion-rt-datafusion/tests/specs/custom/pivot_join_on_bug.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/pivot_join_on_bug.comm_plan.json
@@ -1,0 +1,50 @@
+{
+  "server_to_client": [
+    {
+      "name": "data_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_1_layer_0_layer_0_color_domain_CALC_NAME_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_1_x_domain_yearmonthdate_SESSION_DATE_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2_layer_0_layer_0_color_domain_CALC_NAME_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2_x_domain_yearmonthdate_SESSION_DATE_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_x_domain_yearmonthdate_SESSION_DATE_2",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_4",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/pivot_join_on_bug.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/pivot_join_on_bug.vg.json
@@ -1,0 +1,476 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {"name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store"},
+    {
+      "name": "user_sessions",
+      "values": [
+        {
+          "CALC_NAME": "A",
+          "GLOBAL_SESSION_ID": 1,
+          "SESSION_DATE": "2022-12-01"
+        },
+        {
+          "CALC_NAME": "A",
+          "GLOBAL_SESSION_ID": 2,
+          "SESSION_DATE": "2022-12-01"
+        },
+        {
+          "CALC_NAME": "A",
+          "GLOBAL_SESSION_ID": 2,
+          "SESSION_DATE": "2022-12-01"
+        },
+        {
+          "CALC_NAME": "A",
+          "GLOBAL_SESSION_ID": 3,
+          "SESSION_DATE": "2023-01-01"
+        },
+        {
+          "CALC_NAME": "BB",
+          "GLOBAL_SESSION_ID": 4,
+          "SESSION_DATE": "2022-12-01"
+        },
+        {
+          "CALC_NAME": "BB",
+          "GLOBAL_SESSION_ID": 4,
+          "SESSION_DATE": "2022-12-01"
+        },
+        {
+          "CALC_NAME": "BB",
+          "GLOBAL_SESSION_ID": -5,
+          "SESSION_DATE": "2023-01-01"
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "user_sessions",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "toDate(datum[\"SESSION_DATE\"])",
+          "as": "SESSION_DATE"
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "data_0",
+      "transform": [
+        {"type": "filter", "expr": "isValid(datum[\"SESSION_DATE\"])"},
+        {
+          "field": "SESSION_DATE",
+          "type": "timeunit",
+          "units": ["year", "month", "date"],
+          "timezone": "utc",
+          "as": ["yearmonthdate_SESSION_DATE", "yearmonthdate_SESSION_DATE_end"]
+        },
+        {
+          "type": "aggregate",
+          "groupby": ["yearmonthdate_SESSION_DATE", "CALC_NAME"],
+          "ops": ["distinct"],
+          "fields": ["GLOBAL_SESSION_ID"],
+          "as": ["distinct_GLOBAL_SESSION_ID"]
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"distinct_GLOBAL_SESSION_ID\"]) && isFinite(+datum[\"distinct_GLOBAL_SESSION_ID\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_0",
+      "transform": [
+        {
+          "field": "SESSION_DATE",
+          "type": "timeunit",
+          "timezone": "utc",
+          "units": ["year", "month", "date"],
+          "as": ["yearmonthdate_SESSION_DATE", "yearmonthdate_SESSION_DATE_end"]
+        },
+        {
+          "type": "pivot",
+          "field": "CALC_NAME",
+          "value": "GLOBAL_SESSION_ID",
+          "op": "distinct",
+          "groupby": ["yearmonthdate_SESSION_DATE"]
+        }
+      ]
+    },
+    {
+      "name": "data_4",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["CALC_NAME"],
+          "ops": [],
+          "fields": [],
+          "as": []
+        },
+        {
+          "type": "window",
+          "params": [null],
+          "as": ["rank"],
+          "ops": ["rank"],
+          "fields": [null],
+          "sort": {"field": [], "order": []}
+        },
+        {"type": "filter", "expr": "datum.rank <= 21"}
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 100},
+    {"name": "width", "update": "bandspace(domain('x').length, 0, 0) * x_step"},
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573",
+      "update": "vlSelectionResolve(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\", \"union\", true, true)"
+    },
+    {
+      "name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple",
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_0_layer_1_layer_0_voronoi"
+            }
+          ],
+          "update": "datum && item().mark.marktype !== 'group' && indexof(item().mark.role, 'legend') < 0 ? {unit: \"layer_0_layer_1_layer_0\", fields: pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"yearmonthdate_SESSION_DATE\"]]} : null",
+          "force": true
+        },
+        {"events": [{"source": "view", "type": "mouseout"}], "update": "null"}
+      ]
+    },
+    {
+      "name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple_fields",
+      "value": [{"type": "E", "field": "yearmonthdate_SESSION_DATE"}]
+    },
+    {
+      "name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_toggle",
+      "value": false,
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_0_layer_1_layer_0_voronoi"
+            }
+          ],
+          "update": "event.shiftKey"
+        },
+        {"events": [{"source": "view", "type": "mouseout"}], "update": "false"}
+      ]
+    },
+    {
+      "name": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_modify",
+      "on": [
+        {
+          "events": {
+            "signal": "pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple"
+          },
+          "update": "modify(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\", pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_toggle ? null : pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple, pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_toggle ? null : true, pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_toggle ? pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_tuple : null)"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_layer_0_layer_0_pathgroup",
+      "type": "group",
+      "from": {
+        "facet": {
+          "name": "faceted_path_layer_0_layer_0_layer_0_main",
+          "data": "data_1",
+          "groupby": ["CALC_NAME"]
+        }
+      },
+      "encode": {
+        "update": {
+          "width": {"field": {"group": "width"}},
+          "height": {"field": {"group": "height"}}
+        }
+      },
+      "marks": [
+        {
+          "name": "layer_0_layer_0_layer_0_marks",
+          "type": "line",
+          "clip": true,
+          "style": ["line"],
+          "sort": {"field": "datum[\"yearmonthdate_SESSION_DATE\"]"},
+          "interactive": false,
+          "from": {"data": "faceted_path_layer_0_layer_0_layer_0_main"},
+          "encode": {
+            "update": {
+              "stroke": {
+                "scale": "layer_0_layer_0_color",
+                "field": "CALC_NAME"
+              },
+              "opacity": {"value": 1},
+              "description": {
+                "signal": "\"SESSION_DATE (year-month-date): \" + (timeFormat(datum[\"yearmonthdate_SESSION_DATE\"], timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; Distinct of GLOBAL_SESSION_ID: \" + (format(datum[\"distinct_GLOBAL_SESSION_ID\"], \"\")) + \"; CALC_NAME: \" + (isValid(datum[\"CALC_NAME\"]) ? datum[\"CALC_NAME\"] : \"\"+datum[\"CALC_NAME\"])"
+              },
+              "x": {
+                "scale": "x",
+                "field": "yearmonthdate_SESSION_DATE",
+                "band": 0.5
+              },
+              "y": {"scale": "y", "field": "distinct_GLOBAL_SESSION_ID"},
+              "defined": {
+                "signal": "isValid(datum[\"distinct_GLOBAL_SESSION_ID\"]) && isFinite(+datum[\"distinct_GLOBAL_SESSION_ID\"])"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "layer_0_layer_0_layer_1_marks",
+      "type": "symbol",
+      "clip": true,
+      "style": ["point"],
+      "interactive": false,
+      "from": {"data": "data_2"},
+      "encode": {
+        "update": {
+          "fill": {"value": "transparent"},
+          "stroke": {"scale": "layer_0_layer_0_color", "field": "CALC_NAME"},
+          "opacity": [
+            {
+              "test": "length(data(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\")) && vlSelectionTest(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\", datum)",
+              "value": 1
+            },
+            {"value": 0}
+          ],
+          "ariaRoleDescription": {"value": "point"},
+          "description": {
+            "signal": "\"SESSION_DATE (year-month-date): \" + (timeFormat(datum[\"yearmonthdate_SESSION_DATE\"], timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; Distinct of GLOBAL_SESSION_ID: \" + (format(datum[\"distinct_GLOBAL_SESSION_ID\"], \"\")) + \"; CALC_NAME: \" + (isValid(datum[\"CALC_NAME\"]) ? datum[\"CALC_NAME\"] : \"\"+datum[\"CALC_NAME\"])"
+          },
+          "x": {
+            "scale": "x",
+            "field": "yearmonthdate_SESSION_DATE",
+            "band": 0.5
+          },
+          "y": {"scale": "y", "field": "distinct_GLOBAL_SESSION_ID"},
+          "size": {"value": 80}
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_1_layer_0_marks",
+      "type": "rule",
+      "clip": true,
+      "style": ["rule"],
+      "interactive": true,
+      "from": {"data": "data_3"},
+      "encode": {
+        "update": {
+          "stroke": {"value": "CHART_DEFAULT_RULE_COLOR_MARKER"},
+          "opacity": [
+            {
+              "test": "length(data(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\")) && vlSelectionTest(\"pivot_hover_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_store\", datum)",
+              "value": 0.3
+            },
+            {"value": 0}
+          ],
+          "tooltip": {
+            "signal": "{\"SESSION_DATE (year-month-date)\": timeFormat(datum[\"yearmonthdate_SESSION_DATE\"], timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))}"
+          },
+          "description": {
+            "signal": "\"SESSION_DATE (year-month-date): \" + (timeFormat(datum[\"yearmonthdate_SESSION_DATE\"], timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"})))"
+          },
+          "x": {
+            "scale": "x",
+            "field": "yearmonthdate_SESSION_DATE",
+            "band": 0.5
+          },
+          "y": {"value": 0},
+          "y2": {"field": {"group": "height"}}
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_1_layer_0_voronoi",
+      "type": "path",
+      "interactive": true,
+      "from": {"data": "layer_0_layer_1_layer_0_marks"},
+      "encode": {
+        "update": {
+          "fill": {"value": "transparent"},
+          "strokeWidth": {"value": 0.35},
+          "stroke": {"value": "transparent"},
+          "isVoronoi": {"value": true},
+          "tooltip": {
+            "signal": "{\"SESSION_DATE (year-month-date)\": timeFormat(datum.datum[\"yearmonthdate_SESSION_DATE\"], timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))}"
+          }
+        }
+      },
+      "transform": [
+        {
+          "type": "voronoi",
+          "x": {"expr": "datum.datum.x || 0"},
+          "y": {"expr": "datum.datum.y || 0"},
+          "size": [{"signal": "width"}, {"signal": "height"}]
+        }
+      ]
+    },
+    {
+      "name": "aggregate_color_spec_3eb8ffb8_6f35_4e9d_93f2_512f1caca573_marks",
+      "type": "rule",
+      "clip": true,
+      "style": ["rule"],
+      "interactive": false,
+      "from": {"data": "data_4"},
+      "encode": {"update": {}}
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {
+        "fields": [
+          {"data": "data_1", "field": "yearmonthdate_SESSION_DATE"},
+          {"data": "data_2", "field": "yearmonthdate_SESSION_DATE"},
+          {"data": "data_3", "field": "yearmonthdate_SESSION_DATE"}
+        ],
+        "sort": true
+      },
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0,
+      "paddingOuter": 0
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {"data": "data_1", "field": "distinct_GLOBAL_SESSION_ID"},
+          {"data": "data_2", "field": "distinct_GLOBAL_SESSION_ID"}
+        ]
+      },
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "layer_0_layer_0_color",
+      "type": "ordinal",
+      "domain": {
+        "fields": [
+          {"data": "data_1", "field": "CALC_NAME"},
+          {"data": "data_2", "field": "CALC_NAME"}
+        ],
+        "sort": true
+      },
+      "range": [
+        "#2c90ed",
+        "#fc632a",
+        "#585858",
+        "#4cd964",
+        "#b9e09b",
+        "#a50fa9",
+        "#f7daf6",
+        "#553096",
+        "#72e5ef",
+        "#871d32",
+        "#1c9820",
+        "#f53176",
+        "#658114",
+        "#f989a4",
+        "#04a38f",
+        "#18519b",
+        "#eb67f9",
+        "#e8ea35",
+        "#562fff",
+        "#a77ae9"
+      ]
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": true,
+      "gridScale": "y",
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": true,
+      "gridScale": "x",
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "SESSION_DATE (year-month-date)",
+      "labels": true,
+      "ticks": true,
+      "format": {
+        "signal": "timeUnitSpecifier([\"year\",\"month\",\"date\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"})"
+      },
+      "formatType": "time",
+      "labelOverlap": true,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Distinct of GLOBAL_SESSION_ID",
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ],
+  "legends": [
+    {
+      "symbolOpacity": 1,
+      "symbolType": "stroke",
+      "stroke": "layer_0_layer_0_color",
+      "title": "CALC_NAME",
+      "encode": {"symbols": {"update": {"fill": {"value": "transparent"}}}}
+    }
+  ],
+  "config": {"legend": {"orient": "right"}},
+  "usermeta": {"selectionConfigs": {}}
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -130,7 +130,8 @@ mod test_custom_specs {
         case("custom/stack_divide_by_zero_error", 0.001, false),
         case("custom/casestudy-us_population_pyramid_over_time", 0.001, true),
         case("custom/sin_cos", 0.001, true),
-        case("custom/area_streamgraph", 0.001, true)
+        case("custom/area_streamgraph", 0.001, true),
+        case("custom/pivot_join_on_bug", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -15,7 +15,6 @@ use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_core::spec::values::{Field, SignalExpressionSpec};
 
 mod test_aggregate_single {
-    use crate::util::check::eval_vegafusion_transforms;
     use crate::*;
 
     #[rstest(
@@ -62,7 +61,6 @@ mod test_aggregate_single {
 }
 
 mod test_aggregate_multi {
-    use crate::util::check::eval_vegafusion_transforms;
     use crate::*;
 
     #[rstest(
@@ -218,7 +216,6 @@ fn test_aggregate_overwrite() {
 }
 
 mod test_aggregate_with_nulls {
-    use crate::util::check::eval_vegafusion_transforms;
     use crate::*;
     use serde_json::json;
     use vegafusion_core::data::table::VegaFusionTable;

--- a/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_aggregate.rs
@@ -47,24 +47,17 @@ mod test_aggregate_single {
 
         let comp_config = Default::default();
 
-        // Order of grouped rows is not defined, so set row_order to false
-        if matches!(op, AggregateOpSpec::Distinct) {
-            // Vega counts null as distinct category but DataFusion does not.
-            // Just make sure it doesn't crash
-            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
-        } else {
-            let eq_config = TablesEqualConfig {
-                row_order: true,
-                ..Default::default()
-            };
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
 
-            check_transform_evaluation(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-                &eq_config,
-            );
-        }
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
     }
 }
 
@@ -109,23 +102,17 @@ mod test_aggregate_multi {
 
         let comp_config = Default::default();
 
-        if matches!(op1, AggregateOpSpec::Distinct) || matches!(op2, AggregateOpSpec::Distinct) {
-            // Vega counts null as distinct category but DataFusion does not
-            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
-        } else {
-            // Order of grouped rows is not defined, so set row_order to false
-            let eq_config = TablesEqualConfig {
-                row_order: true,
-                ..Default::default()
-            };
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
 
-            check_transform_evaluation(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-                &eq_config,
-            );
-        }
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
     }
 }
 
@@ -272,23 +259,16 @@ mod test_aggregate_with_nulls {
 
         let comp_config = Default::default();
 
-        // Order of grouped rows is not defined, so set row_order to false
-        if matches!(op, AggregateOpSpec::Distinct) {
-            // Vega counts null as distinct category but DataFusion does not.
-            // Just make sure it doesn't crash
-            eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &comp_config);
-        } else {
-            let eq_config = TablesEqualConfig {
-                row_order: true,
-                ..Default::default()
-            };
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
 
-            check_transform_evaluation(
-                &dataset,
-                transform_specs.as_slice(),
-                &comp_config,
-                &eq_config,
-            );
-        }
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
     }
 }

--- a/vegafusion-rt-datafusion/tests/test_transform_joinaggregate.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_joinaggregate.rs
@@ -18,17 +18,16 @@ mod test_joinaggregate_zero {
     use vegafusion_core::spec::transform::joinaggregate::JoinAggregateTransformSpec;
 
     #[rstest(
-    op,
-    case(AggregateOpSpec::Count),
-    case(AggregateOpSpec::Valid),
-    case(AggregateOpSpec::Missing),
-    // Vega counts null as distinct category but DataFusion does not
-    // case(AggregateOpSpec::Distinct),
-    case(AggregateOpSpec::Sum),
-    case(AggregateOpSpec::Mean),
-    case(AggregateOpSpec::Average),
-    case(AggregateOpSpec::Min),
-    case(AggregateOpSpec::Max),
+        op,
+        case(AggregateOpSpec::Count),
+        case(AggregateOpSpec::Valid),
+        case(AggregateOpSpec::Missing),
+        case(AggregateOpSpec::Distinct),
+        case(AggregateOpSpec::Sum),
+        case(AggregateOpSpec::Mean),
+        case(AggregateOpSpec::Average),
+        case(AggregateOpSpec::Min),
+        case(AggregateOpSpec::Max)
     )]
     fn test(op: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -67,13 +66,12 @@ mod test_joinaggregate_single {
         case(AggregateOpSpec::Count),
         case(AggregateOpSpec::Valid),
         case(AggregateOpSpec::Missing),
-        // Vega counts null as distinct category but DataFusion does not
-        // case(AggregateOpSpec::Distinct),
+        case(AggregateOpSpec::Distinct),
         case(AggregateOpSpec::Sum),
         case(AggregateOpSpec::Mean),
         case(AggregateOpSpec::Average),
         case(AggregateOpSpec::Min),
-        case(AggregateOpSpec::Max),
+        case(AggregateOpSpec::Max)
     )]
     fn test(op: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -109,17 +107,17 @@ mod test_joinaggregate_multi {
     use vegafusion_core::spec::transform::joinaggregate::JoinAggregateTransformSpec;
 
     #[rstest(
-        op1, op2,
+        op1,
+        op2,
         case(AggregateOpSpec::Count, AggregateOpSpec::Count),
         case(AggregateOpSpec::Valid, AggregateOpSpec::Missing),
         case(AggregateOpSpec::Missing, AggregateOpSpec::Valid),
-        // Vega counts null as distinct category but DataFusion does not
-        // case(AggregateOpSpec::Distinct),
+        case(AggregateOpSpec::Distinct, AggregateOpSpec::Mean),
         case(AggregateOpSpec::Sum, AggregateOpSpec::Max),
         case(AggregateOpSpec::Mean, AggregateOpSpec::Sum),
         case(AggregateOpSpec::Average, AggregateOpSpec::Mean),
         case(AggregateOpSpec::Min, AggregateOpSpec::Average),
-        case(AggregateOpSpec::Max, AggregateOpSpec::Min),
+        case(AggregateOpSpec::Max, AggregateOpSpec::Min)
     )]
     fn test(op1: AggregateOpSpec, op2: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");

--- a/vegafusion-rt-datafusion/tests/test_transform_pivot.rs
+++ b/vegafusion-rt-datafusion/tests/test_transform_pivot.rs
@@ -17,6 +17,7 @@ fn medals() -> VegaFusionTable {
             {"country": "Canada", "type": "gold", "count": 11, "is_gold": true},
             {"country": "Canada", "type": "silver", "count": 8, "is_gold": false},
             {"country": "Canada", "type": "bronze", "count": 10, "is_gold": false},
+            {"country": "Canada", "type": null, "count": 5, "is_gold": null},
         ]),
         1024,
     )
@@ -45,7 +46,8 @@ mod test_pivot_with_group {
         case(Some(AggregateOpSpec::Max), None),
         case(Some(AggregateOpSpec::Max), Some(10)),
         case(Some(AggregateOpSpec::Min), None),
-        case(Some(AggregateOpSpec::Min), Some(0))
+        case(Some(AggregateOpSpec::Min), Some(0)),
+        case(Some(AggregateOpSpec::Distinct), None)
     )]
     fn test(op: Option<AggregateOpSpec>, limit: Option<i32>) {
         let dataset = medals();
@@ -94,7 +96,8 @@ mod test_pivot_no_group {
         case(Some(AggregateOpSpec::Max), None),
         case(Some(AggregateOpSpec::Max), Some(10)),
         case(Some(AggregateOpSpec::Min), None),
-        case(Some(AggregateOpSpec::Min), Some(0))
+        case(Some(AggregateOpSpec::Min), Some(0)),
+        case(Some(AggregateOpSpec::Distinct), None)
     )]
     fn test(op: Option<AggregateOpSpec>, limit: Option<i32>) {
         let dataset = medals();
@@ -143,7 +146,8 @@ mod test_pivot_no_group_boolean {
         case(Some(AggregateOpSpec::Max), None),
         case(Some(AggregateOpSpec::Max), Some(10)),
         case(Some(AggregateOpSpec::Min), None),
-        case(Some(AggregateOpSpec::Min), Some(0))
+        case(Some(AggregateOpSpec::Min), Some(0)),
+        case(Some(AggregateOpSpec::Distinct), None)
     )]
     fn test(op: Option<AggregateOpSpec>, limit: Option<i32>) {
         let dataset = medals();


### PR DESCRIPTION
This PR includes a few fixes to improve the fidelity (the match with stock Vega) of the `distinct` aggregate function and the `pivot`. It also works around the DataFusion error reported in https://github.com/apache/arrow-datafusion/issues/5034.

Changes:
Vega's implementation of `distinct` considers NULL to be a distinct value whereas SQL ignores NULL values before counting distinct values. To align our implementation with Vega's, 40098407a361902636c52ba33330dd1a86695c2b updates the `distinct` aggregation function to add one if the column contains any NULL values.  

d876d0b19057bc12c048450ca250c9248529a1e2 and e13402cf8782d1a01c98fb1041fd598c7389ab84 update DataFusion to 16.1.0 with backports as described in https://github.com/jonmmease/arrow-datafusion/pull/139.

455201fd830c50fb862ab9ed2fcfc7b118fa376d Adds a custom spec that previously triggers the error reported in https://github.com/apache/arrow-datafusion/issues/5034.

3fd34c62249909ffb6d23533fd3b899385bbb617 makes two updates to the pivot transform:
 1. The implementation no longer performs a join per pivoted value and instead uses SQL `CASE` statements inside the aggregation functions to filter down to the values the pivot value.  This avoids https://github.com/apache/arrow-datafusion/issues/5034, and should improve performance for pivots that introduce many columns as we're no longer performing a join per added column.
 2. If the pivoted column includes NULL values, then a column named "null" will be generated. This. matches Vega. There was some additional work required to make sure the NULL column sorts as the first column for the purpose of limiting.