### PR TITLE
Various fixes to support updated Taxi Dashboard example

### DIFF
--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-embed",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -39,7 +39,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",

--- a/python/vegafusion-jupyter/package-lock.json
+++ b/python/vegafusion-jupyter/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-jupyter",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^4 || ^5 || ^6",
@@ -53,7 +53,7 @@
       }
     },
     "../../javascript/vegafusion-embed": {
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -86,7 +86,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -9509,7 +9509,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -11344,7 +11344,7 @@
         "node": ">=14"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -17906,7 +17906,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -17924,7 +17924,7 @@
         "lib0": "^0.2.31"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -17939,7 +17939,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -17957,7 +17957,7 @@
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "optionalDependencies": {
@@ -18040,7 +18040,7 @@
         "lib0": "^0.2.49"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },

--- a/vegafusion-common/src/data/table.rs
+++ b/vegafusion-common/src/data/table.rs
@@ -100,7 +100,7 @@ impl VegaFusionTable {
         let empty_record_batch = RecordBatch::new_empty(Arc::new(Schema::new(vec![Field::new(
             ORDER_COL,
             DataType::UInt64,
-            false,
+            true,
         )])));
         VegaFusionTable::from(empty_record_batch)
     }
@@ -125,7 +125,7 @@ impl VegaFusionTable {
             new_fields.remove(order_col_index);
         }
 
-        new_fields.insert(0, Field::new(ORDER_COL, ORDER_COL_DTYPE, false));
+        new_fields.insert(0, Field::new(ORDER_COL, ORDER_COL_DTYPE, true));
 
         let new_schema = Arc::new(Schema::new(new_fields)) as SchemaRef;
 

--- a/vegafusion-core/src/spec/chart.rs
+++ b/vegafusion-core/src/spec/chart.rs
@@ -50,25 +50,8 @@ pub fn default_schema() -> String {
 
 impl ChartSpec {
     pub fn walk(&self, visitor: &mut dyn ChartVisitor) -> Result<()> {
-        // Visit top-level chart
-        visitor.visit_chart(self)?;
-
-        // Top-level with empty scope
-        let scope: Vec<u32> = Vec::new();
-        for data in &self.data {
-            visitor.visit_data(data, &scope)?;
-        }
-        for scale in &self.scales {
-            visitor.visit_scale(scale, &scope)?;
-        }
-        for axis in &self.axes {
-            visitor.visit_axis(axis, &scope)?;
-        }
-        for signal in &self.signals {
-            visitor.visit_signal(signal, &scope)?;
-        }
-
         // Child groups
+        let scope: Vec<u32> = Vec::new();
         let mut group_index = 0;
         for mark in &self.marks {
             if mark.type_ == "group" {
@@ -84,6 +67,23 @@ impl ChartSpec {
                 visitor.visit_non_group_mark(mark, &scope)?;
             }
         }
+
+        // Top-level with empty scope
+        for data in &self.data {
+            visitor.visit_data(data, &scope)?;
+        }
+        for scale in &self.scales {
+            visitor.visit_scale(scale, &scope)?;
+        }
+        for axis in &self.axes {
+            visitor.visit_axis(axis, &scope)?;
+        }
+        for signal in &self.signals {
+            visitor.visit_signal(signal, &scope)?;
+        }
+
+        // Visit top-level chart
+        visitor.visit_chart(self)?;
 
         Ok(())
     }

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -1,9 +1,6 @@
 use crate::expression::parser::parse;
 use crate::proto::gen::tasks::data_url_task::Url;
-use crate::proto::gen::tasks::{
-    scan_url_format, DataSourceTask, DataUrlTask, DataValuesTask, ParseFieldSpec, ParseFieldSpecs,
-    ScanUrlFormat, Task, TzConfig, Variable,
-};
+use crate::proto::gen::tasks::{scan_url_format, DataSourceTask, DataUrlTask, DataValuesTask, ParseFieldSpec, ParseFieldSpecs, ScanUrlFormat, Task, TzConfig, Variable, VariableNamespace};
 use crate::proto::gen::transforms::TransformPipeline;
 use crate::spec::chart::{ChartSpec, ChartVisitor};
 use crate::spec::data::{DataFormatParseSpec, DataSpec};
@@ -24,7 +21,7 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 use vegafusion_common::data::scalar::ScalarValueHelpers;
 use vegafusion_common::data::table::VegaFusionTable;
-use vegafusion_common::error::{Result, VegaFusionError};
+use vegafusion_common::error::Result;
 
 #[derive(Clone, Debug, Default)]
 pub struct MakeTaskScopeVisitor {
@@ -241,9 +238,8 @@ impl<'a> ChartVisitor for MakeTasksVisitor<'a> {
             let expression = parse(update)?;
             Task::new_signal(signal_var, scope, expression, &self.tz_config)
         } else {
-            return Err(VegaFusionError::internal(format!(
-                "Signal must have an initial value or an update expression: {signal:#?}"
-            )));
+            let value = TaskValue::Scalar(ScalarValue::Null);
+            Task::new_value(signal_var, scope, value)
         };
 
         self.tasks.push(task);
@@ -342,6 +338,19 @@ impl<'a> ChartVisitor for UpdateVarsChartVisitor<'a> {
         {
             self.update_vars
                 .insert((Variable::new_signal(&signal.name), Vec::from(scope)));
+        } else {
+            // Check for empty signal that has an update in a child signal of the same name
+            // Note: We rely on the fact that visit_signal is called after child groups have been
+            // visited
+            for v in &self.update_vars {
+                if v.0.namespace == VariableNamespace::Signal as i32 {
+                    if v.0.name == signal.name {
+                        self.update_vars
+                            .insert((Variable::new_signal(&signal.name), Vec::from(scope)));
+                        break
+                    }
+                }
+            }
         }
 
         // Check for signal expressions that have update dependencies

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -1,6 +1,9 @@
 use crate::expression::parser::parse;
 use crate::proto::gen::tasks::data_url_task::Url;
-use crate::proto::gen::tasks::{scan_url_format, DataSourceTask, DataUrlTask, DataValuesTask, ParseFieldSpec, ParseFieldSpecs, ScanUrlFormat, Task, TzConfig, Variable, VariableNamespace};
+use crate::proto::gen::tasks::{
+    scan_url_format, DataSourceTask, DataUrlTask, DataValuesTask, ParseFieldSpec, ParseFieldSpecs,
+    ScanUrlFormat, Task, TzConfig, Variable, VariableNamespace,
+};
 use crate::proto::gen::transforms::TransformPipeline;
 use crate::spec::chart::{ChartSpec, ChartVisitor};
 use crate::spec::data::{DataFormatParseSpec, DataSpec};
@@ -347,7 +350,7 @@ impl<'a> ChartVisitor for UpdateVarsChartVisitor<'a> {
                     if v.0.name == signal.name {
                         self.update_vars
                             .insert((Variable::new_signal(&signal.name), Vec::from(scope)));
-                        break
+                        break;
                     }
                 }
             }

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -346,12 +346,10 @@ impl<'a> ChartVisitor for UpdateVarsChartVisitor<'a> {
             // Note: We rely on the fact that visit_signal is called after child groups have been
             // visited
             for v in &self.update_vars {
-                if v.0.namespace == VariableNamespace::Signal as i32 {
-                    if v.0.name == signal.name {
-                        self.update_vars
-                            .insert((Variable::new_signal(&signal.name), Vec::from(scope)));
-                        break;
-                    }
+                if v.0.namespace == VariableNamespace::Signal as i32 && v.0.name == signal.name {
+                    self.update_vars
+                        .insert((Variable::new_signal(&signal.name), Vec::from(scope)));
+                    break;
                 }
             }
         }

--- a/vegafusion-datafusion-udfs/src/udfs/array/span.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/array/span.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::sync::Arc;
 use vegafusion_common::arrow::datatypes::{DataType, Field};
 use vegafusion_common::data::scalar::ScalarValueHelpers;
@@ -22,16 +21,15 @@ fn make_span_udf() -> ScalarUDF {
             ColumnarValue::Scalar(value) => {
                 match value {
                     ScalarValue::Float64(_) => {
-                        ColumnarValue::Scalar(ScalarValue::try_from(&DataType::Float64).unwrap())
+                        // Span of scalar (including null) is 0
+                        ColumnarValue::Scalar(ScalarValue::from(0.0))
                     }
                     ScalarValue::List(Some(arr), element_type) => {
                         match element_type.data_type() {
                             DataType::Float64 => {
                                 if arr.is_empty() {
-                                    // Span of empty array is null
-                                    ColumnarValue::Scalar(
-                                        ScalarValue::try_from(&DataType::Float64).unwrap(),
-                                    )
+                                    // Span of empty array is 0
+                                    ColumnarValue::Scalar(ScalarValue::from(0.0))
                                 } else {
                                     let first = arr.first().unwrap().to_f64().unwrap();
                                     let last = arr.last().unwrap().to_f64().unwrap();

--- a/vegafusion-datafusion-udfs/src/udfs/array/span.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/array/span.rs
@@ -20,6 +20,9 @@ fn make_span_udf() -> ScalarUDF {
         Ok(match arg {
             ColumnarValue::Scalar(value) => {
                 match value {
+                    ScalarValue::Null => {
+                        ColumnarValue::Scalar(ScalarValue::from(0.0))
+                    }
                     ScalarValue::Float64(_) => {
                         // Span of scalar (including null) is 0
                         ColumnarValue::Scalar(ScalarValue::from(0.0))
@@ -59,6 +62,7 @@ fn make_span_udf() -> ScalarUDF {
             1,
             vec![
                 DataType::Float64, // For null
+                DataType::Null, // For null
                 DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
             ],
             Volatility::Immutable,

--- a/vegafusion-datafusion-udfs/src/udfs/array/span.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/array/span.rs
@@ -20,9 +20,7 @@ fn make_span_udf() -> ScalarUDF {
         Ok(match arg {
             ColumnarValue::Scalar(value) => {
                 match value {
-                    ScalarValue::Null => {
-                        ColumnarValue::Scalar(ScalarValue::from(0.0))
-                    }
+                    ScalarValue::Null => ColumnarValue::Scalar(ScalarValue::from(0.0)),
                     ScalarValue::Float64(_) => {
                         // Span of scalar (including null) is 0
                         ColumnarValue::Scalar(ScalarValue::from(0.0))
@@ -62,7 +60,7 @@ fn make_span_udf() -> ScalarUDF {
             1,
             vec![
                 DataType::Float64, // For null
-                DataType::Null, // For null
+                DataType::Null,    // For null
                 DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
             ],
             Volatility::Immutable,

--- a/vegafusion-datafusion-udfs/src/udfs/object/mod.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/object/mod.rs
@@ -9,7 +9,7 @@ pub fn make_object_constructor_udf(keys: &[String], value_types: &[DataType]) ->
     let fields: Vec<_> = keys
         .iter()
         .zip(value_types.iter())
-        .map(|(k, dtype)| Field::new(k, dtype.clone(), false))
+        .map(|(k, dtype)| Field::new(k, dtype.clone(), true))
         .collect();
 
     let struct_dtype = DataType::Struct(fields.clone());

--- a/vegafusion-runtime/src/expression/compiler/mod.rs
+++ b/vegafusion-runtime/src/expression/compiler/mod.rs
@@ -499,7 +499,7 @@ mod test_compile {
                 &["a".to_string(), "two".to_string()],
                 &[
                     DataType::Float64,
-                    DataType::Struct(vec![Field::new("three", DataType::Float64, false)]),
+                    DataType::Struct(vec![Field::new("three", DataType::Float64, true)]),
                 ],
             )),
             args: vec![
@@ -570,7 +570,7 @@ mod test_compile {
     fn test_compile_datum_nested_member() {
         let expr = parse("datum['two'].foo * 3").unwrap();
         // let expr = parse("[datum['two'].foo * 3, datum['two'].foo]").unwrap();
-        let foo_field = Field::new("foo", DataType::Float64, false);
+        let foo_field = Field::new("foo", DataType::Float64, true);
 
         let two_type = DataType::Struct(vec![foo_field]);
         let two_field = Field::new("two", two_type, true);

--- a/vegafusion-runtime/src/expression/compiler/mod.rs
+++ b/vegafusion-runtime/src/expression/compiler/mod.rs
@@ -528,7 +528,10 @@ mod test_compile {
         ]);
 
         println!("value: {result_value:?}");
-        assert_eq!(result_value, expected_value);
+
+        // ScalarValue::from(...) creates a Field with nullable=false. We always use nullable=true,
+        // so compare string repr (which doesn't include nullable info) instead of value
+        assert_eq!(format!("{result_value:?}"), format!("{expected_value:?}"));
     }
 
     #[test]

--- a/vegafusion-runtime/src/transform/bin.rs
+++ b/vegafusion-runtime/src/transform/bin.rs
@@ -175,7 +175,9 @@ pub fn calculate_bin_params(
         let span_expr = compile(span_expression, config, Some(schema))?;
         let span_scalar = span_expr.eval_to_scalar()?;
         if let Ok(span_f64) = span_scalar.to_f64() {
-            span = span_f64;
+            if span_f64 > 0.0 {
+                span = span_f64;
+            }
         }
     }
 

--- a/vegafusion-runtime/src/transform/sequence.rs
+++ b/vegafusion-runtime/src/transform/sequence.rs
@@ -63,7 +63,7 @@ impl TransformTrait for Sequence {
         let data_schema = Arc::new(Schema::new(vec![Field::new(
             &col_name,
             DataType::Float64,
-            false,
+            true,
         )])) as SchemaRef;
         let data_batch = RecordBatch::try_new(data_schema, vec![data_array])?;
         let data_table = VegaFusionTable::from(data_batch);

--- a/vegafusion-runtime/tests/specs/custom/taxi_dashboard.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/taxi_dashboard.comm_plan.json
@@ -1,0 +1,8 @@
+{
+  "server_to_client": [
+    { "namespace": "data", "name": "data_2", "scope": [] },
+    { "namespace": "data", "name": "data_3", "scope": [] },
+    { "namespace": "data", "name": "data_4", "scope": [] }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/taxi_dashboard.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/taxi_dashboard.comm_plan.json
@@ -1,8 +1,81 @@
 {
   "server_to_client": [
-    { "namespace": "data", "name": "data_2", "scope": [] },
-    { "namespace": "data", "name": "data_3", "scope": [] },
-    { "namespace": "data", "name": "data_4", "scope": [] }
+    {
+      "name": "concat_0_bin_extent_0_12_maxbins_20_trip_distance_bins",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_x_bins",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_y_bins",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "_server_data_2",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_1_concat_0_y_domain___count",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_concat_2_color_domain_mean_tip_perc",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_concat_2_y_domain_pickup_hour",
+      "namespace": "data",
+      "scope": []
+    }
   ],
-  "client_to_server": []
+  "client_to_server": [
+    {
+      "name": "pickup_scales_pickup_x",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "pickup_scales_pickup_y",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "pickup_scales_store",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "selector013_store",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "selector014_store",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "selector015_store",
+      "namespace": "data",
+      "scope": []
+    }
+  ]
 }

--- a/vegafusion-runtime/tests/specs/custom/taxi_dashboard.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/taxi_dashboard.vg.json
@@ -229,7 +229,7 @@
       "transform": [
         {
           "type": "formula",
-          "expr": "utchours(datum.tpep_pickup_datetime)",
+          "expr": "hours(datum.tpep_pickup_datetime)",
           "as": "pickup_hour"
         },
         {

--- a/vegafusion-runtime/tests/specs/custom/taxi_dashboard.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/taxi_dashboard.vg.json
@@ -1,0 +1,1737 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 400,
+  "data": [
+    {"name": "selector014_store"},
+    {"name": "pickup_scales_store"},
+    {"name": "selector013_store"},
+    {"name": "selector015_store"},
+    {
+      "name": "source_0",
+      "values": [
+        {
+          "VendorID": 2,
+          "tpep_pickup_datetime": "2015-01-15 19:05:39",
+          "tpep_dropoff_datetime": "2015-01-15 19:23:42",
+          "passenger_count": 1,
+          "trip_distance": 1.59,
+          "pickup_x": -8236962.87845,
+          "pickup_y": 4975552.61692,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8234835.38116,
+          "dropoff_y": 4975627.16997,
+          "payment_type": 1,
+          "fare_amount": 12,
+          "extra": 1,
+          "mta_tax": 0.5,
+          "tip_amount": 3.25,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 17.05
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:38",
+          "tpep_dropoff_datetime": "2015-01-10 20:53:28",
+          "passenger_count": 1,
+          "trip_distance": 3.3,
+          "pickup_x": -8237825.76757,
+          "pickup_y": 4971752.28598,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8237020.63087,
+          "dropoff_y": 4976875.03705,
+          "payment_type": 1,
+          "fare_amount": 14.5,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 2,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 17.8
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:39",
+          "tpep_dropoff_datetime": "2015-01-10 20:35:31",
+          "passenger_count": 1,
+          "trip_distance": 0.5,
+          "pickup_x": -8238653.83538,
+          "pickup_y": 4970221.02621,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8238123.87198,
+          "dropoff_y": 4971126.9786,
+          "payment_type": 2,
+          "fare_amount": 3.5,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 0,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 4.8
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:39",
+          "tpep_dropoff_datetime": "2015-01-10 20:52:58",
+          "passenger_count": 1,
+          "trip_distance": 3,
+          "pickup_x": -8234433.66211,
+          "pickup_y": 4977362.79122,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8238107.73527,
+          "dropoff_y": 4974456.80877,
+          "payment_type": 2,
+          "fare_amount": 15,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 0,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 16.3
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:39",
+          "tpep_dropoff_datetime": "2015-01-10 20:58:31",
+          "passenger_count": 1,
+          "trip_distance": 2.2,
+          "pickup_x": -8235780.65241,
+          "pickup_y": 4972011.72183,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8236804.05929,
+          "dropoff_y": 4975482.54878,
+          "payment_type": 2,
+          "fare_amount": 14,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 0,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 15.3
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:39",
+          "tpep_dropoff_datetime": "2015-01-10 20:42:20",
+          "passenger_count": 3,
+          "trip_distance": 0.8,
+          "pickup_x": -8237938.72451,
+          "pickup_y": 4973206.44838,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8237086.8763,
+          "dropoff_y": 4972058.2305,
+          "payment_type": 1,
+          "fare_amount": 7,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 1.66,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 9.96
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:40",
+          "tpep_dropoff_datetime": "2015-01-10 20:40:44",
+          "passenger_count": 2,
+          "trip_distance": 0.9,
+          "pickup_x": -8236037.99041,
+          "pickup_y": 4978174.08688,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8236074.51032,
+          "dropoff_y": 4976912.59886,
+          "payment_type": 1,
+          "fare_amount": 6.5,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 1.55,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 9.35
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:40",
+          "tpep_dropoff_datetime": "2015-01-10 20:41:39",
+          "passenger_count": 1,
+          "trip_distance": 0.9,
+          "pickup_x": -8236375.16263,
+          "pickup_y": 4971584.74898,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8238131.51568,
+          "dropoff_y": 4972389.96139,
+          "payment_type": 1,
+          "fare_amount": 7,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 1.66,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 9.96
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:41",
+          "tpep_dropoff_datetime": "2015-01-10 20:43:26",
+          "passenger_count": 1,
+          "trip_distance": 1.1,
+          "pickup_x": -8236950.13895,
+          "pickup_y": 4975744.88647,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8234014.10776,
+          "dropoff_y": 4976596.972,
+          "payment_type": 1,
+          "fare_amount": 7.5,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 1,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 9.8
+        },
+        {
+          "VendorID": 1,
+          "tpep_pickup_datetime": "2015-01-10 20:33:41",
+          "tpep_dropoff_datetime": "2015-01-10 20:35:23",
+          "passenger_count": 1,
+          "trip_distance": 0.3,
+          "pickup_x": -8238573.15185,
+          "pickup_y": 4968834.52694,
+          "RateCodeID": 1,
+          "store_and_fwd_flag": "N",
+          "dropoff_x": -8238730.2724,
+          "dropoff_y": 4969326.36156,
+          "payment_type": 2,
+          "fare_amount": 3,
+          "extra": 0.5,
+          "mta_tax": 0.5,
+          "tip_amount": 0,
+          "tolls_amount": 0,
+          "improvement_surcharge": 0.3,
+          "total_amount": 4.3
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "utchours(datum.tpep_pickup_datetime)",
+          "as": "pickup_hour"
+        },
+        {
+          "type": "formula",
+          "expr": "day(datum.tpep_pickup_datetime)",
+          "as": "pickup_day"
+        },
+        {"type": "formula", "expr": "datum.tip_amount", "as": "tip_perc"},
+        {"type": "filter", "expr": "datum.tip_perc < 100"}
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "(!length(data(\"selector013_store\")) || vlSelectionTest(\"selector013_store\", datum)) && (!length(data(\"selector015_store\")) || vlSelectionTest(\"selector015_store\", datum))"
+        },
+        {
+          "type": "bin",
+          "field": "trip_distance",
+          "as": [
+            "bin_extent_0_12_maxbins_20_trip_distance",
+            "bin_extent_0_12_maxbins_20_trip_distance_end"
+          ],
+          "signal": "concat_0_bin_extent_0_12_maxbins_20_trip_distance_bins",
+          "extent": [0, 12],
+          "maxbins": 20
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_extent_0_12_maxbins_20_trip_distance",
+            "bin_extent_0_12_maxbins_20_trip_distance_end"
+          ],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"bin_extent_0_12_maxbins_20_trip_distance\"]) && isFinite(+datum[\"bin_extent_0_12_maxbins_20_trip_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "(!length(data(\"pickup_scales_store\")) || vlSelectionTest(\"pickup_scales_store\", datum)) && (!length(data(\"selector014_store\")) || vlSelectionTest(\"selector014_store\", datum)) && (!length(data(\"selector015_store\")) || vlSelectionTest(\"selector015_store\", datum))"
+        },
+        {
+          "type": "extent",
+          "field": "pickup_x",
+          "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_x_extent"
+        },
+        {
+          "type": "bin",
+          "field": "pickup_x",
+          "as": [
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_x",
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_x_end"
+          ],
+          "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_x_bins",
+          "extent": {
+            "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_x_extent"
+          },
+          "span": {"signal": "span(pickup_scales[\"pickup_x\"])"},
+          "maxbins": 50
+        },
+        {
+          "type": "extent",
+          "field": "pickup_y",
+          "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_y_extent"
+        },
+        {
+          "type": "bin",
+          "field": "pickup_y",
+          "as": [
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_y",
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_y_end"
+          ],
+          "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_y_bins",
+          "extent": {
+            "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_y_extent"
+          },
+          "span": {"signal": "span(pickup_scales[\"pickup_x\"])"},
+          "maxbins": 50
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_x",
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_x_end",
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_y",
+            "bin_extent_param_pickup_scales_maxbins_50_pickup_y_end"
+          ],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x\"]) && isFinite(+datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x\"]) && isValid(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y\"]) && isFinite(+datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "(!length(data(\"selector013_store\")) || vlSelectionTest(\"selector013_store\", datum)) && (!length(data(\"selector014_store\")) || vlSelectionTest(\"selector014_store\", datum))"
+        },
+        {
+          "type": "aggregate",
+          "groupby": ["pickup_day", "pickup_hour"],
+          "ops": ["mean"],
+          "fields": ["tip_perc"],
+          "as": ["mean_tip_perc"]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"mean_tip_perc\"]) && isFinite(+datum[\"mean_tip_perc\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "concat_0_width", "value": 400},
+    {"name": "concat_1_width", "value": 400},
+    {"name": "concat_2_width", "value": 120},
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "selector014",
+      "update": "vlSelectionResolve(\"selector014_store\", \"union\")"
+    },
+    {
+      "name": "pickup_scales",
+      "update": "{\"pickup_x\": pickup_scales_pickup_x, \"pickup_y\": pickup_scales_pickup_y}"
+    },
+    {"name": "pickup_scales_pickup_x"},
+    {"name": "pickup_scales_pickup_y"},
+    {
+      "name": "selector013",
+      "update": "vlSelectionResolve(\"selector013_store\", \"union\")"
+    },
+    {
+      "name": "selector015",
+      "update": "vlSelectionResolve(\"selector015_store\", \"union\")"
+    }
+  ],
+  "layout": {"padding": 20, "bounds": "full", "align": "each"},
+  "marks": [
+    {
+      "type": "group",
+      "name": "concat_0_group",
+      "style": "cell",
+      "encode": {
+        "update": {
+          "width": {"signal": "concat_0_width"},
+          "height": {"signal": "height"}
+        }
+      },
+      "signals": [
+        {
+          "name": "selector014_x",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"selector014_brush\""
+                ]
+              },
+              "update": "[x(unit), x(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "mousemove",
+                "consume": true,
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "mousedown",
+                    "filter": [
+                      "!event.item || event.item.mark.name !== \"selector014_brush\""
+                    ]
+                  },
+                  {"source": "window", "type": "mouseup"}
+                ]
+              },
+              "update": "[selector014_x[0], clamp(x(unit), 0, concat_0_width)]"
+            },
+            {
+              "events": {"signal": "selector014_scale_trigger"},
+              "update": "[scale(\"concat_0_x\", selector014_trip_distance[0]), scale(\"concat_0_x\", selector014_trip_distance[1])]"
+            },
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {"signal": "selector014_translate_delta"},
+              "update": "clampRange(panLinear(selector014_translate_anchor.extent_x, selector014_translate_delta.x / span(selector014_translate_anchor.extent_x)), 0, concat_0_width)"
+            },
+            {
+              "events": {"signal": "selector014_zoom_delta"},
+              "update": "clampRange(zoomLinear(selector014_x, selector014_zoom_anchor.x, selector014_zoom_delta), 0, concat_0_width)"
+            }
+          ]
+        },
+        {
+          "name": "selector014_trip_distance",
+          "on": [
+            {
+              "events": {"signal": "selector014_x"},
+              "update": "selector014_x[0] === selector014_x[1] ? null : invert(\"concat_0_x\", selector014_x)"
+            }
+          ]
+        },
+        {
+          "name": "selector014_scale_trigger",
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}],
+              "update": "(!isArray(selector014_trip_distance) || (+invert(\"concat_0_x\", selector014_x)[0] === +selector014_trip_distance[0] && +invert(\"concat_0_x\", selector014_x)[1] === +selector014_trip_distance[1])) ? selector014_scale_trigger : {}"
+            }
+          ]
+        },
+        {
+          "name": "selector014_tuple",
+          "on": [
+            {
+              "events": [{"signal": "selector014_trip_distance"}],
+              "update": "selector014_trip_distance ? {unit: \"concat_0\", fields: selector014_tuple_fields, values: [selector014_trip_distance]} : null"
+            }
+          ]
+        },
+        {
+          "name": "selector014_tuple_fields",
+          "value": [{"field": "trip_distance", "channel": "x", "type": "R"}]
+        },
+        {
+          "name": "selector014_translate_anchor",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "mousedown",
+                  "markname": "selector014_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit), extent_x: slice(selector014_x)}"
+            }
+          ]
+        },
+        {
+          "name": "selector014_translate_delta",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "window",
+                  "type": "mousemove",
+                  "consume": true,
+                  "between": [
+                    {
+                      "source": "scope",
+                      "type": "mousedown",
+                      "markname": "selector014_brush"
+                    },
+                    {"source": "window", "type": "mouseup"}
+                  ]
+                }
+              ],
+              "update": "{x: selector014_translate_anchor.x - x(unit), y: selector014_translate_anchor.y - y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector014_zoom_anchor",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "markname": "selector014_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector014_zoom_delta",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "markname": "selector014_brush"
+                }
+              ],
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        },
+        {
+          "name": "selector014_modify",
+          "on": [
+            {
+              "events": {"signal": "selector014_tuple"},
+              "update": "modify(\"selector014_store\", selector014_tuple, true)"
+            }
+          ]
+        }
+      ],
+      "marks": [
+        {
+          "name": "selector014_brush_bg",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {
+              "fill": {"value": "#333"},
+              "fillOpacity": {"value": 0.125}
+            },
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "signal": "selector014_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "value": 0
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "signal": "selector014_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "field": {"group": "height"}
+                },
+                {"value": 0}
+              ]
+            }
+          }
+        },
+        {
+          "name": "concat_0_marks",
+          "type": "rect",
+          "style": ["bar"],
+          "interactive": true,
+          "from": {"data": "data_1"},
+          "encode": {
+            "update": {
+              "fill": {"value": "#4c78a8"},
+              "ariaRoleDescription": {"value": "bar"},
+              "description": {
+                "signal": "\"trip_distance (binned): \" + (!isValid(datum[\"bin_extent_0_12_maxbins_20_trip_distance\"]) || !isFinite(+datum[\"bin_extent_0_12_maxbins_20_trip_distance\"]) ? \"null\" : format(datum[\"bin_extent_0_12_maxbins_20_trip_distance\"], \"\") + \" – \" + format(datum[\"bin_extent_0_12_maxbins_20_trip_distance_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+              },
+              "x2": {
+                "scale": "concat_0_x",
+                "field": "bin_extent_0_12_maxbins_20_trip_distance",
+                "offset": 1
+              },
+              "x": {
+                "scale": "concat_0_x",
+                "field": "bin_extent_0_12_maxbins_20_trip_distance_end"
+              },
+              "y": {"scale": "concat_0_y", "field": "__count"},
+              "y2": {"scale": "concat_0_y", "value": 0}
+            }
+          }
+        },
+        {
+          "name": "selector014_brush",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {"fill": {"value": "transparent"}},
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "signal": "selector014_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "value": 0
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "signal": "selector014_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector014_store\").length && data(\"selector014_store\")[0].unit === \"concat_0\"",
+                  "field": {"group": "height"}
+                },
+                {"value": 0}
+              ],
+              "stroke": [
+                {
+                  "test": "selector014_x[0] !== selector014_x[1]",
+                  "value": "white"
+                },
+                {"value": null}
+              ]
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "concat_0_y",
+          "orient": "left",
+          "gridScale": "concat_0_x",
+          "grid": true,
+          "tickCount": {"signal": "ceil(height/40)"},
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "concat_0_x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "trip_distance (binned)",
+          "labelFlush": true,
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(concat_0_width/10)"},
+          "zindex": 0
+        },
+        {
+          "scale": "concat_0_y",
+          "orient": "left",
+          "grid": false,
+          "title": "Count of Records",
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(height/40)"},
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "concat_1_group",
+      "style": "cell",
+      "encode": {
+        "update": {
+          "width": {"signal": "concat_1_width"},
+          "height": {"signal": "height"}
+        }
+      },
+      "signals": [
+        {
+          "name": "pickup_scales_pickup_x",
+          "on": [
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "null"
+            },
+            {
+              "events": {"signal": "pickup_scales_translate_delta"},
+              "update": "panLinear(pickup_scales_translate_anchor.extent_x, -pickup_scales_translate_delta.x / concat_1_width)"
+            },
+            {
+              "events": {"signal": "pickup_scales_zoom_delta"},
+              "update": "zoomLinear(domain(\"concat_1_x\"), pickup_scales_zoom_anchor.x, pickup_scales_zoom_delta)"
+            }
+          ],
+          "push": "outer"
+        },
+        {
+          "name": "pickup_scales_pickup_y",
+          "on": [
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "null"
+            },
+            {
+              "events": {"signal": "pickup_scales_translate_delta"},
+              "update": "panLinear(pickup_scales_translate_anchor.extent_y, pickup_scales_translate_delta.y / height)"
+            },
+            {
+              "events": {"signal": "pickup_scales_zoom_delta"},
+              "update": "zoomLinear(domain(\"concat_1_y\"), pickup_scales_zoom_anchor.y, pickup_scales_zoom_delta)"
+            }
+          ],
+          "push": "outer"
+        },
+        {
+          "name": "pickup_scales_tuple",
+          "on": [
+            {
+              "events": [
+                {"signal": "pickup_scales_pickup_x || pickup_scales_pickup_y"}
+              ],
+              "update": "pickup_scales_pickup_x && pickup_scales_pickup_y ? {unit: \"concat_1\", fields: pickup_scales_tuple_fields, values: [pickup_scales_pickup_x,pickup_scales_pickup_y]} : null"
+            }
+          ]
+        },
+        {
+          "name": "pickup_scales_tuple_fields",
+          "value": [
+            {"field": "pickup_x", "channel": "x", "type": "R"},
+            {"field": "pickup_y", "channel": "y", "type": "R"}
+          ]
+        },
+        {
+          "name": "pickup_scales_translate_anchor",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "mousedown",
+                  "filter": ["event.altKey"]
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit), extent_x: domain(\"concat_1_x\"), extent_y: domain(\"concat_1_y\")}"
+            }
+          ]
+        },
+        {
+          "name": "pickup_scales_translate_delta",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "window",
+                  "type": "mousemove",
+                  "consume": true,
+                  "filter": ["event.altKey"],
+                  "between": [
+                    {
+                      "source": "scope",
+                      "type": "mousedown",
+                      "filter": ["event.altKey"]
+                    },
+                    {"source": "window", "type": "mouseup"}
+                  ]
+                }
+              ],
+              "update": "{x: pickup_scales_translate_anchor.x - x(unit), y: pickup_scales_translate_anchor.y - y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "pickup_scales_zoom_anchor",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "filter": ["event.altKey"]
+                }
+              ],
+              "update": "{x: invert(\"concat_1_x\", x(unit)), y: invert(\"concat_1_y\", y(unit))}"
+            }
+          ]
+        },
+        {
+          "name": "pickup_scales_zoom_delta",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "filter": ["event.altKey"]
+                }
+              ],
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        },
+        {
+          "name": "pickup_scales_modify",
+          "on": [
+            {
+              "events": {"signal": "pickup_scales_tuple"},
+              "update": "modify(\"pickup_scales_store\", pickup_scales_tuple, true)"
+            }
+          ]
+        },
+        {
+          "name": "selector013_x",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.altKey",
+                  "!event.item || event.item.mark.name !== \"selector013_brush\""
+                ]
+              },
+              "update": "[x(unit), x(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "mousemove",
+                "consume": true,
+                "filter": ["!event.altKey"],
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "mousedown",
+                    "filter": [
+                      "!event.altKey",
+                      "!event.item || event.item.mark.name !== \"selector013_brush\""
+                    ]
+                  },
+                  {"source": "window", "type": "mouseup"}
+                ]
+              },
+              "update": "[selector013_x[0], clamp(x(unit), 0, concat_1_width)]"
+            },
+            {
+              "events": {"signal": "selector013_scale_trigger"},
+              "update": "[scale(\"concat_1_x\", selector013_pickup_x[0]), scale(\"concat_1_x\", selector013_pickup_x[1])]"
+            },
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {"signal": "selector013_translate_delta"},
+              "update": "clampRange(panLinear(selector013_translate_anchor.extent_x, selector013_translate_delta.x / span(selector013_translate_anchor.extent_x)), 0, concat_1_width)"
+            },
+            {
+              "events": {"signal": "selector013_zoom_delta"},
+              "update": "clampRange(zoomLinear(selector013_x, selector013_zoom_anchor.x, selector013_zoom_delta), 0, concat_1_width)"
+            }
+          ]
+        },
+        {
+          "name": "selector013_pickup_x",
+          "on": [
+            {
+              "events": {"signal": "selector013_x"},
+              "update": "selector013_x[0] === selector013_x[1] ? null : invert(\"concat_1_x\", selector013_x)"
+            }
+          ]
+        },
+        {
+          "name": "selector013_y",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.altKey",
+                  "!event.item || event.item.mark.name !== \"selector013_brush\""
+                ]
+              },
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "mousemove",
+                "consume": true,
+                "filter": ["!event.altKey"],
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "mousedown",
+                    "filter": [
+                      "!event.altKey",
+                      "!event.item || event.item.mark.name !== \"selector013_brush\""
+                    ]
+                  },
+                  {"source": "window", "type": "mouseup"}
+                ]
+              },
+              "update": "[selector013_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": {"signal": "selector013_scale_trigger"},
+              "update": "[scale(\"concat_1_y\", selector013_pickup_y[0]), scale(\"concat_1_y\", selector013_pickup_y[1])]"
+            },
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {"signal": "selector013_translate_delta"},
+              "update": "clampRange(panLinear(selector013_translate_anchor.extent_y, selector013_translate_delta.y / span(selector013_translate_anchor.extent_y)), 0, height)"
+            },
+            {
+              "events": {"signal": "selector013_zoom_delta"},
+              "update": "clampRange(zoomLinear(selector013_y, selector013_zoom_anchor.y, selector013_zoom_delta), 0, height)"
+            }
+          ]
+        },
+        {
+          "name": "selector013_pickup_y",
+          "on": [
+            {
+              "events": {"signal": "selector013_y"},
+              "update": "selector013_y[0] === selector013_y[1] ? null : invert(\"concat_1_y\", selector013_y)"
+            }
+          ]
+        },
+        {
+          "name": "selector013_scale_trigger",
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_1_x"}, {"scale": "concat_1_y"}],
+              "update": "(!isArray(selector013_pickup_x) || (+invert(\"concat_1_x\", selector013_x)[0] === +selector013_pickup_x[0] && +invert(\"concat_1_x\", selector013_x)[1] === +selector013_pickup_x[1])) && (!isArray(selector013_pickup_y) || (+invert(\"concat_1_y\", selector013_y)[0] === +selector013_pickup_y[0] && +invert(\"concat_1_y\", selector013_y)[1] === +selector013_pickup_y[1])) ? selector013_scale_trigger : {}"
+            }
+          ]
+        },
+        {
+          "name": "selector013_tuple",
+          "on": [
+            {
+              "events": [
+                {"signal": "selector013_pickup_x || selector013_pickup_y"}
+              ],
+              "update": "selector013_pickup_x && selector013_pickup_y ? {unit: \"concat_1\", fields: selector013_tuple_fields, values: [selector013_pickup_x,selector013_pickup_y]} : null"
+            }
+          ]
+        },
+        {
+          "name": "selector013_tuple_fields",
+          "value": [
+            {"field": "pickup_x", "channel": "x", "type": "R"},
+            {"field": "pickup_y", "channel": "y", "type": "R"}
+          ]
+        },
+        {
+          "name": "selector013_translate_anchor",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "mousedown",
+                  "filter": ["!event.altKey"],
+                  "markname": "selector013_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit), extent_x: slice(selector013_x), extent_y: slice(selector013_y)}"
+            }
+          ]
+        },
+        {
+          "name": "selector013_translate_delta",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "window",
+                  "type": "mousemove",
+                  "consume": true,
+                  "filter": ["!event.altKey"],
+                  "between": [
+                    {
+                      "source": "scope",
+                      "type": "mousedown",
+                      "filter": ["!event.altKey"],
+                      "markname": "selector013_brush"
+                    },
+                    {"source": "window", "type": "mouseup"}
+                  ]
+                }
+              ],
+              "update": "{x: selector013_translate_anchor.x - x(unit), y: selector013_translate_anchor.y - y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector013_zoom_anchor",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "filter": ["!event.altKey"],
+                  "markname": "selector013_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector013_zoom_delta",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "filter": ["!event.altKey"],
+                  "markname": "selector013_brush"
+                }
+              ],
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        },
+        {
+          "name": "selector013_modify",
+          "on": [
+            {
+              "events": {"signal": "selector013_tuple"},
+              "update": "modify(\"selector013_store\", selector013_tuple, true)"
+            }
+          ]
+        }
+      ],
+      "marks": [
+        {
+          "name": "selector013_brush_bg",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {
+              "fill": {"value": "#333"},
+              "fillOpacity": {"value": 0.125}
+            },
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_y[0]"
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_y[1]"
+                },
+                {"value": 0}
+              ]
+            }
+          }
+        },
+        {
+          "name": "concat_1_marks",
+          "type": "rect",
+          "clip": true,
+          "style": ["rect"],
+          "interactive": true,
+          "from": {"data": "data_2"},
+          "encode": {
+            "update": {
+              "fill": {"scale": "concat_1_color", "field": "__count"},
+              "opacity": {"scale": "opacity", "field": "__count"},
+              "description": {
+                "signal": "\"pickup_x (binned): \" + (!isValid(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x\"]) || !isFinite(+datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x\"]) ? \"null\" : format(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x\"], \"\") + \" – \" + format(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_x_end\"], \"\")) + \"; pickup_y (binned): \" + (!isValid(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y\"]) || !isFinite(+datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y\"]) ? \"null\" : format(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y\"], \"\") + \" – \" + format(datum[\"bin_extent_param_pickup_scales_maxbins_50_pickup_y_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+              },
+              "x2": {
+                "scale": "concat_1_x",
+                "field": "bin_extent_param_pickup_scales_maxbins_50_pickup_x",
+                "offset": 0.5
+              },
+              "x": {
+                "scale": "concat_1_x",
+                "field": "bin_extent_param_pickup_scales_maxbins_50_pickup_x_end",
+                "offset": 0.5
+              },
+              "y2": {
+                "scale": "concat_1_y",
+                "field": "bin_extent_param_pickup_scales_maxbins_50_pickup_y",
+                "offset": 0.5
+              },
+              "y": {
+                "scale": "concat_1_y",
+                "field": "bin_extent_param_pickup_scales_maxbins_50_pickup_y_end",
+                "offset": 0.5
+              }
+            }
+          }
+        },
+        {
+          "name": "selector013_brush",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {"fill": {"value": "transparent"}},
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_y[0]"
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector013_store\").length && data(\"selector013_store\")[0].unit === \"concat_1\"",
+                  "signal": "selector013_y[1]"
+                },
+                {"value": 0}
+              ],
+              "stroke": [
+                {
+                  "test": "selector013_x[0] !== selector013_x[1] && selector013_y[0] !== selector013_y[1]",
+                  "value": "white"
+                },
+                {"value": null}
+              ]
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "concat_1_x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "pickup_x (binned)",
+          "labels": false,
+          "ticks": false,
+          "labelFlush": true,
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(concat_1_width/10)"},
+          "zindex": 1
+        },
+        {
+          "scale": "concat_1_y",
+          "orient": "left",
+          "grid": false,
+          "title": "pickup_y (binned)",
+          "labels": false,
+          "ticks": false,
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(height/10)"},
+          "zindex": 1
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "concat_2_group",
+      "style": "cell",
+      "encode": {
+        "update": {
+          "width": {"signal": "concat_2_width"},
+          "height": {"signal": "height"}
+        }
+      },
+      "signals": [
+        {
+          "name": "selector015_x",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"selector015_brush\""
+                ]
+              },
+              "update": "[x(unit), x(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "mousemove",
+                "consume": true,
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "mousedown",
+                    "filter": [
+                      "!event.item || event.item.mark.name !== \"selector015_brush\""
+                    ]
+                  },
+                  {"source": "window", "type": "mouseup"}
+                ]
+              },
+              "update": "[selector015_x[0], clamp(x(unit), 0, concat_2_width)]"
+            },
+            {
+              "events": {"signal": "selector015_scale_trigger"},
+              "update": "[0, 0]"
+            },
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {"signal": "selector015_translate_delta"},
+              "update": "clampRange(panLinear(selector015_translate_anchor.extent_x, selector015_translate_delta.x / span(selector015_translate_anchor.extent_x)), 0, concat_2_width)"
+            },
+            {
+              "events": {"signal": "selector015_zoom_delta"},
+              "update": "clampRange(zoomLinear(selector015_x, selector015_zoom_anchor.x, selector015_zoom_delta), 0, concat_2_width)"
+            }
+          ]
+        },
+        {
+          "name": "selector015_pickup_day",
+          "on": [
+            {
+              "events": {"signal": "selector015_x"},
+              "update": "selector015_x[0] === selector015_x[1] ? null : invert(\"concat_2_x\", selector015_x)"
+            }
+          ]
+        },
+        {
+          "name": "selector015_y",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "mousedown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"selector015_brush\""
+                ]
+              },
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "mousemove",
+                "consume": true,
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "mousedown",
+                    "filter": [
+                      "!event.item || event.item.mark.name !== \"selector015_brush\""
+                    ]
+                  },
+                  {"source": "window", "type": "mouseup"}
+                ]
+              },
+              "update": "[selector015_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": {"signal": "selector015_scale_trigger"},
+              "update": "[0, 0]"
+            },
+            {
+              "events": [{"source": "view", "type": "dblclick"}],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {"signal": "selector015_translate_delta"},
+              "update": "clampRange(panLinear(selector015_translate_anchor.extent_y, selector015_translate_delta.y / span(selector015_translate_anchor.extent_y)), 0, height)"
+            },
+            {
+              "events": {"signal": "selector015_zoom_delta"},
+              "update": "clampRange(zoomLinear(selector015_y, selector015_zoom_anchor.y, selector015_zoom_delta), 0, height)"
+            }
+          ]
+        },
+        {
+          "name": "selector015_pickup_hour",
+          "on": [
+            {
+              "events": {"signal": "selector015_y"},
+              "update": "selector015_y[0] === selector015_y[1] ? null : invert(\"concat_2_y\", selector015_y)"
+            }
+          ]
+        },
+        {
+          "name": "selector015_scale_trigger",
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_2_x"}, {"scale": "concat_2_y"}],
+              "update": "(!isArray(selector015_pickup_day) || (invert(\"concat_2_x\", selector015_x)[0] === selector015_pickup_day[0] && invert(\"concat_2_x\", selector015_x)[1] === selector015_pickup_day[1])) && (!isArray(selector015_pickup_hour) || (invert(\"concat_2_y\", selector015_y)[0] === selector015_pickup_hour[0] && invert(\"concat_2_y\", selector015_y)[1] === selector015_pickup_hour[1])) ? selector015_scale_trigger : {}"
+            }
+          ]
+        },
+        {
+          "name": "selector015_tuple",
+          "on": [
+            {
+              "events": [
+                {"signal": "selector015_pickup_day || selector015_pickup_hour"}
+              ],
+              "update": "selector015_pickup_day && selector015_pickup_hour ? {unit: \"concat_2\", fields: selector015_tuple_fields, values: [selector015_pickup_day,selector015_pickup_hour]} : null"
+            }
+          ]
+        },
+        {
+          "name": "selector015_tuple_fields",
+          "value": [
+            {"field": "pickup_day", "channel": "x", "type": "E"},
+            {"field": "pickup_hour", "channel": "y", "type": "E"}
+          ]
+        },
+        {
+          "name": "selector015_translate_anchor",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "mousedown",
+                  "markname": "selector015_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit), extent_x: slice(selector015_x), extent_y: slice(selector015_y)}"
+            }
+          ]
+        },
+        {
+          "name": "selector015_translate_delta",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "window",
+                  "type": "mousemove",
+                  "consume": true,
+                  "between": [
+                    {
+                      "source": "scope",
+                      "type": "mousedown",
+                      "markname": "selector015_brush"
+                    },
+                    {"source": "window", "type": "mouseup"}
+                  ]
+                }
+              ],
+              "update": "{x: selector015_translate_anchor.x - x(unit), y: selector015_translate_anchor.y - y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector015_zoom_anchor",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "markname": "selector015_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "selector015_zoom_delta",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "wheel",
+                  "consume": true,
+                  "markname": "selector015_brush"
+                }
+              ],
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        },
+        {
+          "name": "selector015_modify",
+          "on": [
+            {
+              "events": {"signal": "selector015_tuple"},
+              "update": "modify(\"selector015_store\", selector015_tuple, true)"
+            }
+          ]
+        }
+      ],
+      "marks": [
+        {
+          "name": "selector015_brush_bg",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {
+              "fill": {"value": "#333"},
+              "fillOpacity": {"value": 0.125}
+            },
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_y[0]"
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_y[1]"
+                },
+                {"value": 0}
+              ]
+            }
+          }
+        },
+        {
+          "name": "concat_2_marks",
+          "type": "rect",
+          "style": ["rect"],
+          "interactive": true,
+          "from": {"data": "data_3"},
+          "encode": {
+            "update": {
+              "fill": {"scale": "concat_2_color", "field": "mean_tip_perc"},
+              "opacity": [
+                {
+                  "test": "!length(data(\"selector015_store\")) || vlSelectionTest(\"selector015_store\", datum)",
+                  "value": 1
+                },
+                {"value": 0.3}
+              ],
+              "description": {
+                "signal": "\"pickup_day: \" + (isValid(datum[\"pickup_day\"]) ? datum[\"pickup_day\"] : \"\"+datum[\"pickup_day\"]) + \"; pickup_hour: \" + (isValid(datum[\"pickup_hour\"]) ? datum[\"pickup_hour\"] : \"\"+datum[\"pickup_hour\"]) + \"; Mean of tip_perc: \" + (format(datum[\"mean_tip_perc\"], \"\"))"
+              },
+              "x": {"scale": "concat_2_x", "field": "pickup_day"},
+              "width": {"signal": "max(0.25, bandwidth('concat_2_x'))"},
+              "y": {"scale": "concat_2_y", "field": "pickup_hour"},
+              "height": {"signal": "max(0.25, bandwidth('concat_2_y'))"}
+            }
+          }
+        },
+        {
+          "name": "selector015_brush",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {"fill": {"value": "transparent"}},
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_x[0]"
+                },
+                {"value": 0}
+              ],
+              "y": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_y[0]"
+                },
+                {"value": 0}
+              ],
+              "x2": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_x[1]"
+                },
+                {"value": 0}
+              ],
+              "y2": [
+                {
+                  "test": "data(\"selector015_store\").length && data(\"selector015_store\")[0].unit === \"concat_2\"",
+                  "signal": "selector015_y[1]"
+                },
+                {"value": 0}
+              ],
+              "stroke": [
+                {
+                  "test": "selector015_x[0] !== selector015_x[1] && selector015_y[0] !== selector015_y[1]",
+                  "value": "white"
+                },
+                {"value": null}
+              ]
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "concat_2_x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "pickup_day",
+          "labelAlign": "right",
+          "labelAngle": 270,
+          "labelBaseline": "middle",
+          "encode": {
+            "labels": {
+              "update": {
+                "text": {
+                  "signal": "datum.label==1 ? 'Mon': datum.label==0? 'Sun': ''"
+                }
+              }
+            }
+          },
+          "zindex": 1
+        },
+        {
+          "scale": "concat_2_y",
+          "orient": "left",
+          "grid": false,
+          "title": "pickup_hour",
+          "zindex": 1
+        }
+      ],
+      "legends": [
+        {
+          "title": "Tip Ratio",
+          "fill": "concat_2_color",
+          "gradientLength": {"signal": "clamp(height, 64, 200)"},
+          "encode": {"gradient": {"update": {"opacity": {"value": 1}}}}
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "opacity",
+      "type": "log",
+      "domain": {"data": "data_2", "field": "__count"},
+      "range": [0.5, 1]
+    },
+    {
+      "name": "concat_0_x",
+      "type": "linear",
+      "domain": {
+        "signal": "[concat_0_bin_extent_0_12_maxbins_20_trip_distance_bins.start, concat_0_bin_extent_0_12_maxbins_20_trip_distance_bins.stop]"
+      },
+      "range": [0, {"signal": "concat_0_width"}],
+      "bins": {
+        "signal": "concat_0_bin_extent_0_12_maxbins_20_trip_distance_bins"
+      },
+      "zero": false
+    },
+    {
+      "name": "concat_0_y",
+      "type": "linear",
+      "domain": {"data": "data_1", "field": "__count"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "concat_1_x",
+      "type": "linear",
+      "domain": [-8243204, -8226511],
+      "domainRaw": {"signal": "pickup_scales[\"pickup_x\"]"},
+      "range": [0, {"signal": "concat_1_width"}],
+      "bins": {
+        "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_x_bins"
+      },
+      "zero": false
+    },
+    {
+      "name": "concat_1_y",
+      "type": "linear",
+      "domain": [4968192, 4982886],
+      "domainRaw": {"signal": "pickup_scales[\"pickup_y\"]"},
+      "range": [{"signal": "height"}, 0],
+      "bins": {
+        "signal": "concat_1_bin_extent_param_pickup_scales_maxbins_50_pickup_y_bins"
+      },
+      "zero": false
+    },
+    {
+      "name": "concat_1_color",
+      "type": "log",
+      "domain": {"data": "data_2", "field": "__count"},
+      "range": {"scheme": "purpleblue"},
+      "reverse": false,
+      "interpolate": "hcl"
+    },
+    {
+      "name": "concat_2_x",
+      "type": "band",
+      "domain": [1, 2, 3, 4, 5, 6, 0],
+      "range": [0, {"signal": "concat_2_width"}],
+      "paddingInner": 0,
+      "paddingOuter": 0
+    },
+    {
+      "name": "concat_2_y",
+      "type": "band",
+      "domain": {"data": "data_3", "field": "pickup_hour", "sort": true},
+      "range": [0, {"signal": "height"}],
+      "paddingInner": 0,
+      "paddingOuter": 0
+    },
+    {
+      "name": "concat_2_color",
+      "type": "linear",
+      "domain": {"data": "data_3", "field": "mean_tip_perc"},
+      "range": "heatmap",
+      "interpolate": "hcl",
+      "zero": false
+    }
+  ]
+}

