### PR TITLE
Fix 1.1.0rc4 hang in pre_transform_dataset

### DIFF
--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -280,7 +280,7 @@ class VegaFusionRuntime:
                     self._connection.unregister_temporary_tables()
 
             # Deserialize values to Arrow tables
-            datasets = [pa.ipc.deserialize_pandas(value) for value in values]
+            datasets = [value.to_pandas() for value in values]
 
             # Localize datetime columns to UTC
             for df in datasets:

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -226,14 +226,14 @@ impl PyVegaFusionRuntime {
         Python::with_gil(|py| -> PyResult<(PyObject, PyObject)> {
             let py_response_list = PyList::empty(py);
             for value in values {
-                let bytes: PyObject = if let TaskValue::Table(table) = value {
-                    PyBytes::new(py, table.to_ipc_bytes()?.as_slice()).into()
+                let pytable: PyObject = if let TaskValue::Table(table) = value {
+                    table.to_pyarrow(py)?
                 } else {
                     return Err(PyErr::from(VegaFusionError::internal(
                         "Unexpected value type",
                     )));
                 };
-                py_response_list.append(bytes)?;
+                py_response_list.append(pytable)?;
             }
 
             let py_warnings = pythonize::pythonize(py, &warnings)?;

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -2,7 +2,7 @@ pub mod connection;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyList};
 use std::collections::HashMap;
 use std::sync::{Arc, Once};
 use tokio::runtime::Runtime;
@@ -54,18 +54,14 @@ fn process_inline_datasets(
 ) -> PyResult<HashMap<String, VegaFusionDataset>> {
     if let Some(inline_datasets) = inline_datasets {
         Python::with_gil(|py| -> PyResult<_> {
-            let pyarrow_module = PyModule::import(py, "builtins")?;
-            let id_fun = pyarrow_module.getattr("id")?;
-
             inline_datasets
                 .iter()
                 .map(|(name, pyarrow_table)| {
-                    // Use object id of the pyarrow table as dataset's fingerprint
-                    let args = PyTuple::new(py, vec![pyarrow_table]);
-                    let id_object = id_fun.call(args, None)?;
-                    let id = id_object.extract::<u64>()?;
+                    // We convert to ipc bytes for two reasons:
+                    // - It allows VegaFusionDataset to compute an accurate hash of the table
+                    // - It works around https://github.com/hex-inc/vegafusion/issues/268
                     let table = VegaFusionTable::from_pyarrow(py, pyarrow_table)?;
-                    let dataset = VegaFusionDataset::Table { table, hash: id };
+                    let dataset = VegaFusionDataset::from_table_ipc_bytes(&table.to_ipc_bytes()?)?;
                     Ok((name.to_string(), dataset))
                 })
                 .collect::<PyResult<HashMap<_, _>>>()


### PR DESCRIPTION
Closes https://github.com/hex-inc/vegafusion/issues/268

This fixes / works around the hang reported in #268. I don't understand the full cause, but it's mitigated by copying the input Arrow table through the IPC format.  We lose zero copy, but it should still be an improvement over prior versions as the IPC clone is happening all in Rust. Also important, this approach allows us to compute an accurate hash for the input table (rather than using the Python `id` of the PyArrow table), so it improves cacheing.