### PR TITLE
Fix path to apple silicon build of vegafusion-server

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -139,9 +139,15 @@ jobs:
           dest: vegafusion-server-${{ matrix.options[1] }}.zip
       - name: zip executable (Mac or Linux)
         uses: papeloto/action-zip@v1
-        if: runner.os != 'Windows'
+        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
         with:
           files: target/release/vegafusion-server
+          dest: vegafusion-server-${{ matrix.options[1] }}.zip
+      - name: zip executable (Apple silicon)
+        uses: papeloto/action-zip@v1
+        if: ${{ matrix.options[1] == 'osx-arm64'}}
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
           dest: vegafusion-server-${{ matrix.options[1] }}.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Merged https://github.com/hex-inc/vegafusion/pull/277 too quickly.  The path of the apple silicon build is under a different release directory.