### PR TITLE
All timestamp UDFs should accept nanoseconds / Date32 / Date64

### DIFF
--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_add_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_add_tz.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use vegafusion_common::datafusion_expr::TypeSignature;
 use vegafusion_common::{
     arrow::datatypes::{DataType, TimeUnit},
     datafusion_expr::{
@@ -15,12 +16,20 @@ fn make_date_add_tz_udf() -> ScalarUDF {
     let return_type: ReturnTypeFunction =
         Arc::new(move |_| Ok(Arc::new(DataType::Timestamp(TimeUnit::Millisecond, None))));
 
-    let signature = Signature::exact(
+    let signature = Signature::one_of(
         vec![
-            DataType::Utf8,
-            DataType::Int32,
-            DataType::Timestamp(TimeUnit::Millisecond, None),
-            DataType::Utf8,
+            TypeSignature::Exact(vec![
+                DataType::Utf8,
+                DataType::Int32,
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Utf8,
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8,
+                DataType::Int32,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                DataType::Utf8,
+            ]),
         ],
         Volatility::Immutable,
     );

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_add_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_add_tz.rs
@@ -21,6 +21,18 @@ fn make_date_add_tz_udf() -> ScalarUDF {
             TypeSignature::Exact(vec![
                 DataType::Utf8,
                 DataType::Int32,
+                DataType::Date32,
+                DataType::Utf8,
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8,
+                DataType::Int32,
+                DataType::Date64,
+                DataType::Utf8,
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8,
+                DataType::Int32,
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8,
             ]),

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_part_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_part_tz.rs
@@ -56,6 +56,16 @@ fn make_date_part_tz_udf() -> ScalarUDF {
         vec![
             TypeSignature::Exact(vec![
                 DataType::Utf8, // part
+                DataType::Date32,
+                DataType::Utf8, // timezone
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
+                DataType::Date64,
+                DataType::Utf8, // timezone
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8, // timezone
             ]),

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_part_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_part_tz.rs
@@ -3,6 +3,7 @@ use crate::udfs::datetime::to_utc_timestamp::to_timestamp_ms;
 use datafusion_physical_expr::datetime_expressions;
 use std::str::FromStr;
 use std::sync::Arc;
+use vegafusion_common::datafusion_expr::TypeSignature;
 use vegafusion_common::{
     arrow::datatypes::{DataType, TimeUnit},
     datafusion_common::DataFusionError,
@@ -11,7 +12,6 @@ use vegafusion_common::{
         Volatility,
     },
 };
-use vegafusion_common::datafusion_expr::TypeSignature;
 
 fn make_date_part_tz_udf() -> ScalarUDF {
     let scalar_fn: ScalarFunctionImplementation = Arc::new(move |args: &[ColumnarValue]| {

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_trunc_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_trunc_tz.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use vegafusion_common::datafusion_expr::TypeSignature;
 use vegafusion_common::{
     arrow::datatypes::{DataType, TimeUnit},
     datafusion_expr::{
@@ -15,11 +16,18 @@ fn make_date_trunc_tz_udf() -> ScalarUDF {
     let return_type: ReturnTypeFunction =
         Arc::new(move |_| Ok(Arc::new(DataType::Timestamp(TimeUnit::Millisecond, None))));
 
-    let signature = Signature::exact(
+    let signature = Signature::one_of(
         vec![
-            DataType::Utf8, // part
-            DataType::Timestamp(TimeUnit::Millisecond, None),
-            DataType::Utf8, // timezone
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Utf8, // timezone
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                DataType::Utf8, // timezone
+            ]),
         ],
         Volatility::Immutable,
     );

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/date_trunc_tz.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/date_trunc_tz.rs
@@ -20,6 +20,16 @@ fn make_date_trunc_tz_udf() -> ScalarUDF {
         vec![
             TypeSignature::Exact(vec![
                 DataType::Utf8, // part
+                DataType::Date32,
+                DataType::Utf8, // timezone
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
+                DataType::Date64,
+                DataType::Utf8, // timezone
+            ]),
+            TypeSignature::Exact(vec![
+                DataType::Utf8, // part
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8, // timezone
             ]),

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/format_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/format_timestamp.rs
@@ -73,6 +73,8 @@ fn make_format_timestamp_udf() -> ScalarUDF {
 
     let signature: Signature = Signature::one_of(
         vec![
+            TypeSignature::Exact(vec![DataType::Date32, DataType::Utf8]),
+            TypeSignature::Exact(vec![DataType::Date64, DataType::Utf8]),
             TypeSignature::Exact(vec![
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8,

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/from_utc_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/from_utc_timestamp.rs
@@ -53,6 +53,8 @@ fn make_from_utc_timestamp() -> ScalarUDF {
 
     let signature: Signature = Signature::one_of(
         vec![
+            TypeSignature::Exact(vec![DataType::Date32, DataType::Utf8]),
+            TypeSignature::Exact(vec![DataType::Date64, DataType::Utf8]),
             TypeSignature::Exact(vec![
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8,

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/to_utc_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/to_utc_timestamp.rs
@@ -115,6 +115,10 @@ pub fn to_timestamp_ms(array: &ArrayRef) -> Result<ArrayRef, DataFusionError> {
                 )?)
             }
         }
+        DataType::Date32 => Ok(cast(
+            array,
+            &DataType::Timestamp(TimeUnit::Millisecond, None),
+        )?),
         DataType::Date64 => Ok(cast(
             array,
             &DataType::Timestamp(TimeUnit::Millisecond, None),

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/utc_timestamp_to_epoch.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/utc_timestamp_to_epoch.rs
@@ -36,6 +36,8 @@ fn make_utc_timestamp_to_epoch_ms_udf() -> ScalarUDF {
     let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Int64)));
     let signature = Signature::one_of(
         vec![
+            TypeSignature::Exact(vec![DataType::Date32]),
+            TypeSignature::Exact(vec![DataType::Date64]),
             TypeSignature::Exact(vec![DataType::Timestamp(TimeUnit::Millisecond, None)]),
             TypeSignature::Exact(vec![DataType::Timestamp(TimeUnit::Nanosecond, None)]),
         ],

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/utc_timestamp_to_str.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/utc_timestamp_to_str.rs
@@ -80,6 +80,8 @@ fn make_utc_timestamp_to_str_udf() -> ScalarUDF {
 
     let signature = Signature::one_of(
         vec![
+            TypeSignature::Exact(vec![DataType::Date32, DataType::Utf8]),
+            TypeSignature::Exact(vec![DataType::Date64, DataType::Utf8]),
             TypeSignature::Exact(vec![
                 DataType::Timestamp(TimeUnit::Millisecond, None),
                 DataType::Utf8,

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/date_format.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/date_format.rs
@@ -1,9 +1,10 @@
 use crate::task_graph::timezone::RuntimeTzConfig;
-use datafusion_expr::{lit, Expr, ExprSchemable};
+use datafusion_expr::{expr, lit, Expr, ExprSchemable};
 use std::sync::Arc;
 use vegafusion_common::arrow::datatypes::DataType;
 use vegafusion_common::datafusion_common::{DFSchema, ScalarValue};
 use vegafusion_common::datatypes::{cast_to, is_numeric_datatype};
+use vegafusion_core::arrow::datatypes::TimeUnit;
 use vegafusion_core::error::{Result, VegaFusionError};
 use vegafusion_datafusion_udfs::udfs::datetime::epoch_to_utc_timestamp::EPOCH_MS_TO_UTC_TIMESTAMP_UDF;
 use vegafusion_datafusion_udfs::udfs::datetime::format_timestamp::FORMAT_TIMESTAMP_UDF;
@@ -91,6 +92,14 @@ pub fn utc_format_fn(
 
 fn to_timestamptz_expr(arg: &Expr, schema: &DFSchema, default_input_tz: &str) -> Result<Expr> {
     Ok(match arg.get_type(schema)? {
+        DataType::Date32 => Expr::Cast(expr::Cast {
+            expr: Box::new(arg.clone()),
+            data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
+        }),
+        DataType::Date64 => Expr::Cast(expr::Cast {
+            expr: Box::new(arg.clone()),
+            data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
+        }),
         DataType::Timestamp(_, _) => arg.clone(),
         DataType::Utf8 => Expr::ScalarUDF {
             fun: Arc::new((*STR_TO_UTC_TIMESTAMP_UDF).clone()),

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/date_parts.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/date_parts.rs
@@ -1,8 +1,8 @@
 use crate::expression::compiler::call::TzTransformFn;
 use crate::task_graph::timezone::RuntimeTzConfig;
-use datafusion_expr::{floor, lit, Expr, ExprSchemable};
+use datafusion_expr::{expr, floor, lit, Expr, ExprSchemable};
 use std::sync::Arc;
-use vegafusion_common::arrow::datatypes::DataType;
+use vegafusion_common::arrow::datatypes::{DataType, TimeUnit};
 use vegafusion_common::datafusion_common::DFSchema;
 use vegafusion_common::datatypes::{cast_to, is_numeric_datatype};
 use vegafusion_core::error::{Result, VegaFusionError};
@@ -64,6 +64,14 @@ fn extract_timestamp_arg(
 ) -> Result<Expr> {
     if let Some(arg) = args.get(0) {
         Ok(match arg.get_type(schema)? {
+            DataType::Date32 => Expr::Cast(expr::Cast {
+                expr: Box::new(arg.clone()),
+                data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
+            }),
+            DataType::Date64 => Expr::Cast(expr::Cast {
+                expr: Box::new(arg.clone()),
+                data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
+            }),
             DataType::Timestamp(_, _) => arg.clone(),
             DataType::Utf8 => Expr::ScalarUDF {
                 fun: Arc::new((*STR_TO_UTC_TIMESTAMP_UDF).clone()),

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/time.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/time.rs
@@ -22,7 +22,7 @@ pub fn time_fn(tz_config: &RuntimeTzConfig, args: &[Expr], schema: &DFSchema) ->
 
     // Dispatch handling on data type
     let expr = match arg.get_type(schema)? {
-        DataType::Timestamp(_, _) => Expr::ScalarUDF {
+        DataType::Timestamp(_, _) | DataType::Date32 | DataType::Date64 => Expr::ScalarUDF {
             fun: Arc::new((*UTC_TIMESTAMP_TO_EPOCH_MS).clone()),
             args: vec![arg.clone()],
         },

--- a/vegafusion-sql/src/dialect/mod.rs
+++ b/vegafusion-sql/src/dialect/mod.rs
@@ -41,7 +41,7 @@ use crate::dialect::transforms::utc_timestamp_to_str::{
     UtcTimestampToStrDuckDBTransformer, UtcTimestampToStrPostgresTransformer,
     UtcTimestampToStrSnowflakeTransformer,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, TimeUnit};
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::DFSchema;
 use datafusion_expr::{lit, ExprSchemable};
@@ -969,6 +969,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Float(None)),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::Varchar(None)),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -1213,6 +1217,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Real),
                 (DataType::Float64, SqlDataType::DoublePrecision),
                 (DataType::Utf8, SqlDataType::Text),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),

--- a/vegafusion-sql/src/dialect/mod.rs
+++ b/vegafusion-sql/src/dialect/mod.rs
@@ -329,6 +329,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Double),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::Varchar(None)),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -450,6 +454,10 @@ impl Dialect {
                 (DataType::Float32, float64dtype.clone()),
                 (DataType::Float64, float64dtype),
                 (DataType::Utf8, SqlDataType::String),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -544,6 +552,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Float(None)),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::Varchar(None)),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -681,6 +693,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Float(None)),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::String),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -820,6 +836,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Float(None)),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::String),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -1347,6 +1367,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Real),
                 (DataType::Float64, SqlDataType::DoublePrecision),
                 (DataType::Utf8, SqlDataType::Text),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -1483,6 +1507,10 @@ impl Dialect {
                 (DataType::Float32, SqlDataType::Float(None)),
                 (DataType::Float64, SqlDataType::Double),
                 (DataType::Utf8, SqlDataType::Varchar(None)),
+                (
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    SqlDataType::Timestamp(None, TimezoneInfo::None),
+                ),
             ]
             .into_iter()
             .collect(),


### PR DESCRIPTION
DataFusion won't automatically cast from timestamp nanos to timestamp millis due to precision loss. Therefore all of our timestamp UDFs should accept timestamp nanos, and perform the conversion internally if necessary.
