### PR TITLE
Fix chart editor demo project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -469,13 +469,13 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.1"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -524,7 +524,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.1",
+ "itoa 1.0.6",
  "matchit",
  "memchr",
  "mime",
@@ -534,16 +534,15 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -800,7 +799,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1032,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1059,7 +1058,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1076,7 +1075,7 @@ checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1133,7 +1132,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util",
  "url",
  "uuid",
  "xz2",
@@ -1413,7 +1412,7 @@ checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1503,7 +1502,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1563,14 +1562,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1594,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1607,7 +1606,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1662,13 +1661,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.6",
 ]
 
 [[package]]
@@ -1708,9 +1707,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1721,7 +1720,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.6",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1853,9 +1852,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -1978,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libm"
@@ -2515,7 +2514,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2621,7 +2620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2633,7 +2632,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2656,9 +2655,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -2690,7 +2689,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.107",
  "tempfile",
  "which",
 ]
@@ -2705,7 +2704,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2773,7 +2772,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2784,7 +2783,7 @@ checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2799,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3030,7 +3029,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3055,7 +3054,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
  "unicode-ident",
 ]
 
@@ -3068,7 +3067,7 @@ dependencies = [
  "quote",
  "rand",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3189,7 +3188,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3199,7 +3198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "indexmap",
- "itoa 1.0.1",
+ "itoa 1.0.6",
  "ryu",
  "serde",
 ]
@@ -3220,7 +3219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.6",
  "ryu",
  "serde",
 ]
@@ -3273,7 +3272,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3284,9 +3283,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3316,7 +3315,7 @@ checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3347,7 +3346,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3361,6 +3360,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3426,7 +3436,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -3462,7 +3472,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3558,7 +3568,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3579,20 +3589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -3648,13 +3644,12 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+source = "git+https://github.com/hyperium/tonic.git?rev=b3358dc6acf11ec800571735de1e1f1e449ec96a#b3358dc6acf11ec800571735de1e1f1e449ec96a"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3666,17 +3661,14 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.7.4",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -3689,16 +3681,15 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "tonic-web"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9213351ad53b0dcf1c9cf7c372a47533446b1114928a9177bedc6c551e14b7cf"
+source = "git+https://github.com/hyperium/tonic.git?rev=b3358dc6acf11ec800571735de1e1f1e449ec96a#b3358dc6acf11ec800571735de1e1f1e449ec96a"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "http",
@@ -3726,7 +3717,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3734,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e980386f06883cf4d0578d6c9178c81f68b45d77d00f2c2c1bc034b3439c2c56"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3746,7 +3737,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3770,7 +3760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3784,7 +3773,7 @@ checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3794,16 +3783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -4058,6 +4037,7 @@ dependencies = [
  "assert_cmd",
  "clap 3.2.22",
  "futures-util",
+ "h2",
  "predicates",
  "prost",
  "prost-build",
