### PR TITLE
Output polars/arrow from pre_transform_datasets/transformed_data

### DIFF
--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -1004,8 +1004,11 @@ def test_pre_transform_dataset_dataframe_interface_protocol():
     assert len(datasets) == 1
 
     result = datasets[0]
-    expected = pd.DataFrame({"menu_item": [0, 1, 2], "__count": [n, 2 * n, 3 * n]})
-    pd.testing.assert_frame_equal(result, expected)
+
+    # Result should be a polars DataFrame
+    assert isinstance(result, pl.DataFrame)
+    expected = pl.DataFrame({"menu_item": [0, 1, 2], "__count": [n, 2 * n, 3 * n]})
+    assert result.frame_equal(expected)
 
 
 def test_pre_transform_dataset_duckdb_conn():

--- a/vegafusion-common/src/data/json_writer.rs
+++ b/vegafusion-common/src/data/json_writer.rs
@@ -270,6 +270,9 @@ fn set_column_for_json_rows(
         DataType::Utf8 => {
             set_column_by_array_type!(as_string_array, col_name, rows, array, row_count);
         }
+        DataType::LargeUtf8 => {
+            set_column_by_array_type!(as_largestring_array, col_name, rows, array, row_count);
+        }
         DataType::Date32 => {
             // Write as integer UTC milliseconds
             let arr = array.as_any().downcast_ref::<Date32Array>().unwrap();


### PR DESCRIPTION
Updates `pre_transform_datasets` (and thereby `vf.transformed_data`) to output polars DataFrame(s) if:
 - There is at least one inline dataset
 - all of the inline datasets are polars DataFrames

This way a polars user can create a chart from a polars DataFrame and retrieve a polars DataFrame with `vf.transformed_data` all without any pandas conversions.