### PR TITLE
Expose WASM methods for getting and setting signal and data values

### DIFF
--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-embed",
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -39,7 +39,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",

--- a/python/vegafusion-jupyter/package-lock.json
+++ b/python/vegafusion-jupyter/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-jupyter",
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^4 || ^5 || ^6",
@@ -53,7 +53,7 @@
       }
     },
     "../../javascript/vegafusion-embed": {
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -86,7 +86,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -8118,7 +8118,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -9810,7 +9810,7 @@
         "node": ">=14"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -15155,7 +15155,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15173,7 +15173,7 @@
         "lib0": "^0.2.31"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15188,7 +15188,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -15206,7 +15206,7 @@
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "optionalDependencies": {
@@ -15290,7 +15290,7 @@
         "lib0": "^0.2.49"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -125,20 +125,36 @@ impl MsgReceiver {
         this
     }
 
-    pub fn get_signal_value(&self, name: &str, scope: &[u32]) -> JsValue {
+    pub fn get_signal(&self, name: &str, scope: &[u32]) -> JsValue {
         get_signal_value(self.view.as_ref(), name, scope)
     }
 
-    pub fn get_data_value(&self, name: &str, scope: &[u32]) -> JsValue {
+    pub fn get_data(&self, name: &str, scope: &[u32]) -> JsValue {
         get_data_value(self.view.as_ref(), name, scope)
     }
 
-    pub fn set_signal_value(&self, name: &str, scope: &[u32], value: JsValue) {
+    pub fn set_signal(&self, name: &str, scope: &[u32], value: JsValue) {
         set_signal_value(self.view.as_ref(), name, scope, value);
     }
 
-    pub fn set_data_value(&self, name: &str, scope: &[u32], value: JsValue) {
+    pub fn set_data(&self, name: &str, scope: &[u32], value: JsValue) {
         set_data_value(self.view.as_ref(), name, scope, value);
+    }
+
+    pub fn get_state(&self) -> JsValue {
+        self.view.get_state()
+    }
+
+    pub fn set_state(&self, state: JsValue) {
+        self.view.set_state(state)
+    }
+
+    pub fn run(&self) {
+        self.view.run()
+    }
+
+    pub fn run_async(&self) -> Promise {
+        self.view.run_async()
     }
 
     pub fn receive(&mut self, bytes: Vec<u8>) {
@@ -164,7 +180,7 @@ impl MsgReceiver {
                                 let js_value =
                                     js_sys::JSON::parse(&serde_json::to_string(&json).unwrap())
                                         .unwrap();
-                                self.set_signal_value(&var.name, scope.as_slice(), js_value);
+                                self.set_signal(&var.name, scope.as_slice(), js_value);
                             }
                             TaskValue::Table(value) => {
                                 let json = value.to_json().expect("Failed to serialize table");
@@ -177,7 +193,7 @@ impl MsgReceiver {
                                 let js_value =
                                     js_sys::JSON::parse(&serde_json::to_string(&json).unwrap())
                                         .unwrap();
-                                self.set_data_value(&var.name, scope.as_slice(), js_value);
+                                self.set_data(&var.name, scope.as_slice(), js_value);
                             }
                         }
                     }
@@ -502,8 +518,17 @@ extern "C" {
     #[wasm_bindgen(method, js_name = "run")]
     pub fn run(this: &View);
 
+    #[wasm_bindgen(method, js_name = "runAsync")]
+    pub fn run_async(this: &View) -> Promise;
+
     #[wasm_bindgen(method, js_name = "hover")]
     pub fn hover(this: &View);
+
+    #[wasm_bindgen(method, js_name = "getState")]
+    pub fn get_state(this: &View) -> JsValue;
+
+    #[wasm_bindgen(method, js_name = "setState")]
+    pub fn set_state(this: &View, state: JsValue);
 
     #[wasm_bindgen(method, js_name = "toImageURL")]
     pub fn to_image_url(this: &View, img_type: &str, scale_factor: f64) -> Promise;

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -125,6 +125,22 @@ impl MsgReceiver {
         this
     }
 
+    pub fn get_signal_value(&self, name: &str, scope: &[u32]) -> JsValue {
+        get_signal_value(self.view.as_ref(), name, scope)
+    }
+
+    pub fn get_data_value(&self, name: &str, scope: &[u32]) -> JsValue {
+        get_data_value(self.view.as_ref(), name, scope)
+    }
+
+    pub fn set_signal_value(&self, name: &str, scope: &[u32], value: JsValue) {
+        set_signal_value(self.view.as_ref(), name, scope, value);
+    }
+
+    pub fn set_data_value(&self, name: &str, scope: &[u32], value: JsValue) {
+        set_data_value(self.view.as_ref(), name, scope, value);
+    }
+
     pub fn receive(&mut self, bytes: Vec<u8>) {
         // Decode message
         let response = QueryResult::decode(bytes.as_slice()).unwrap();
@@ -132,7 +148,6 @@ impl MsgReceiver {
         if let Some(response) = response.response {
             match response {
                 query_result::Response::TaskGraphValues(task_graph_vals) => {
-                    let view = self.view();
                     for (var, scope, value) in task_graph_vals
                         .deserialize()
                         .expect("Failed to deserialize response")
@@ -149,7 +164,7 @@ impl MsgReceiver {
                                 let js_value =
                                     js_sys::JSON::parse(&serde_json::to_string(&json).unwrap())
                                         .unwrap();
-                                set_signal_value(view, &var.name, scope.as_slice(), js_value);
+                                self.set_signal_value(&var.name, scope.as_slice(), js_value);
                             }
                             TaskValue::Table(value) => {
                                 let json = value.to_json().expect("Failed to serialize table");
@@ -162,11 +177,11 @@ impl MsgReceiver {
                                 let js_value =
                                     js_sys::JSON::parse(&serde_json::to_string(&json).unwrap())
                                         .unwrap();
-
-                                set_data_value(view, &var.name, scope.as_slice(), js_value);
+                                self.set_data_value(&var.name, scope.as_slice(), js_value);
                             }
                         }
                     }
+                    let view = self.view();
                     view.run();
                 }
                 query_result::Response::Error(error) => {


### PR DESCRIPTION
Adds several public Vega View methods to the `MsgReceiver` WASM struct:

```
pub fn get_signal(&self, name: &str, scope: &[u32]) -> JsValue ;

pub fn get_data(&self, name: &str, scope: &[u32]) -> JsValue;

pub fn set_signal(&self, name: &str, scope: &[u32], value: JsValue);

pub fn set_data(&self, name: &str, scope: &[u32], value: JsValue);

pub fn get_state(&self) -> JsValue;

pub fn set_state(&self, state: JsValue);

pub fn run(&self);

pub fn run_async(&self) -> Promise;
```
These are to make it easier to introspect and manipulate the view from outside.