@@ -4201,7 +4181,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -4235,7 +4215,7 @@ checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/javascript/vegafusion-chart-editor/index.js
+++ b/javascript/vegafusion-chart-editor/index.js
@@ -102,12 +102,11 @@ let flights_spec = {
     "$schema": "https://vega.github.io/schema/vega/v5.json",
     "background": "white",
     "padding": 5,
-    "width": 400,
     "data": [
         {"name": "brush_store"},
         {
             "name": "source_0",
-            "url": "https://raw.githubusercontent.com/vega/vega-datasets/master/data/flights-2k.json",
+            "url": "https://raw.githubusercontent.com/vega/vega-datasets/main/data/flights-2k.json",
             "format": {"type": "json", "parse": {"date": "date"}},
             "transform": [
                 {
@@ -139,7 +138,8 @@ let flights_spec = {
                         "signal": "child__column_distance_layer_0_bin_maxbins_20_distance_extent"
                     },
                     "maxbins": 20
-                }
+                },
+                {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
             ]
         },
         {
@@ -147,14 +147,73 @@ let flights_spec = {
             "source": "source_0",
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum, \"union\")"
+                    "type": "extent",
+                    "field": "time",
+                    "signal": "child__column_time_layer_1_bin_maxbins_20_time_extent"
+                },
+                {
+                    "type": "bin",
+                    "field": "time",
+                    "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "signal": "child__column_time_layer_1_bin_maxbins_20_time_bins",
+                    "extent": {
+                        "signal": "child__column_time_layer_1_bin_maxbins_20_time_extent"
+                    },
+                    "maxbins": 20
                 }
             ]
         },
         {
             "name": "data_1",
             "source": "data_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_time\"]) && isFinite(+datum[\"bin_maxbins_20_time\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_2",
+            "source": "data_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_time\"]) && isFinite(+datum[\"bin_maxbins_20_time\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_3",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)"
+                }
+            ]
+        },
+        {
+            "name": "data_4",
+            "source": "data_3",
             "transform": [
                 {
                     "type": "aggregate",
@@ -170,8 +229,8 @@ let flights_spec = {
             ]
         },
         {
-            "name": "data_2",
-            "source": "data_0",
+            "name": "data_5",
+            "source": "data_3",
             "transform": [
                 {
                     "type": "aggregate",
@@ -187,7 +246,7 @@ let flights_spec = {
             ]
         },
         {
-            "name": "data_3",
+            "name": "data_6",
             "source": "source_0",
             "transform": [
                 {
@@ -204,7 +263,7 @@ let flights_spec = {
             ]
         },
         {
-            "name": "data_4",
+            "name": "data_7",
             "source": "source_0",
             "transform": [
                 {
@@ -236,7 +295,7 @@ let flights_spec = {
             "update": "vlSelectionResolve(\"brush_store\", \"union\")"
         }
     ],
-    "layout": {"padding": 20, "columns": 2, "bounds": "full", "align": "all"},
+    "layout": {"padding": 20, "columns": 3, "bounds": "full", "align": "all"},
     "marks": [
         {
             "type": "group",
@@ -409,7 +468,7 @@ let flights_spec = {
                     "on": [
                         {
                             "events": {"signal": "brush_tuple"},
-                            "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__column_distance_layer_0\"})"
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
                         }
                     ]
                 }
@@ -425,10 +484,34 @@ let flights_spec = {
                             "fillOpacity": {"value": 0.125}
                         },
                         "update": {
-                            "x": {"signal": "brush_x[0]"},
-                            "y": {"value": 0},
-                            "x2": {"signal": "brush_x[1]"},
-                            "y2": {"field": {"group": "height"}}
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
                         }
                     }
                 },
@@ -437,7 +520,7 @@ let flights_spec = {
                     "type": "rect",
                     "style": ["bar"],
                     "interactive": true,
-                    "from": {"data": "data_3"},
+                    "from": {"data": "data_6"},
                     "encode": {
                         "update": {
                             "fill": {"value": "#ddd"},
@@ -445,27 +528,15 @@ let flights_spec = {
                             "description": {
                                 "signal": "\"distance (binned): \" + (!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"]) ? \"null\" : format(datum[\"bin_maxbins_20_distance\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_distance_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
                             },
-                            "x2": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_distance_x",
-                                    "field": "bin_maxbins_20_distance",
-                                    "offset": 1
-                                }
-                            ],
-                            "x": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_distance_x",
-                                    "field": "bin_maxbins_20_distance_end"
-                                }
-                            ],
+                            "x2": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance_end"
+                            },
                             "y": {"scale": "child__column_distance_y", "field": "__count"},
                             "y2": {"scale": "child__column_distance_y", "value": 0}
                         }
@@ -476,7 +547,7 @@ let flights_spec = {
                     "type": "rect",
                     "style": ["bar"],
                     "interactive": false,
-                    "from": {"data": "data_2"},
+                    "from": {"data": "data_5"},
                     "encode": {
                         "update": {
                             "fill": {"value": "#4c78a8"},
@@ -484,27 +555,15 @@ let flights_spec = {
                             "description": {
                                 "signal": "\"distance (binned): \" + (!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"]) ? \"null\" : format(datum[\"bin_maxbins_20_distance\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_distance_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
                             },
-                            "x2": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_distance_x",
-                                    "field": "bin_maxbins_20_distance",
-                                    "offset": 1
-                                }
-                            ],
-                            "x": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_distance_x",
-                                    "field": "bin_maxbins_20_distance_end"
-                                }
-                            ],
+                            "x2": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance_end"
+                            },
                             "y": {"scale": "child__column_distance_y", "field": "__count"},
                             "y2": {"scale": "child__column_distance_y", "value": 0}
                         }