--- a/vegafusion-runtime/tests/test_expression_evaluation.rs
+++ b/vegafusion-runtime/tests/test_expression_evaluation.rs
@@ -549,3 +549,24 @@ mod test_indexof {
     #[test]
     fn test_marker() {} // Help IDE detect test module
 }
+
+
+mod test_span {
+    use crate::*;
+
+    #[rstest(
+        expr,
+        case("span([2, 3])"),
+        case("span([2, 3, 6])"),
+        case("span([3, 2])"),
+        case("span(null)"),
+        case("span([])"),
+        case("span(72)"),
+    )]
+    fn test(expr: &str) {
+        check_scalar_evaluation(expr, &config_a())
+    }
+
+    #[test]
+    fn test_marker() {} // Help IDE detect test module
+}

--- a/vegafusion-runtime/tests/test_expression_evaluation.rs
+++ b/vegafusion-runtime/tests/test_expression_evaluation.rs
@@ -550,7 +550,6 @@ mod test_indexof {
     fn test_marker() {} // Help IDE detect test module
 }
 
-
 mod test_span {
     use crate::*;
 
@@ -561,7 +560,7 @@ mod test_span {
         case("span([3, 2])"),
         case("span(null)"),
         case("span([])"),
-        case("span(72)"),
+        case("span(72)")
     )]
     fn test(expr: &str) {
         check_scalar_evaluation(expr, &config_a())

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -138,6 +138,8 @@ mod test_custom_specs {
         // Need to investigate why this test panics on Windows
         #[cfg(not(target_os = "windows"))]
         case("custom/pivot_crash", 0.001, false),
+
+        case("custom/taxi_dashboard", 0.001, true),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");
@@ -1429,19 +1431,19 @@ async fn check_spec_sequence(
 
     // println!("task_scope: {:#?}", task_scope);
 
-    // println!(
-    //     "client_spec: {}",
-    //     serde_json::to_string_pretty(&spec_plan.client_spec).unwrap()
-    // );
+    println!(
+        "client_spec: {}",
+        serde_json::to_string_pretty(&spec_plan.client_spec).unwrap()
+    );
     println!(
         "server_spec: {}",
         serde_json::to_string_pretty(&spec_plan.server_spec).unwrap()
     );
-    //
-    // println!(
-    //     "comm_plan:\n---\n{}\n---",
-    //     serde_json::to_string_pretty(&WatchPlan::from(spec_plan.comm_plan.clone())).unwrap()
-    // );
+
+    println!(
+        "comm_plan:\n---\n{}\n---",
+        serde_json::to_string_pretty(&WatchPlan::from(spec_plan.comm_plan.clone())).unwrap()
+    );
 
     // Build task graph
     let tasks = spec_plan

--- a/vegafusion-runtime/tests/util/vegajs_runtime/vegajsRuntime.js
+++ b/vegafusion-runtime/tests/util/vegajs_runtime/vegajsRuntime.js
@@ -44,10 +44,10 @@ function getWatchValues(view, watches) {
         let {namespace, name, scope} = watch;
         if (namespace === "signal") {
             let signalValue = lookupSignalOp(view, name, scope).value;
-            watch_values.push({watch: {namespace, name, scope}, value: _.clone(signalValue)});
+            watch_values.push({watch: {namespace, name, scope}, value: _.clone(signalValue) ?? null});
         } else if (namespace === "data") {
             let dataOp = lookupDataOp(view, name, scope);
-            watch_values.push({watch: {namespace, name, scope}, value: _.clone(dataOp.values.value)});
+            watch_values.push({watch: {namespace, name, scope}, value: _.clone(dataOp.values.value) ?? []});
         } else {
             throw `Invalid watch namespace: ${namespace}`
         }

--- a/vegafusion-wasm/js/vega_utils.js
+++ b/vegafusion-wasm/js/vega_utils.js
@@ -28,7 +28,7 @@ function getNestedRuntime(view, scope) {
 function lookupSignalOp(view, name, scope) {
     // name is an array that may have leading integer group indices
     let parent_runtime = getNestedRuntime(view, scope);
-    return parent_runtime.signals[name];
+    return parent_runtime.signals[name] ?? null;
 }
 
 function dataref(view, name, scope) {

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -223,7 +223,8 @@ impl MsgReceiver {
                         } else {
                             serde_json::from_str(
                                 &js_sys::JSON::stringify(&val).unwrap().as_string().unwrap(),
-                            ).unwrap()
+                            )
+                            .unwrap()
                         };
 
                         if verbose {

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -218,10 +218,14 @@ impl MsgReceiver {
             match scoped_var.0.namespace() {
                 VariableNamespace::Signal => {
                     let closure = Closure::wrap(Box::new(move |name: String, val: JsValue| {
-                        let val: serde_json::Value = serde_json::from_str(
-                            &js_sys::JSON::stringify(&val).unwrap().as_string().unwrap(),
-                        )
-                        .unwrap();
+                        let val: serde_json::Value = if val.is_undefined() {
+                            serde_json::Value::Null
+                        } else {
+                            serde_json::from_str(
+                                &js_sys::JSON::stringify(&val).unwrap().as_string().unwrap(),
+                            ).unwrap()
+                        };
+
                         if verbose {
                             log(&format!("VegaFusion(wasm): Sending signal {name}"));
                             log(&serde_json::to_string_pretty(&val).unwrap());


### PR DESCRIPTION
I'm working on a new version of the [NYC Taxi Dashboard](https://vegafusion.io/example_nyc_taxi.html) example.  To improve the experience of zooming in on the pickup location view, I want to bind the bin extent to the axis scale. e.g.

```python
pickup_chart = base.mark_rect().encode(
    x=alt.X(
        "pickup_x:Q",
        bin=alt.Bin(maxbins=width_bins, extent=scales),
        scale=alt.Scale(domain=x_domain),
    ),
    ...
)
```
This small change uncovered a whole slew of issues, mostly related to signals that have an initial state of `undefined`.

Here's a full example, based on the new DuckDB connection with an external DuckDB table:

```python
import duckdb
import vegafusion as vf
import altair as alt

# Create DuckDB connection and set as the acive VegaFusion connection
conn = duckdb.connect()
vf.runtime.set_connection(conn)

# Read parquet file
rel = conn.read_parquet("./nyc_taxi.parquet")

# Clean data and build view named "taxi"
rel.query("tbl", """
    select * from tbl where tip_amount < 100
""").to_view("taxi")

# Build data URL referncing the taxi DuckDB table
source = "table://taxi"

# Initial domain values for the pickup heatmap
x_domain = [-8.243204e+06, -8.226511e+06]
y_domain = [4.968192e+06, 4.982886e+06]

width_bins = 180
height_bins = 180

width = 400
height = 400

# Build chart
base = alt.Chart(source, width=width, height=height).transform_calculate(
    pickup_hour="utchours(datum.tpep_pickup_datetime)",
    pickup_day="day(datum.tpep_pickup_datetime)",
    tip_perc="datum.tip_amount",
).transform_filter(
    "datum.tip_perc < 100"
)

scales = alt.selection_interval(
    name="pickup_scales",
    bind='scales',
    # fields=["pickup_x", "pickup_y"],
    on="[mousedown[event.altKey], window:mouseup] > window:mousemove![event.altKey]",
    translate="[mousedown[event.altKey], window:mouseup] > window:mousemove![event.altKey]",
    zoom="wheel![event.altKey]"
)

pickup_selection = alt.selection_interval(
    on="[mousedown[!event.altKey], window:mouseup] > window:mousemove![!event.altKey]",
    translate="[mousedown[!event.altKey], window:mouseup] > window:mousemove![!event.altKey]",
    zoom="wheel![!event.altKey]",
)

distance_selection = alt.selection_interval(encodings=["x"])
day_hour_selection = alt.selection_interval()

# Distance
distance_chart = base.mark_bar().encode(
    x=alt.X("trip_distance:Q", bin=alt.Bin(maxbins=20, extent=[0, 12])),
    y="count()"
).add_selection(
    distance_selection
).transform_filter(
    {"and": [
        pickup_selection,
        day_hour_selection
    ]}
)

# Pickup
pickup_chart = base.mark_rect().encode(
    x=alt.X(
        "pickup_x:Q",
        bin=alt.Bin(maxbins=width_bins, extent=scales),
        scale=alt.Scale(domain=x_domain),
        axis=alt.Axis(labels=False, ticks=False)
    ),
    y=alt.Y(
        "pickup_y:Q",
        bin=alt.Bin(maxbins=height_bins, extent=scales),
        scale=alt.Scale(domain=y_domain),
        axis=alt.Axis(labels=False, ticks=False),
    ),
    opacity=alt.Opacity("count():Q", scale=alt.Scale(type="log", range=[0.5, 1.0]), legend=None),
    # color=alt.value("steelblue")
    color=alt.Color("count():Q", scale=alt.Scale(type="log", scheme="purpleblue", reverse=False), legend=None)
).add_selection(
    scales
).add_selection(
    pickup_selection
).transform_filter(
    {"and": [
        scales,
        distance_selection,
        day_hour_selection
    ]}
)

# Tip percentage
tip_perc_chart = base.mark_rect().encode(
    x=alt.X(
        "pickup_day:O", 
        scale=alt.Scale(domain=[1, 2, 3, 4, 5, 6, 0]),
        axis=alt.Axis(labelExpr="datum.label==1 ? 'Mon': datum.label==0? 'Sun': ''")
    ),
    y=alt.Y("pickup_hour:O"),
    color=alt.Color(
        'mean(tip_perc):Q', 
        scale=alt.Scale(type="linear"),
        legend=alt.Legend(title="Tip Ratio")
    ),
    opacity=alt.condition(day_hour_selection, alt.value(1.0), alt.value(0.3))
).properties(
    width=120
).add_selection(
    day_hour_selection
).transform_filter(
    {"and": [
        pickup_selection,
        distance_selection
    ]}
)

layout = (
    distance_chart 
    | pickup_chart 
    | tip_perc_chart
).resolve_scale(
    color="independent"
)

widget = vf.jupyter.VegaFusionWidget(
    layout, 
    debounce_max_wait=400,
    debounce_wait=200,
)
widget
```

https://user-images.githubusercontent.com/15064365/226116151-9ba18654-5a15-4e28-90f2-2f151578270b.mov

The parquet file is available from https://vegafusion-datasets.s3.amazonaws.com/datashader/nyc_taxi.parquet





