### PR TITLE
Add pre_transform_extract low-level API

### DIFF
--- a/vegafusion-core/src/planning/watch.rs
+++ b/vegafusion-core/src/planning/watch.rs
@@ -119,15 +119,34 @@ impl TryFrom<VariableNamespace> for ExportUpdateNamespace {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ExportUpdateArrow {
+    pub namespace: ExportUpdateNamespace,
+    pub name: String,
+    pub scope: Vec<u32>,
+    pub value: TaskValue,
+}
+
+impl ExportUpdateArrow {
+    pub fn to_json(&self) -> Result<ExportUpdateJSON> {
+        Ok(ExportUpdateJSON {
+            namespace: self.namespace.clone(),
+            name: self.name.clone(),
+            scope: self.scope.clone(),
+            value: self.value.to_json()?,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExportUpdate {
+pub struct ExportUpdateJSON {
     pub namespace: ExportUpdateNamespace,
     pub name: String,
     pub scope: Vec<u32>,
     pub value: Value,
 }
 
-impl ExportUpdate {
+impl ExportUpdateJSON {
     pub fn to_scoped_var(&self) -> ScopedVariable {
         let namespace = match self.namespace {
             ExportUpdateNamespace::Signal => VariableNamespace::Signal as i32,
@@ -155,4 +174,4 @@ impl ExportUpdate {
     }
 }
 
-pub type ExportUpdateBatch = Vec<ExportUpdate>;
+pub type ExportUpdateBatch = Vec<ExportUpdateJSON>;

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -83,3 +83,35 @@ message PreTransformInlineDataset {
 message PlannerWarning {
   string message = 1;
 }
+
+/// Pre Transform Extract Datasets
+message PreTransformExtractDataset {
+  // Result dataset name
+  string name = 1;
+
+  // Result dataset scope
+  repeated uint32 scope = 2;
+
+  // Serialized Arrow record batch in Arrow IPC format
+  bytes table = 3;
+}
+
+message PreTransformExtractWarning {
+  oneof warning_type {
+    PlannerWarning planner = 1;
+  }
+}
+
+message PreTransformExtractResponse {
+  string spec = 1;
+  repeated PreTransformExtractDataset datasets = 2;
+  repeated PreTransformExtractWarning warnings = 3;
+}
+
+message PreTransformExtractRequest {
+  string spec = 1;
+  string local_tz = 2;
+  optional string default_input_tz = 3;
+  bool preserve_interactivity = 4;
+  repeated PreTransformInlineDataset inline_datasets = 5;
+}

--- a/vegafusion-core/src/proto/prost_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/prost_gen/pretransform.rs
@@ -138,3 +138,56 @@ pub struct PlannerWarning {
     #[prost(string, tag = "1")]
     pub message: ::prost::alloc::string::String,
 }
+/// / Pre Transform Extract Datasets
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractDataset {
+    /// Result dataset name
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Result dataset scope
+    #[prost(uint32, repeated, tag = "2")]
+    pub scope: ::prost::alloc::vec::Vec<u32>,
+    /// Serialized Arrow record batch in Arrow IPC format
+    #[prost(bytes = "vec", tag = "3")]
+    pub table: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractWarning {
+    #[prost(oneof = "pre_transform_extract_warning::WarningType", tags = "1")]
+    pub warning_type: ::core::option::Option<pre_transform_extract_warning::WarningType>,
+}
+/// Nested message and enum types in `PreTransformExtractWarning`.
+pub mod pre_transform_extract_warning {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum WarningType {
+        #[prost(message, tag = "1")]
+        Planner(super::PlannerWarning),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractResponse {
+    #[prost(string, tag = "1")]
+    pub spec: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub datasets: ::prost::alloc::vec::Vec<PreTransformExtractDataset>,
+    #[prost(message, repeated, tag = "3")]
+    pub warnings: ::prost::alloc::vec::Vec<PreTransformExtractWarning>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractRequest {
+    #[prost(string, tag = "1")]
+    pub spec: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub local_tz: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "3")]
+    pub default_input_tz: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bool, tag = "4")]
+    pub preserve_interactivity: bool,
+    #[prost(message, repeated, tag = "5")]
+    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+}

--- a/vegafusion-core/src/proto/prost_gen/services.rs
+++ b/vegafusion-core/src/proto/prost_gen/services.rs
@@ -64,3 +64,20 @@ pub mod pre_transform_values_result {
         Response(super::super::pretransform::PreTransformValuesResponse),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractResult {
+    #[prost(oneof = "pre_transform_extract_result::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<pre_transform_extract_result::Result>,
+}
+/// Nested message and enum types in `PreTransformExtractResult`.
+pub mod pre_transform_extract_result {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Error(super::super::errors::Error),
+        #[prost(message, tag = "2")]
+        Response(super::super::pretransform::PreTransformExtractResponse),
+    }
+}

--- a/vegafusion-core/src/proto/services.proto
+++ b/vegafusion-core/src/proto/services.proto
@@ -9,6 +9,7 @@ service VegaFusionRuntime {
   rpc TaskGraphQuery(QueryRequest) returns (QueryResult) {}
   rpc PreTransformSpec(pretransform.PreTransformSpecRequest) returns (PreTransformSpecResult) {}
   rpc PreTransformValues(pretransform.PreTransformValuesRequest) returns (PreTransformValuesResult) {}
+  rpc PreTransformExtract(pretransform.PreTransformExtractRequest) returns (PreTransformExtractResult) {}
 }
 
 message QueryRequest {
@@ -35,5 +36,12 @@ message PreTransformValuesResult {
   oneof result {
     errors.Error error = 1;
     pretransform.PreTransformValuesResponse response = 2;
+  }
+}
+
+message PreTransformExtractResult {
+  oneof result {
+    errors.Error error = 1;
+    pretransform.PreTransformExtractResponse response = 2;
   }
 }

--- a/vegafusion-core/src/proto/tonic_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/tonic_gen/pretransform.rs
@@ -138,3 +138,56 @@ pub struct PlannerWarning {
     #[prost(string, tag = "1")]
     pub message: ::prost::alloc::string::String,
 }
+/// / Pre Transform Extract Datasets
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractDataset {
+    /// Result dataset name
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Result dataset scope
+    #[prost(uint32, repeated, tag = "2")]
+    pub scope: ::prost::alloc::vec::Vec<u32>,
+    /// Serialized Arrow record batch in Arrow IPC format
+    #[prost(bytes = "vec", tag = "3")]
+    pub table: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractWarning {
+    #[prost(oneof = "pre_transform_extract_warning::WarningType", tags = "1")]
+    pub warning_type: ::core::option::Option<pre_transform_extract_warning::WarningType>,
+}
+/// Nested message and enum types in `PreTransformExtractWarning`.
+pub mod pre_transform_extract_warning {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum WarningType {
+        #[prost(message, tag = "1")]
+        Planner(super::PlannerWarning),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractResponse {
+    #[prost(string, tag = "1")]
+    pub spec: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub datasets: ::prost::alloc::vec::Vec<PreTransformExtractDataset>,
+    #[prost(message, repeated, tag = "3")]
+    pub warnings: ::prost::alloc::vec::Vec<PreTransformExtractWarning>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractRequest {
+    #[prost(string, tag = "1")]
+    pub spec: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub local_tz: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "3")]
+    pub default_input_tz: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bool, tag = "4")]
+    pub preserve_interactivity: bool,
+    #[prost(message, repeated, tag = "5")]
+    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+}

--- a/vegafusion-core/src/proto/tonic_gen/services.rs
+++ b/vegafusion-core/src/proto/tonic_gen/services.rs
@@ -64,6 +64,23 @@ pub mod pre_transform_values_result {
         Response(super::super::pretransform::PreTransformValuesResponse),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PreTransformExtractResult {
+    #[prost(oneof = "pre_transform_extract_result::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<pre_transform_extract_result::Result>,
+}
+/// Nested message and enum types in `PreTransformExtractResult`.
+pub mod pre_transform_extract_result {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Error(super::super::errors::Error),
+        #[prost(message, tag = "2")]
+        Response(super::super::pretransform::PreTransformExtractResponse),
+    }
+}
 /// Generated client implementations.
 pub mod vega_fusion_runtime_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -194,6 +211,27 @@ pub mod vega_fusion_runtime_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn pre_transform_extract(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::super::pretransform::PreTransformExtractRequest,
+            >,
+        ) -> Result<tonic::Response<super::PreTransformExtractResult>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/services.VegaFusionRuntime/PreTransformExtract",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -217,6 +255,12 @@ pub mod vega_fusion_runtime_server {
                 super::super::pretransform::PreTransformValuesRequest,
             >,
         ) -> Result<tonic::Response<super::PreTransformValuesResult>, tonic::Status>;
+        async fn pre_transform_extract(
+            &self,
+            request: tonic::Request<
+                super::super::pretransform::PreTransformExtractRequest,
+            >,
+        ) -> Result<tonic::Response<super::PreTransformExtractResult>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct VegaFusionRuntimeServer<T: VegaFusionRuntime> {
@@ -392,6 +436,49 @@ pub mod vega_fusion_runtime_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = PreTransformValuesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/services.VegaFusionRuntime/PreTransformExtract" => {
+                    #[allow(non_camel_case_types)]
+                    struct PreTransformExtractSvc<T: VegaFusionRuntime>(pub Arc<T>);
+                    impl<
+                        T: VegaFusionRuntime,
+                    > tonic::server::UnaryService<
+                        super::super::pretransform::PreTransformExtractRequest,
+                    > for PreTransformExtractSvc<T> {
+                        type Response = super::PreTransformExtractResult;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::pretransform::PreTransformExtractRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).pre_transform_extract(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = PreTransformExtractSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -682,7 +682,7 @@ impl VegaFusionRuntime {
                         // Set inline value
                         data.values = Some(input_values);
                     } else if let TaskValue::Table(table) = export_update.value {
-                        if table.num_rows() < 100 {
+                        if table.num_rows() <= 20 {
                             // Inline small tables
                             data.values = Some(table.to_json()?);
                         } else {

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -14,23 +14,27 @@ use serde_json::Value;
 use std::convert::{TryFrom, TryInto};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
-use vegafusion_core::planning::watch::{ExportUpdate, ExportUpdateNamespace};
+use vegafusion_core::planning::watch::{ExportUpdateArrow, ExportUpdateNamespace};
 use vegafusion_core::proto::gen::errors::error::Errorkind;
 use vegafusion_core::proto::gen::errors::{Error, TaskGraphValueError};
 use vegafusion_core::proto::gen::pretransform::pre_transform_spec_warning::WarningType;
 use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType as ValuesWarningType;
 use vegafusion_core::proto::gen::pretransform::{
-    PlannerWarning, PreTransformSpecWarning, PreTransformValuesRequest, PreTransformValuesResponse,
-    PreTransformValuesWarning,
+    pre_transform_extract_warning, PlannerWarning,
+    PreTransformExtractDataset as ProtoPreTransformExtractDataset, PreTransformExtractRequest,
+    PreTransformExtractResponse, PreTransformExtractWarning, PreTransformSpecWarning,
+    PreTransformValuesRequest, PreTransformValuesResponse, PreTransformValuesWarning,
 };
 use vegafusion_core::proto::gen::pretransform::{
     PreTransformBrokenInteractivityWarning, PreTransformRowLimitWarning, PreTransformSpecRequest,
     PreTransformSpecResponse, PreTransformUnsupportedWarning,
 };
 use vegafusion_core::proto::gen::services::{
-    pre_transform_spec_result, pre_transform_values_result, query_request, query_result,
-    PreTransformSpecResult, PreTransformValuesResult, QueryRequest, QueryResult,
+    pre_transform_extract_result, pre_transform_spec_result, pre_transform_values_result,
+    query_request, query_result, PreTransformExtractResult, PreTransformSpecResult,
+    PreTransformValuesResult, QueryRequest, QueryResult,
 };
 use vegafusion_core::proto::gen::tasks::{
     task::TaskKind, NodeValueIndex, ResponseTaskValue, TaskGraph, TaskGraphValueResponse,
@@ -41,6 +45,7 @@ use vegafusion_core::task_graph::graph::ScopedVariable;
 use vegafusion_dataframe::connection::Connection;
 
 type CacheValue = (TaskValue, Vec<TaskValue>);
+type PreTransformExtractDataset = (String, Vec<u32>, VegaFusionTable);
 
 #[derive(Clone)]
 pub struct VegaFusionRuntime {
@@ -245,61 +250,15 @@ impl VegaFusionRuntime {
     ) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
         let input_spec = spec;
 
-        // Create spec plan
-        let plan = SpecPlan::try_new(
-            spec,
-            &PlannerConfig {
-                stringify_local_datetimes: true,
-                extract_inline_data: true,
-                allow_client_to_server_comms: !preserve_interactivity,
-                ..Default::default()
-            },
-        )?;
-        // println!("pre transform client_spec: {}", serde_json::to_string_pretty(&plan.client_spec).unwrap());
-        // println!("pre transform server_spec: {}", serde_json::to_string_pretty(&plan.server_spec).unwrap());
-        // println!("pre transform comm plan: {:#?}", plan.comm_plan);
-
-        // Extract inline dataset fingerprints
-        let dataset_fingerprints = inline_datasets
-            .iter()
-            .map(|(k, ds)| (k.clone(), ds.fingerprint()))
-            .collect::<HashMap<_, _>>();
-
-        // Create task graph for server spec
-        let tz_config = TzConfig {
-            local_tz: local_tz.to_string(),
-            default_input_tz: default_input_tz.clone(),
-        };
-        let task_scope = plan.server_spec.to_task_scope().unwrap();
-        let tasks = plan
-            .server_spec
-            .to_tasks(&tz_config, &dataset_fingerprints)
-            .unwrap();
-        let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
-        let task_graph_mapping = task_graph.build_mapping();
-
-        // Gather values of server-to-client values
-        let mut init = Vec::new();
-        for var in &plan.comm_plan.server_to_client {
-            let node_index = task_graph_mapping
-                .get(var)
-                .unwrap_or_else(|| panic!("Failed to lookup variable '{var:?}'"));
-            let value = self
-                .get_node_value(
-                    Arc::new(task_graph.clone()),
-                    node_index,
-                    inline_datasets.clone(),
-                )
-                .await
-                .expect("Failed to get node value");
-
-            init.push(ExportUpdate {
-                namespace: ExportUpdateNamespace::try_from(var.0.namespace()).unwrap(),
-                name: var.0.name.clone(),
-                scope: var.1.clone(),
-                value: value.to_json().unwrap(),
-            });
-        }
+        let (plan, init) = self
+            .perform_pre_transform_spec(
+                spec,
+                local_tz,
+                default_input_tz,
+                preserve_interactivity,
+                inline_datasets,
+            )
+            .await?;
 
         // Update client spec with server values
         let mut spec = plan.client_spec.clone();
@@ -307,6 +266,7 @@ impl VegaFusionRuntime {
         for export_update in init {
             let scope = export_update.scope.clone();
             let name = export_update.name.as_str();
+            let export_update = export_update.to_json()?;
             match export_update.namespace {
                 ExportUpdateNamespace::Signal => {
                     let signal = spec.get_nested_signal_mut(&scope, name)?;
@@ -603,6 +563,225 @@ impl VegaFusionRuntime {
         }
 
         Ok((values, warnings))
+    }
+
+    pub async fn pre_transform_extract_request(
+        &self,
+        request: PreTransformExtractRequest,
+    ) -> Result<PreTransformExtractResult> {
+        // Extract and deserialize inline datasets
+        let inline_pretransform_datasets = request.inline_datasets;
+
+        let inline_datasets = inline_pretransform_datasets
+            .iter()
+            .map(|inline_dataset| {
+                let dataset = VegaFusionDataset::from_table_ipc_bytes(&inline_dataset.table)?;
+                Ok((inline_dataset.name.clone(), dataset))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        // Parse spec
+        let spec_string = request.spec;
+        let spec: ChartSpec = serde_json::from_str(&spec_string)?;
+        let local_tz = request.local_tz;
+        let default_input_tz = request.default_input_tz;
+        let preserve_interactivity = request.preserve_interactivity;
+
+        let (spec, datasets, warnings) = self
+            .pre_transform_extract(
+                &spec,
+                &local_tz,
+                &default_input_tz,
+                preserve_interactivity,
+                inline_datasets,
+            )
+            .await?;
+
+        // Build Response
+        let proto_datasets = datasets
+            .into_iter()
+            .map(|(name, scope, table)| {
+                Ok(ProtoPreTransformExtractDataset {
+                    name,
+                    scope,
+                    table: table.to_ipc_bytes()?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let response = PreTransformExtractResponse {
+            spec: serde_json::to_string(&spec)?,
+            datasets: proto_datasets,
+            warnings,
+        };
+
+        // Build result
+        let result = PreTransformExtractResult {
+            result: Some(pre_transform_extract_result::Result::Response(response)),
+        };
+
+        Ok(result)
+    }
+
+    pub async fn pre_transform_extract(
+        &self,
+        spec: &ChartSpec,
+        local_tz: &str,
+        default_input_tz: &Option<String>,
+        preserve_interactivity: bool,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
+    ) -> Result<(
+        ChartSpec,
+        Vec<PreTransformExtractDataset>,
+        Vec<PreTransformExtractWarning>,
+    )> {
+        let input_spec = spec;
+
+        let (plan, init) = self
+            .perform_pre_transform_spec(
+                spec,
+                local_tz,
+                default_input_tz,
+                preserve_interactivity,
+                inline_datasets,
+            )
+            .await?;
+
+        // Update client spec with server values
+        let mut spec = plan.client_spec.clone();
+        let mut datasets: Vec<PreTransformExtractDataset> = Vec::new();
+
+        for export_update in init {
+            let scope = export_update.scope.clone();
+            let name = export_update.name.as_str();
+            match export_update.namespace {
+                ExportUpdateNamespace::Signal => {
+                    // Always inline signal values
+                    let signal = spec.get_nested_signal_mut(&scope, name)?;
+                    signal.value = Some(export_update.value.to_json()?);
+                }
+                ExportUpdateNamespace::Data => {
+                    let data = spec.get_nested_data_mut(&scope, name)?;
+
+                    // If the input dataset includes inline values and no transforms,
+                    // copy the input JSON directly to avoid the case where round-tripping
+                    // through Arrow homogenizes mixed type arrays.
+                    // E.g. round tripping may turn [1, "two"] into ["1", "two"]
+                    let input_values =
+                        input_spec
+                            .get_nested_data(&scope, name)
+                            .ok()
+                            .and_then(|data| {
+                                if data.transform.is_empty() {
+                                    data.values.clone()
+                                } else {
+                                    None
+                                }
+                            });
+                    if let Some(input_values) = input_values {
+                        // Set inline value
+                        data.values = Some(input_values);
+                    } else if let TaskValue::Table(table) = export_update.value {
+                        if table.num_rows() < 100 {
+                            // Inline small tables
+                            data.values = Some(table.to_json()?);
+                        } else {
+                            // Extract non-small tables
+                            datasets.push((export_update.name, export_update.scope, table));
+                        }
+                    } else {
+                        return Err(VegaFusionError::internal(
+                            "Expected Data TaskValue to be an Table",
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Destringify datetime strings in selection store datasets
+        destringify_selection_datetimes(&mut spec)?;
+
+        // Build warnings
+        let mut warnings: Vec<PreTransformExtractWarning> = Vec::new();
+
+        // Add planner warnings
+        for planner_warning in &plan.warnings {
+            warnings.push(PreTransformExtractWarning {
+                warning_type: Some(pre_transform_extract_warning::WarningType::Planner(
+                    PlannerWarning {
+                        message: planner_warning.message(),
+                    },
+                )),
+            });
+        }
+
+        Ok((spec, datasets, warnings))
+    }
+
+    async fn perform_pre_transform_spec(
+        &self,
+        spec: &ChartSpec,
+        local_tz: &str,
+        default_input_tz: &Option<String>,
+        preserve_interactivity: bool,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
+    ) -> Result<(SpecPlan, Vec<ExportUpdateArrow>)> {
+        // Create spec plan
+        let plan = SpecPlan::try_new(
+            spec,
+            &PlannerConfig {
+                stringify_local_datetimes: true,
+                extract_inline_data: true,
+                allow_client_to_server_comms: !preserve_interactivity,
+                ..Default::default()
+            },
+        )?;
+        // println!("pre transform client_spec: {}", serde_json::to_string_pretty(&plan.client_spec).unwrap());
+        // println!("pre transform server_spec: {}", serde_json::to_string_pretty(&plan.server_spec).unwrap());
+        // println!("pre transform comm plan: {:#?}", plan.comm_plan);
+
+        // Extract inline dataset fingerprints
+        let dataset_fingerprints = inline_datasets
+            .iter()
+            .map(|(k, ds)| (k.clone(), ds.fingerprint()))
+            .collect::<HashMap<_, _>>();
+
+        // Create task graph for server spec
+        let tz_config = TzConfig {
+            local_tz: local_tz.to_string(),
+            default_input_tz: default_input_tz.clone(),
+        };
+        let task_scope = plan.server_spec.to_task_scope().unwrap();
+        let tasks = plan
+            .server_spec
+            .to_tasks(&tz_config, &dataset_fingerprints)
+            .unwrap();
+        let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
+        let task_graph_mapping = task_graph.build_mapping();
+
+        // Gather values of server-to-client values
+        let mut init = Vec::new();
+        for var in &plan.comm_plan.server_to_client {
+            let node_index = task_graph_mapping
+                .get(var)
+                .unwrap_or_else(|| panic!("Failed to lookup variable '{var:?}'"));
+            let value = self
+                .get_node_value(
+                    Arc::new(task_graph.clone()),
+                    node_index,
+                    inline_datasets.clone(),
+                )
+                .await
+                .expect("Failed to get node value");
+
+            init.push(ExportUpdateArrow {
+                namespace: ExportUpdateNamespace::try_from(var.0.namespace()).unwrap(),
+                name: var.0.name.clone(),
+                scope: var.1.clone(),
+                value,
+            });
+        }
+        Ok((plan, init))
     }
 
     pub async fn clear_cache(&self) {

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -18,7 +18,7 @@ use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
 
 use vegafusion_core::planning::watch::{
-    ExportUpdate, ExportUpdateBatch, ExportUpdateNamespace, Watch, WatchNamespace, WatchPlan,
+    ExportUpdateBatch, ExportUpdateJSON, ExportUpdateNamespace, Watch, WatchNamespace, WatchPlan,
 };
 use vegafusion_core::proto::gen::pretransform::{PreTransformSpecOpts, PreTransformSpecRequest};
 use vegafusion_core::proto::gen::services::pre_transform_spec_result;
@@ -1481,7 +1481,7 @@ async fn check_spec_sequence(
             .await
             .expect("Failed to get node value");
 
-        init.push(ExportUpdate {
+        init.push(ExportUpdateJSON {
             namespace: ExportUpdateNamespace::try_from(var.0.namespace()).unwrap(),
             name: var.0.name.clone(),
             scope: var.1.clone(),
@@ -1567,7 +1567,7 @@ async fn check_spec_sequence(
                         TaskValue::Scalar(value) => value.to_json().unwrap(),
                         TaskValue::Table(value) => value.to_json().unwrap(),
                     };
-                    ExportUpdate {
+                    ExportUpdateJSON {
                         namespace: ExportUpdateNamespace::try_from(scoped_var.0.namespace())
                             .unwrap(),
                         name: scoped_var.0.name.clone(),

--- a/vegafusion-runtime/tests/test_pre_transform_extract.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_extract.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod tests {
+    use crate::crate_dir;
+    use serde_json::json;
+
+    use std::fs;
+    use std::sync::Arc;
+
+    use vegafusion_core::spec::chart::ChartSpec;
+
+    use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
+    use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
+
+    #[tokio::test]
+    async fn test_pre_transform_extract_scatter() {
+        // Load spec
+        let spec_path = format!(
+            "{}/tests/specs/vegalite/rect_binned_heatmap.vg.json",
+            crate_dir()
+        );
+        let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
+
+        // Initialize task graph runtime
+        let runtime = VegaFusionRuntime::new(
+            Arc::new(DataFusionConnection::default()),
+            Some(16),
+            Some(1024_i32.pow(3) as usize),
+        );
+
+        let (tx_spec, datasets, warnings) = runtime
+            .pre_transform_extract(&spec, "UTC", &None, true, Default::default())
+            .await
+            .unwrap();
+
+        // Check there are no warnings
+        assert!(warnings.is_empty());
+
+        // Check single extracted dataset
+        assert_eq!(datasets.len(), 1);
+        let dataset = datasets[0].clone();
+        assert_eq!(dataset.0.as_str(), "source_0");
+        assert_eq!(dataset.1, Vec::<u32>::new());
+        assert_eq!(dataset.2.num_rows(), 379);
+
+        // Check that source_0 is included as a stub in the transformed spec
+        let source_0 = &tx_spec.data[0];
+        assert_eq!(source_0.name.as_str(), "source_0");
+        assert_eq!(source_0.values, None);
+
+        // Check that source_0_color_domain___count was included inline (since it's small)
+        let source_0_color_domain_count = &tx_spec.data[1];
+        assert_eq!(
+            source_0_color_domain_count.name.as_str(),
+            "source_0_color_domain___count"
+        );
+        assert_eq!(
+            source_0_color_domain_count.values,
+            Some(json!([{"min": 1, "max": 24}]))
+        );
+    }
+}
+
+fn crate_dir() -> String {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .display()
+        .to_string()
+}

--- a/vegafusion-runtime/tests/test_vegajs_runtime.rs
+++ b/vegafusion-runtime/tests/test_vegajs_runtime.rs
@@ -12,7 +12,7 @@ use std::fs;
 use vegafusion_common::arrow::datatypes::{DataType, Field};
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::planning::watch::{
-    ExportUpdate, ExportUpdateBatch, ExportUpdateNamespace, Watch, WatchNamespace,
+    ExportUpdateBatch, ExportUpdateJSON, ExportUpdateNamespace, Watch, WatchNamespace,
 };
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::spec::transform::extent::ExtentTransformSpec;
@@ -184,26 +184,26 @@ fn try_export_sequence_helper_crossfilter() {
     let init = Vec::new();
     let updates: Vec<ExportUpdateBatch> = vec![
         vec![
-            ExportUpdate {
+            ExportUpdateJSON {
                 namespace: ExportUpdateNamespace::Signal,
                 name: "brush_x".to_string(),
                 scope: vec![0],
                 value: json!([70, 120]),
             },
-            ExportUpdate {
+            ExportUpdateJSON {
                 namespace: ExportUpdateNamespace::Signal,
                 name: "brush_x".to_string(),
                 scope: vec![1],
                 value: json!([40, 80]),
             },
         ],
-        vec![ExportUpdate {
+        vec![ExportUpdateJSON {
             namespace: ExportUpdateNamespace::Signal,
             name: "brush_x".to_string(),
             scope: vec![0],
             value: json!([0, 0]),
         }],
-        vec![ExportUpdate {
+        vec![ExportUpdateJSON {
             namespace: ExportUpdateNamespace::Signal,
             name: "brush_x".to_string(),
             scope: vec![1],

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -6,14 +6,15 @@ use vegafusion_core::proto::gen::services::vega_fusion_runtime_server::{
     VegaFusionRuntimeServer as TonicVegaFusionRuntimeServer,
 };
 use vegafusion_core::proto::gen::services::{
-    PreTransformSpecResult, PreTransformValuesResult, QueryRequest, QueryResult,
+    PreTransformExtractResult, PreTransformSpecResult, PreTransformValuesResult, QueryRequest,
+    QueryResult,
 };
 use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 
 use clap::Parser;
 use regex::Regex;
 use vegafusion_core::proto::gen::pretransform::{
-    PreTransformSpecRequest, PreTransformValuesRequest,
+    PreTransformExtractRequest, PreTransformSpecRequest, PreTransformValuesRequest,
 };
 use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 
@@ -62,6 +63,20 @@ impl TonicVegaFusionRuntime for VegaFusionRuntimeGrpc {
         let result = self
             .runtime
             .pre_transform_values_request(request.into_inner())
+            .await;
+        match result {
+            Ok(result) => Ok(Response::new(result)),
+            Err(err) => Err(Status::unknown(err.to_string())),
+        }
+    }
+
+    async fn pre_transform_extract(
+        &self,
+        request: Request<PreTransformExtractRequest>,
+    ) -> Result<Response<PreTransformExtractResult>, Status> {
+        let result = self
+            .runtime
+            .pre_transform_extract_request(request.into_inner())
             .await;
         match result {
             Ok(result) => Ok(Response::new(result)),


### PR DESCRIPTION
This PR adds a new low-level api (alongside `pre_transform_spec` and `pre_transform_dataset`) called `pre_transform_extract`.  

The `pre_transform_spec` function evaluates the transforms in an input spec and inlines the results into the resulting transformed JSON specification. This makes the resulting spec self-contained (able to be rendered directly by the Vega JavaScript library) , but for non-aggregated charts this can result in a really large JSON spec and cost a lot in terms of serialization.

The new `pre_transform_extract` function works like `pre_transform_spec`, but only datasets of under 21 rows are inlined into the resulting transformed JSON spec. Larger datasets are returned separately in arrow format.  Each extracted dataset is a tuple of `(name, scope, table)`.

The motivation for this function is to improve efficiency in rendering pipelines that are capable of transferring binary data from server to client separately from a JSON bundle. Two such systems I'm aware of are Panel and Streamlit. The client would then be responsible for inlining the extracted datasets prior to rendering with Vega. I haven't tested this yet, but it should be possible to serialize the pyarrow tables into arrow ipc format on the server and then deserialize them into the [arrow JavaScript library](https://arrow.apache.org/docs/js/) on the client and inline the arrow tables directly into the Vega spec.

API:
```python
(transformed, datasets, warnings) = vf.runtime.pre_transform_extract(spec, "UTC", inline_datasets=dict(...))
```