@@ -517,10 +576,34 @@ let flights_spec = {
                     "encode": {
                         "enter": {"fill": {"value": "transparent"}},
                         "update": {
-                            "x": {"signal": "brush_x[0]"},
-                            "y": {"value": 0},
-                            "x2": {"signal": "brush_x[1]"},
-                            "y2": {"field": {"group": "height"}},
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
                             "stroke": [
                                 {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
                                 {"value": null}
@@ -736,7 +819,7 @@ let flights_spec = {
                     "on": [
                         {
                             "events": {"signal": "brush_tuple"},
-                            "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__column_delay_layer_0\"})"
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
                         }
                     ]
                 }
@@ -752,10 +835,34 @@ let flights_spec = {
                             "fillOpacity": {"value": 0.125}
                         },
                         "update": {
-                            "x": {"signal": "brush_x[0]"},
-                            "y": {"value": 0},
-                            "x2": {"signal": "brush_x[1]"},
-                            "y2": {"field": {"group": "height"}}
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
                         }
                     }
                 },
@@ -764,7 +871,7 @@ let flights_spec = {
                     "type": "rect",
                     "style": ["bar"],
                     "interactive": true,
-                    "from": {"data": "data_4"},
+                    "from": {"data": "data_7"},
                     "encode": {
                         "update": {
                             "fill": {"value": "#ddd"},
@@ -772,27 +879,15 @@ let flights_spec = {
                             "description": {
                                 "signal": "\"delay (binned): \" + (!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"]) ? \"null\" : format(datum[\"bin_maxbins_20_delay\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_delay_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
                             },
-                            "x2": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_delay_x",
-                                    "field": "bin_maxbins_20_delay",
-                                    "offset": 1
-                                }
-                            ],
-                            "x": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_delay_x",
-                                    "field": "bin_maxbins_20_delay_end"
-                                }
-                            ],
+                            "x2": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay_end"
+                            },
                             "y": {"scale": "child__column_delay_y", "field": "__count"},
                             "y2": {"scale": "child__column_delay_y", "value": 0}
                         }
@@ -803,7 +898,7 @@ let flights_spec = {
                     "type": "rect",
                     "style": ["bar"],
                     "interactive": false,
-                    "from": {"data": "data_1"},
+                    "from": {"data": "data_4"},
                     "encode": {
                         "update": {
                             "fill": {"value": "#4c78a8"},
@@ -811,27 +906,15 @@ let flights_spec = {
                             "description": {
                                 "signal": "\"delay (binned): \" + (!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"]) ? \"null\" : format(datum[\"bin_maxbins_20_delay\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_delay_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
                             },
-                            "x2": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_delay_x",
-                                    "field": "bin_maxbins_20_delay",
-                                    "offset": 1
-                                }
-                            ],
-                            "x": [
-                                {
-                                    "test": "!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"])",
-                                    "value": 0
-                                },
-                                {
-                                    "scale": "child__column_delay_x",
-                                    "field": "bin_maxbins_20_delay_end"
-                                }
-                            ],
+                            "x2": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay_end"
+                            },
                             "y": {"scale": "child__column_delay_y", "field": "__count"},
                             "y2": {"scale": "child__column_delay_y", "value": 0}
                         }
