### PR TITLE
Don't cache DuckDB schema of externally registered tables

### DIFF
--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -87,7 +87,7 @@ class DuckDbConnection(SqlConnection):
         # Use a less round number for pandas_analyze_sample (default is 1000)
         self.conn.execute("SET GLOBAL pandas_analyze_sample=1007")
 
-        self._table_schemas = dict()
+        self._registered_table_schemas = dict()
         # Call self.tables to warm the cache of table schemas
         self.tables()
 
@@ -98,6 +98,10 @@ class DuckDbConnection(SqlConnection):
     def fallback(self) -> bool:
         return self._fallback
 
+    def _schema_for_table(self, table_name: str):
+        rel = self.conn.query(f'select * from "{table_name}" limit 1')
+        return duckdb_relation_to_schema(rel)
+
     def tables(self) -> Dict[str, pa.Schema]:
         result = {}
         table_names = self.conn.query(
@@ -105,13 +109,14 @@ class DuckDbConnection(SqlConnection):
         ).to_df()["table_name"].tolist()
 
         for table_name in table_names:
-            if table_name in self._table_schemas:
-                result[table_name] = self._table_schemas[table_name]
+            if table_name in self._registered_table_schemas:
+                # Registered tables are expected to only change when self.register_* is called,
+                # so use the cached version
+                result[table_name] = self._registered_table_schemas[table_name]
             else:
-                rel = self.conn.query(f'select * from "{table_name}" limit 1')
-                schema = duckdb_relation_to_schema(rel)
-                self._table_schemas[table_name] = schema
-                result[table_name] = schema
+                # Dynamically look up schema for tables that are registered with duckdb but now with
+                # the self.register_* methods
+                result[table_name] = self._schema_for_table(table_name)
 
         return result
 
@@ -135,19 +140,18 @@ class DuckDbConnection(SqlConnection):
         df["_vf_order"] = range(0, len(df))
         self.conn.register(name, df)
         self._update_temp_names(name, temporary)
+        self._registered_table_schemas[name] = self._schema_for_table(name)
 
     def register_arrow(self, name: str, table: pa.Table, temporary: bool = False):
         self.conn.register(name, table)
         self._update_temp_names(name, temporary)
-
-        # We have the exact schema, save it in _table_schemas, so it doesn't need to
-        # be constructed later
-        self._table_schemas[name] = table.schema
+        self._registered_table_schemas[name] = table.schema
 
     def register_json(self, name: str, path: str, temporary: bool = False):
         relation = self.conn.read_json(path)
         relation.to_view(name)
         self._update_temp_names(name, temporary)
+        self._registered_table_schemas[name] = self._schema_for_table(name)
 
     def register_csv(self, name: str, path: str, options: CsvReadOptions, temporary: bool = False):
         relation = self.conn.read_csv(
@@ -176,17 +180,19 @@ class DuckDbConnection(SqlConnection):
 
         relation.to_view(name)
         self._update_temp_names(name, temporary)
+        self._registered_table_schemas[name] = self._schema_for_table(name)
 
     def register_parquet(self, name: str, path: str, temporary: bool = False):
         relation = self.conn.read_parquet(path)
         relation.to_view(name)
         self._update_temp_names(name, temporary)
+        self._registered_table_schemas[name] = self._schema_for_table(name)
 
     def unregister(self, name: str):
         self.conn.unregister(name)
         if name in self._temp_tables:
             self._temp_tables.remove(name)
-        self._table_schemas.pop(name, None)
+        self._registered_table_schemas.pop(name, None)
 
     def unregister_temporary_tables(self):
         for name in list(self._temp_tables):

--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -54,7 +54,7 @@ def duckdb_relation_to_schema(rel: duckdb.DuckDBPyRelation) -> pa.Schema:
 
 
 class DuckDbConnection(SqlConnection):
-    def __init__(self, connection: duckdb.DuckDBPyConnection = None, fallback: bool = True):
+    def __init__(self, connection: duckdb.DuckDBPyConnection = None, fallback: bool = True, verbose: bool = False):
         # Validate duckdb version
         if LooseVersion(duckdb.__version__) < LooseVersion("0.7.0"):
             raise ImportError(
@@ -63,6 +63,7 @@ class DuckDbConnection(SqlConnection):
             )
 
         self._fallback = fallback
+        self._verbose = verbose
         self._temp_tables = set()
 
         if connection is None:
@@ -116,6 +117,8 @@ class DuckDbConnection(SqlConnection):
 
     def fetch_query(self, query: str, schema: pa.Schema) -> pa.Table:
         self.logger.info(f"Query:\n{query}\n")
+        if self._verbose:
+            print(f"DuckDB Query:\n{query}\n")
         return self.conn.query(query).to_arrow_table(8096)
 
     def _update_temp_names(self, name: str, temporary: bool):

--- a/vegafusion-sql/src/dialect/transforms/to_utc_timestamp.rs
+++ b/vegafusion-sql/src/dialect/transforms/to_utc_timestamp.rs
@@ -61,18 +61,16 @@ impl FunctionTransformer for ToUtcTimestampWithAtTimeZoneTransformer {
                 timestamp: Box::new(sql_arg0),
                 time_zone: "UTC".to_string(),
             }
+        } else if time_zone == "UTC" {
+            sql_arg0
         } else {
-            if time_zone == "UTC" {
-                sql_arg0
-            } else {
-                let at_tz_expr = SqlExpr::AtTimeZone {
-                    timestamp: Box::new(sql_arg0),
-                    time_zone,
-                };
-                SqlExpr::AtTimeZone {
-                    timestamp: Box::new(at_tz_expr),
-                    time_zone: "UTC".to_string(),
-                }
+            let at_tz_expr = SqlExpr::AtTimeZone {
+                timestamp: Box::new(sql_arg0),
+                time_zone,
+            };
+            SqlExpr::AtTimeZone {
+                timestamp: Box::new(at_tz_expr),
+                time_zone: "UTC".to_string(),
             }
         };
 

--- a/vegafusion-sql/src/dialect/transforms/to_utc_timestamp.rs
+++ b/vegafusion-sql/src/dialect/transforms/to_utc_timestamp.rs
@@ -62,13 +62,17 @@ impl FunctionTransformer for ToUtcTimestampWithAtTimeZoneTransformer {
                 time_zone: "UTC".to_string(),
             }
         } else {
-            let at_tz_expr = SqlExpr::AtTimeZone {
-                timestamp: Box::new(sql_arg0),
-                time_zone,
-            };
-            SqlExpr::AtTimeZone {
-                timestamp: Box::new(at_tz_expr),
-                time_zone: "UTC".to_string(),
+            if time_zone == "UTC" {
+                sql_arg0
+            } else {
+                let at_tz_expr = SqlExpr::AtTimeZone {
+                    timestamp: Box::new(sql_arg0),
+                    time_zone,
+                };
+                SqlExpr::AtTimeZone {
+                    timestamp: Box::new(at_tz_expr),
+                    time_zone: "UTC".to_string(),
+                }
             }
         };
 


### PR DESCRIPTION
Follow up to https://github.com/hex-inc/vegafusion/pull/252.

When a chart references an external duckdb table (using a "table://{name}" URL string), we were caching the table's schema the first time it was accessed. But when working interactively, this table's schema may change.

After this PR, we only cache the schema of tables directly registered with the VegaFusion DuckDBConnection.