### PR TITLE
Handle special characters in projection pushdown

### DIFF
--- a/vegafusion-core/src/expression/escape.rs
+++ b/vegafusion-core/src/expression/escape.rs
@@ -1,20 +1,19 @@
 pub fn escape_field(col: &str) -> String {
-    // Escape single quote with backslash
-    let col = col.replace('\'', "\\'");
-
-    // Escape double quote with backslash
-    col.replace('\"', "\\\"")
+    // Escape single quote, double quote, period, and brackets with a backslash
+    col.replace('\'', "\\'")
+        .replace('\"', "\\\"")
+        .replace('.', "\\.")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
 }
 
 pub fn unescape_field(col: &str) -> String {
-    // Unescape backslash single quote
-    let col = col.replace("\\'", "'");
-
-    // Unescape backslash double quote
-    let col = col.replace("\\\"", "\"");
-
-    //  Unescape backslash period
-    col.replace("\\.", ".")
+    // Unescape single quote, double quote, period, and brackets
+    col.replace("\\'", "'")
+        .replace("\\\"", "\"")
+        .replace("\\.", ".")
+        .replace("\\[", "[")
+        .replace("\\]", "]")
 }
 
 #[cfg(test)]

--- a/vegafusion-core/src/expression/escape.rs
+++ b/vegafusion-core/src/expression/escape.rs
@@ -24,7 +24,7 @@ mod tests {
     fn test_escape() {
         let col = "'foo'_._\"bar\"";
         let escaped = escape_field(col);
-        assert_eq!(escaped, r#"\'foo\'_._\"bar\""#)
+        assert_eq!(escaped, r#"\'foo\'_\._\"bar\""#)
     }
 
     #[test]

--- a/vegafusion-core/src/spec/transform/aggregate.rs
+++ b/vegafusion-core/src/spec/transform/aggregate.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
 use crate::task_graph::graph::ScopedVariable;
@@ -140,7 +141,11 @@ impl TransformSpecTrait for AggregateTransformSpec {
             };
 
             // Compute used columns (both groupby and fields)
-            let mut usage_cols: Vec<_> = self.groupby.iter().map(|field| field.field()).collect();
+            let mut usage_cols: Vec<_> = self
+                .groupby
+                .iter()
+                .map(|field| unescape_field(&field.field()))
+                .collect();
             for field in self
                 .fields
                 .clone()
@@ -148,7 +153,7 @@ impl TransformSpecTrait for AggregateTransformSpec {
                 .into_iter()
                 .flatten()
             {
-                usage_cols.push(field.field())
+                usage_cols.push(unescape_field(&field.field()))
             }
             let col_usage = ColumnUsage::from(usage_cols.as_slice());
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);

--- a/vegafusion-core/src/spec/transform/bin.rs
+++ b/vegafusion-core/src/spec/transform/bin.rs
@@ -2,6 +2,7 @@ use crate::error::Result;
 use crate::expression::parser::parse;
 
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::{Field, SignalExpressionSpec};
 use crate::task_graph::graph::ScopedVariable;
@@ -134,7 +135,7 @@ impl TransformSpecTrait for BinTransformSpec {
             let produced = ColumnUsage::from(vec![bin_start, bin_end].as_slice());
 
             // Compute used columns
-            let field = self.field.field();
+            let field = unescape_field(&self.field.field());
             let col_usage = ColumnUsage::empty().with_column(&field);
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
 

--- a/vegafusion-core/src/spec/transform/collect.rs
+++ b/vegafusion-core/src/spec/transform/collect.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -25,7 +26,14 @@ impl TransformSpecTrait for CollectTransformSpec {
         _vl_selection_fields: &VlSelectionFields,
     ) -> TransformColumns {
         if let Some(datum_var) = datum_var {
-            let col_usage = ColumnUsage::from(self.sort.field.to_vec().as_slice());
+            let unescaped_sort_fields = self
+                .sort
+                .field
+                .to_vec()
+                .iter()
+                .map(|f| unescape_field(f))
+                .collect::<Vec<_>>();
+            let col_usage = ColumnUsage::from(unescaped_sort_fields.as_slice());
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
             TransformColumns::PassThrough {
                 usage,

--- a/vegafusion-core/src/spec/transform/extent.rs
+++ b/vegafusion-core/src/spec/transform/extent.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
@@ -30,8 +31,10 @@ impl TransformSpecTrait for ExtentTransformSpec {
         _vl_selection_fields: &VlSelectionFields,
     ) -> TransformColumns {
         if let Some(datum_var) = datum_var {
-            let usage = DatasetsColumnUsage::empty()
-                .with_column_usage(datum_var, ColumnUsage::empty().with_column(&self.field));
+            let usage = DatasetsColumnUsage::empty().with_column_usage(
+                datum_var,
+                ColumnUsage::empty().with_column(&unescape_field(&self.field)),
+            );
             TransformColumns::PassThrough {
                 usage,
                 produced: ColumnUsage::empty(),

--- a/vegafusion-core/src/spec/transform/fold.rs
+++ b/vegafusion-core/src/spec/transform/fold.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
 use crate::task_graph::graph::ScopedVariable;
@@ -46,12 +47,12 @@ impl TransformSpecTrait for FoldTransformSpec {
             let produced = ColumnUsage::from(self.as_().as_slice());
 
             // Uses fields columns
-            let fields = self
+            let unescaped_fields = self
                 .fields
                 .iter()
-                .map(|field| field.field())
+                .map(|field| unescape_field(&field.field()))
                 .collect::<Vec<_>>();
-            let col_usage = ColumnUsage::from(fields.as_slice());
+            let col_usage = ColumnUsage::from(unescaped_fields.as_slice());
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
 
             // All input columns are passed through as well

--- a/vegafusion-core/src/spec/transform/impute.rs
+++ b/vegafusion-core/src/spec/transform/impute.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
 use crate::task_graph::graph::ScopedVariable;
@@ -70,14 +71,17 @@ impl TransformSpecTrait for ImputeTransformSpec {
     ) -> TransformColumns {
         if let Some(datum_var) = datum_var {
             // Init column usage with field
-            let mut col_usage = ColumnUsage::from(self.field.field().as_str());
+            let mut col_usage = ColumnUsage::from(unescape_field(&self.field.field()).as_str());
 
             // Add key
-            col_usage = col_usage.with_column(self.key.field().as_str());
+            col_usage = col_usage.with_column(&unescape_field(&self.key.field()));
 
             // Add groupby usage
             if let Some(groupby) = self.groupby.as_ref() {
-                let groupby: Vec<_> = groupby.iter().map(|field| field.field()).collect();
+                let groupby: Vec<_> = groupby
+                    .iter()
+                    .map(|field| unescape_field(&field.field()))
+                    .collect();
                 col_usage = col_usage.union(&ColumnUsage::from(groupby.as_slice()));
             }
 

--- a/vegafusion-core/src/spec/transform/joinaggregate.rs
+++ b/vegafusion-core/src/spec/transform/joinaggregate.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::aggregate::AggregateOpSpec;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::Field;
@@ -84,10 +85,10 @@ impl TransformSpecTrait for JoinAggregateTransformSpec {
                 .clone()
                 .unwrap_or_default()
                 .iter()
-                .map(|field| field.field())
+                .map(|field| unescape_field(&field.field()))
                 .collect();
             for field in self.fields.iter().flatten() {
-                usage_cols.push(field.field())
+                usage_cols.push(unescape_field(&field.field()))
             }
             let col_usage = ColumnUsage::from(usage_cols.as_slice());
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);

--- a/vegafusion-core/src/spec/transform/lookup.rs
+++ b/vegafusion-core/src/spec/transform/lookup.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use crate::error::Result;
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 
 use crate::proto::gen::tasks::Variable;
 use crate::spec::values::Field;
@@ -46,7 +47,11 @@ impl TransformSpecTrait for LookupTransformSpec {
         if let Some(datum_var) = datum_var {
             // For lookup, we can tell which field(s) are needed, but we don't currently
             // attempt to determine the output fields
-            let fields: Vec<_> = self.fields.iter().map(|field| field.field()).collect();
+            let fields: Vec<_> = self
+                .fields
+                .iter()
+                .map(|field| unescape_field(&field.field()))
+                .collect();
             let usage = DatasetsColumnUsage::empty()
                 .with_column_usage(datum_var, ColumnUsage::from(fields.as_slice()));
 

--- a/vegafusion-core/src/spec/transform/project.rs
+++ b/vegafusion-core/src/spec/transform/project.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use crate::error::Result;
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
 use crate::task_graph::task::InputVariable;
@@ -35,7 +36,8 @@ impl TransformSpecTrait for ProjectTransformSpec {
         _vl_selection_fields: &VlSelectionFields,
     ) -> TransformColumns {
         if let Some(datum_var) = datum_var {
-            let col_usage = ColumnUsage::from(self.fields.as_slice());
+            let unescaped_fields: Vec<_> = self.fields.iter().map(|f| unescape_field(f)).collect();
+            let col_usage = ColumnUsage::from(unescaped_fields.as_slice());
             let usage =
                 DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage.clone());
             TransformColumns::Overwrite {

--- a/vegafusion-core/src/spec/transform/timeunit.rs
+++ b/vegafusion-core/src/spec/transform/timeunit.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
@@ -110,8 +111,7 @@ impl TransformSpecTrait for TimeUnitTransformSpec {
             let produced = ColumnUsage::from(produced_cols.as_slice());
 
             // Compute used columns
-            let field = self.field.clone();
-            let col_usage = ColumnUsage::empty().with_column(&field);
+            let col_usage = ColumnUsage::empty().with_column(&unescape_field(&self.field));
             let usage = DatasetsColumnUsage::empty().with_column_usage(datum_var, col_usage);
 
             TransformColumns::PassThrough { usage, produced }

--- a/vegafusion-core/src/spec/transform/window.rs
+++ b/vegafusion-core/src/spec/transform/window.rs
@@ -1,4 +1,5 @@
 use crate::expression::column_usage::{ColumnUsage, DatasetsColumnUsage, VlSelectionFields};
+use crate::expression::escape::unescape_field;
 use crate::spec::transform::aggregate::AggregateOpSpec;
 use crate::spec::transform::{TransformColumns, TransformSpecTrait};
 use crate::spec::values::{CompareSpec, Field};
@@ -156,13 +157,19 @@ impl TransformSpecTrait for WindowTransformSpec {
                 .clone()
                 .unwrap_or_default()
                 .iter()
-                .map(|field| field.field())
+                .map(|field| unescape_field(&field.field()))
                 .collect();
             for field in self.fields.iter().flatten() {
-                usage_cols.push(field.field())
+                usage_cols.push(unescape_field(&field.field()))
             }
             if let Some(sort) = &self.sort {
-                usage_cols.extend(sort.field.to_vec())
+                let unescaped_sort_fields: Vec<_> = sort
+                    .field
+                    .to_vec()
+                    .iter()
+                    .map(|f| unescape_field(f))
+                    .collect();
+                usage_cols.extend(unescaped_sort_fields)
             }
 
             let col_usage = ColumnUsage::from(usage_cols.as_slice());

--- a/vegafusion-rt-datafusion/tests/specs/custom/special_chars_bar.comm_plan.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/special_chars_bar.comm_plan.json
@@ -1,0 +1,15 @@
+{
+  "server_to_client": [
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "specialchars",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-rt-datafusion/tests/specs/custom/special_chars_bar.vg.json
+++ b/vegafusion-rt-datafusion/tests/specs/custom/special_chars_bar.vg.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "specialchars",
+      "values": [
+        {"pe.riods": "a.b", "bracket[values": "[1]"},
+        {"pe.riods": "c.d", "bracket[values": "[2]"},
+        {"pe.riods": "e.f", "bracket[values": "[2]"},
+        {"pe.riods": "e.f", "bracket[values": "[2]"}
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "specialchars",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum[\"pe.riods\"]===\"c.d\" ? 0 : datum[\"pe.riods\"]===\"a.b\" ? 1 : datum[\"pe.riods\"]===\"e.f\" ? 2 : 3",
+          "as": "color_pe.riods_sort_index"
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["pe\\.riods"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "specialchars",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["pe\\.riods"],
+          "ops": [],
+          "fields": [],
+          "as": []
+        },
+        {
+          "type": "window",
+          "params": [null],
+          "as": ["rank"],
+          "ops": ["rank"],
+          "fields": [null],
+          "sort": {"field": [], "order": []}
+        },
+        {"type": "filter", "expr": "datum.rank <= 21"}
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_layer_0_layer_0_marks",
+      "type": "rect",
+      "clip": true,
+      "style": ["bar"],
+      "from": {"data": "data_2"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "layer_0_layer_0_color", "field": "pe\\.riods"},
+          "opacity": {"value": 1},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"pe.riods: \" + (isValid(datum[\"pe.riods\"]) ? datum[\"pe.riods\"] : \"\"+datum[\"pe.riods\"]) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "pe\\.riods"},
+          "width": {"signal": "max(0.25, bandwidth('x'))"},
+          "y": {"scale": "y", "field": "__count"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    },
+    {
+      "name": "aggregate_xAxis_spec_967cacb2_18eb_422b_9030_a57a4b3ee080_marks",
+      "type": "rule",
+      "clip": true,
+      "style": ["rule"],
+      "from": {"data": "data_3"},
+      "encode": {"update": {}}
+    },
+    {
+      "name": "aggregate_color_spec_967cacb2_18eb_422b_9030_a57a4b3ee080_marks",
+      "type": "rule",
+      "clip": true,
+      "style": ["rule"],
+      "from": {"data": "data_3"},
+      "encode": {"update": {}}
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {"data": "data_2", "field": "pe\\.riods", "sort": true},
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_2", "field": "__count"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "layer_0_layer_0_color",
+      "type": "ordinal",
+      "domain": {
+        "data": "data_1",
+        "field": "pe\\.riods",
+        "sort": {"op": "min", "field": "color_pe\\.riods_sort_index"}
+      },
+      "range": [
+        "#4C78A8",
+        "#F58518",
+        "#E45756",
+        "#72B7B2",
+        "#54A24B",
+        "#EECA3B",
+        "#B279A2",
+        "#FF9DA6",
+        "#9D755D",
+        "#BAB0AC"
+      ],
+      "interpolate": "hcl"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": true,
+      "gridScale": "y",
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": true,
+      "gridScale": "x",
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "pe.riods",
+      "labels": true,
+      "ticks": true,
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle",
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Count of Records",
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ],
+  "legends": [
+    {
+      "symbolOpacity": 1,
+      "title": "pe.riods",
+      "fill": "layer_0_layer_0_color",
+      "symbolType": "square"
+    }
+  ],
+  "config": {"legend": {"orient": "right"}},
+  "usermeta": {"selectionConfigs": {}}
+}

--- a/vegafusion-rt-datafusion/tests/test_image_comparison.rs
+++ b/vegafusion-rt-datafusion/tests/test_image_comparison.rs
@@ -131,7 +131,8 @@ mod test_custom_specs {
         case("custom/casestudy-us_population_pyramid_over_time", 0.001, true),
         case("custom/sin_cos", 0.001, true),
         case("custom/area_streamgraph", 0.001, true),
-        case("custom/pivot_join_on_bug", 0.001, true)
+        case("custom/pivot_join_on_bug", 0.001, true),
+        case("custom/special_chars_bar", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {}", spec_name);


### PR DESCRIPTION
This PR adds a previously failing test in e7e8d2ad7170237654630c925a429f5fdde59045. The issue is that projection pushdown was creating a transform that looked like this:

```json
{
  "type": "project",
  "fields": ["pe.riod", "pe\\.riod"]
}
```

The resulting error was:
```
Projections require unique expression names but the expression \"tbl_1.pe.riods\" at position 1 and \"tbl_1.pe.riods\" at position 2 have the same name
```

To fix the issue, 81f5aef85c61b4967e64945ddd2d62978b46cb0d updates the `transform_columns` transform spec implementations to unescape fields before including them in `ColumnUsage` sets. 

4794951e007565ef1e39c404361992a5ad760f59 updates the (un)escape logic to handle periods and brackets.