@@ -844,10 +927,34 @@ let flights_spec = {
                     "encode": {
                         "enter": {"fill": {"value": "transparent"}},
                         "update": {
-                            "x": {"signal": "brush_x[0]"},
-                            "y": {"value": 0},
-                            "x2": {"signal": "brush_x[1]"},
-                            "y2": {"field": {"group": "height"}},
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
                             "stroke": [
                                 {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
                                 {"value": null}
@@ -891,6 +998,357 @@ let flights_spec = {
                     "zindex": 0
                 }
             ]
+        },
+        {
+            "type": "group",
+            "name": "child__column_time_group",
+            "style": "cell",
+            "encode": {
+                "update": {
+                    "width": {"signal": "childWidth"},
+                    "height": {"signal": "childHeight"}
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {"source": "window", "type": "mouseup"}
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, childWidth)]"
+                        },
+                        {
+                            "events": {"signal": "brush_scale_trigger"},
+                            "update": "[scale(\"child__column_time_x\", brush_time[0]), scale(\"child__column_time_x\", brush_time[1])]"
+                        },
+                        {
+                            "events": [{"source": "view", "type": "dblclick"}],
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {"signal": "brush_translate_delta"},
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, childWidth)"
+                        },
+                        {
+                            "events": {"signal": "brush_zoom_delta"},
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, childWidth)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_time",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_x"},
+                            "update": "brush_x[0] === brush_x[1] ? null : invert(\"child__column_time_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [{"scale": "child__column_time_x"}],
+                            "update": "(!isArray(brush_time) || (+invert(\"child__column_time_x\", brush_x)[0] === +brush_time[0] && +invert(\"child__column_time_x\", brush_x)[1] === +brush_time[1])) ? brush_scale_trigger : {}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple",
+                    "on": [
+                        {
+                            "events": [{"signal": "brush_time"}],
+                            "update": "brush_time ? {unit: \"child__column_time_layer_0\", fields: brush_tuple_fields, values: [brush_time]} : null"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple_fields",
+                    "value": [{"field": "time", "channel": "x", "type": "R"}]
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {"source": "window", "type": "mouseup"}
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_tuple"},
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "name": "brush_brush_bg",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {
+                            "fill": {"value": "#333"},
+                            "fillOpacity": {"value": 0.125}
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_time_layer_0_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": true,
+                    "from": {"data": "data_2"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#ddd"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"time (binned): \" + (!isValid(datum[\"bin_maxbins_20_time\"]) || !isFinite(+datum[\"bin_maxbins_20_time\"]) ? \"null\" : format(datum[\"bin_maxbins_20_time\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_time_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time_end"
+                            },
+                            "y": {"scale": "child__column_time_y", "field": "__count"},
+                            "y2": {"scale": "child__column_time_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_time_layer_1_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": false,
+                    "from": {"data": "data_1"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#4c78a8"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"time (binned): \" + (!isValid(datum[\"bin_maxbins_20_time\"]) || !isFinite(+datum[\"bin_maxbins_20_time\"]) ? \"null\" : format(datum[\"bin_maxbins_20_time\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_time_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time_end"
+                            },
+                            "y": {"scale": "child__column_time_y", "field": "__count"},
+                            "y2": {"scale": "child__column_time_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {"fill": {"value": "transparent"}},
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
+                            "stroke": [
+                                {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
+                                {"value": null}
+                            ]
+                        }
+                    }
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "child__column_time_y",
+                    "orient": "left",
+                    "gridScale": "child__column_time_x",
+                    "grid": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "domain": false,
+                    "labels": false,
+                    "aria": false,
+                    "maxExtent": 0,
+                    "minExtent": 0,
+                    "ticks": false,
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_time_x",
+                    "orient": "bottom",
+                    "grid": false,
+                    "title": "time (binned)",
+                    "labelFlush": true,
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childWidth/10)"},
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_time_y",
+                    "orient": "left",
+                    "grid": false,
+                    "title": "Count of Records",
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "zindex": 0
+                }
+            ]
         }
     ],
     "scales": [
@@ -911,8 +1369,8 @@ let flights_spec = {
             "type": "linear",
             "domain": {
                 "fields": [
-                    {"data": "data_3", "field": "__count"},
-                    {"data": "data_2", "field": "__count"}
+                    {"data": "data_6", "field": "__count"},
+                    {"data": "data_5", "field": "__count"}
                 ]
             },
             "range": [{"signal": "childHeight"}, 0],
@@ -936,7 +1394,30 @@ let flights_spec = {
             "type": "linear",
             "domain": {
                 "fields": [
-                    {"data": "data_4", "field": "__count"},
+                    {"data": "data_7", "field": "__count"},
+                    {"data": "data_4", "field": "__count"}
+                ]
+            },
+            "range": [{"signal": "childHeight"}, 0],
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "child__column_time_x",
+            "type": "linear",
+            "domain": {
+                "signal": "[child__column_time_layer_1_bin_maxbins_20_time_bins.start, child__column_time_layer_1_bin_maxbins_20_time_bins.stop]"
+            },
+            "range": [0, {"signal": "childWidth"}],
+            "bins": {"signal": "child__column_time_layer_1_bin_maxbins_20_time_bins"},
+            "zero": false
+        },
+        {
+            "name": "child__column_time_y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {"data": "data_2", "field": "__count"},
                     {"data": "data_1", "field": "__count"}
                 ]
             },
@@ -944,107 +1425,6 @@ let flights_spec = {
             "nice": true,
             "zero": true
         }
-    ]
-}
-
-let weather_spec = {
-    "$schema": "https://vega.github.io/schema/vega/v5.json",
-    "background": "white",
-    "padding": 5,
-    "width": 20,
-    "height": 200,
-    "style": "cell",
-    "data": [
-        {
-            "name": "source_0",
-            // "url": "https://raw.githubusercontent.com/vega/vega-datasets/master/data/seattle-weather.csv",
-            "url": "/media/jmmease/SSD2/rustDev/diorite/datasets/vega-datasets-master/data/seattle-weather.csv",
-            "format": {"type": "csv", "delimiter": ","},
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "groupby": ["weather"],
-                    "ops": ["count"],
-                    "fields": [null],
-                    "as": ["__count"]
-                },
-                {
-                    "type": "stack",
-                    "groupby": [],
-                    "field": "__count",
-                    "sort": {"field": ["weather"], "order": ["descending"]},
-                    "as": ["__count_start", "__count_end"],
-                    "offset": "zero"
-                }
-            ]
-        }
-    ],
-    "marks": [
-        {
-            "name": "marks",
-            "type": "rect",
-            "style": ["bar"],
-            "from": {"data": "source_0"},
-            "encode": {
-                "update": {
-                    "fill": {"scale": "color", "field": "weather"},
-                    "ariaRoleDescription": {"value": "bar"},
-                    "description": {
-                        "signal": "\"Count of Records: \" + (format(datum[\"__count\"], \"\")) + \"; Weather type: \" + (isValid(datum[\"weather\"]) ? datum[\"weather\"] : \"\"+datum[\"weather\"])"
-                    },
-                    "xc": {"signal": "width", "mult": 0.5},
-                    "width": {"value": 18},
-                    "y": {"scale": "y", "field": "__count_end"},
-                    "y2": {"scale": "y", "field": "__count_start"}
-                }
-            }
-        }
-    ],
-    "scales": [
-        {
-            "name": "y",
-            "type": "linear",
-            "domain": {
-                "data": "source_0",
-                "fields": ["__count_start", "__count_end"]
-            },
-            "range": [{"signal": "height"}, 0],
-            "nice": true,
-            "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": ["sun", "fog", "drizzle", "rain", "snow"],
-            "range": ["#e7ba52", "#c7c7c7", "#aec7e8", "#1f77b4", "#9467bd"]
-        }
-    ],
-    "axes": [
-        {
-            "scale": "y",
-            "orient": "left",
-            "grid": true,
-            "tickCount": {"signal": "ceil(height/40)"},
-            "domain": false,
-            "labels": false,
-            "aria": false,
-            "maxExtent": 0,
-            "minExtent": 0,
-            "ticks": false,
-            "zindex": 0
-        },
-        {
-            "scale": "y",
-            "orient": "left",
-            "grid": false,
-            "title": "Count of Records",
-            "labelOverlap": true,
-            "tickCount": {"signal": "ceil(height/40)"},
-            "zindex": 0
-        }
-    ],
-    "legends": [
-        {"title": "Weather type", "fill": "color", "symbolType": "square"}
     ]
 }
 

--- a/javascript/vegafusion-chart-editor/package-lock.json
+++ b/javascript/vegafusion-chart-editor/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "create-wasm-app",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -39,7 +39,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -51,7 +51,7 @@
       }
     },
     "../vegafusion-embed": {
-      "version": "1.0.0-rc1",
+      "version": "1.1.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",

--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-embed",
-      "version": "1.1.0-rc4",
+      "version": "1.1.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -39,7 +39,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.1.0-rc4",
+      "version": "1.1.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",

--- a/javascript/vegafusion-embed/package.json
+++ b/javascript/vegafusion-embed/package.json
@@ -45,9 +45,9 @@
     "watch:lib": "tsc -w"
   },
   "dependencies": {
+    "grpc-web": "^1.3.1",
     "vega-lite": "^4.17.0",
-    "vegafusion-wasm": "../../vegafusion-wasm/pkg",
-    "grpc-web": "^1.3.1"
+    "vegafusion-wasm": "../../vegafusion-wasm/pkg"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -51,6 +51,8 @@ features = [ "derive",]
 [dependencies.tonic]
 version = "0.8.3"
 optional = true
+git = "https://github.com/hyperium/tonic.git"
+rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
 
 [build-dependencies.prost-build]
 version = "0.11.4"

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -16,7 +16,7 @@ protobuf-src = [ "vegafusion-core/protobuf-src",]
 prost = "0.11.3"
 futures-util = "0.3.21"
 regex = "^1.5.5"
-tonic-web = "0.5.0"
+h2 = "0.3.16"
 
 [dev-dependencies]
 serde_json = "1.0.91"
@@ -49,9 +49,16 @@ features = [ "datafusion-conn",]
 version = "1.18.1"
 features = [ "rt-multi-thread", "macros",]
 
+[dependencies.tonic-web]
+version = "0.5.0"
+git = "https://github.com/hyperium/tonic.git"
+rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
+
 [dependencies.tonic]
 version = "0.8.3"
 features = [ "tls",]
+git = "https://github.com/hyperium/tonic.git"
+rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
 
 [dependencies.clap]
 version = "3.2.22"

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -173,7 +173,7 @@ async fn grpc_server(
         let server = tonic_web::enable(server);
         Server::builder()
             .accept_http1(true)
-            .add_service(server.into_inner())
+            .add_service(server)
             .serve(addr)
             .await?;
     } else {

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -34,11 +34,9 @@ impl TonicVegaFusionRuntime for VegaFusionRuntimeGrpc {
         &self,
         request: Request<QueryRequest>,
     ) -> Result<Response<QueryResult>, Status> {
-        println!("grpc request...");
         let result = self.runtime.query_request(request.into_inner()).await;
         match result {
             Ok(result) => {
-                println!("  response");
                 Ok(Response::new(result))
             }
             Err(err) => Err(Status::unknown(err.to_string())),

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -36,9 +36,7 @@ impl TonicVegaFusionRuntime for VegaFusionRuntimeGrpc {
     ) -> Result<Response<QueryResult>, Status> {
         let result = self.runtime.query_request(request.into_inner()).await;
         match result {
-            Ok(result) => {
-                Ok(Response::new(result))
-            }
+            Ok(result) => Ok(Response::new(result)),
             Err(err) => Err(Status::unknown(err.to_string())),
         }
     }

--- a/vegafusion-wasm/Cargo.toml
+++ b/vegafusion-wasm/Cargo.toml
@@ -40,7 +40,7 @@ features = [ "derive",]
 version = "0.2.78"
 
 [dependencies.getrandom]
-version = "0.2.3"
+version = "0.2.8"
 features = [ "js",]
 
 [dependencies.chrono]


### PR DESCRIPTION
This PR fixes the chart editor demo in `javascript/vegafusion-chart-editor`

This is a simple example of a Vega chart editor that uses `vegafusion-embed` in the client to display the Vega chart, [perform planning](https://vegafusion.io/how_it_works.html#planner), and communicate with an instance of the [vegafusion-server](https://github.com/hex-inc/vegafusion/tree/main/vegafusion-server) over gRPC-Web.

I needed to update tonic-web to the latest git revision to fix a CORS issue. I also needed to update the `getrandom` crate to fix an annoying webpack warning.


https://user-images.githubusercontent.com/15064365/227393558-f6418de2-3633-46a6-b2e6-a9552964245f.mov

