### PR TITLE
Handle categorical columns with DuckDB connection

### DIFF
--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -131,8 +131,10 @@ def test_transformed_data_for_mock(mock_name, expected_len, expected_cols, conne
     assert len(df) == expected_len
 
 
-def test_gh_286():
+@pytest.mark.parametrize("connection", get_connections())
+def test_gh_286(connection):
     # https://github.com/hex-inc/vegafusion/issues/286
+    vf.runtime.set_connection(connection)
     source = pl.from_pandas(data.seattle_weather())
 
     chart = alt.Chart(source).mark_bar(

--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -146,3 +146,20 @@ def test_gh_286():
     transformed = vf.transformed_data(chart)
     assert isinstance(transformed, pl.DataFrame)
     assert len(transformed) == 53
+
+
+@pytest.mark.parametrize("connection", get_connections())
+def test_categorical_columns(connection):
+    vf.runtime.set_connection(connection)
+
+    df = pd.DataFrame({
+        "a": [0, 1, 2, 3, 4, 5],
+        "categorical": pd.Categorical.from_codes([0, 1, 0, 1, 1, 0], ["A", "BB"])
+    })
+
+    chart = alt.Chart(df).mark_bar().encode(
+        alt.X("categorical:N"), alt.Y("sum(a):Q")
+    )
+    transformed = vf.transformed_data(chart)
+    expected = pd.DataFrame({"categorical": ["A", "BB"], "sum_a": [7, 8]})
+    pd.testing.assert_frame_equal(transformed, expected)

--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -223,8 +223,9 @@ class DuckDbConnection(SqlConnection):
         if self._verbose:
             print(f"DuckDB Query:\n{query}\n")
         rel = self.conn.query(query)
-        replace_query = pyarrow_schema_to_select_replace(schema, "_tbl")
-        return rel.query("_tbl", replace_query).to_arrow_table(8096)
+        tmp_table = "_duckdb_tmp_tbl"
+        replace_query = pyarrow_schema_to_select_replace(schema, tmp_table)
+        return rel.query(tmp_table, replace_query).to_arrow_table(8096)
 
     def _update_temp_names(self, name: str, temporary: bool):
         if temporary:

--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -187,8 +187,9 @@ class DuckDbConnection(SqlConnection):
                 duckdb_type_name_to_pyarrow_type(type_name)
                 # Skip columns with supported types
             except ValueError:
-                # Convert unsupported types to strings
-                replaces.append(f"{quoted_col_name}::varchar as {quoted_col_name}")
+                # Convert unsupported types to strings (except struct)
+                if not type_name.startswith("STRUCT"):
+                    replaces.append(f"{quoted_col_name}::varchar as {quoted_col_name}")
 
         if replaces:
             replace_csv = ", ".join(replaces)

--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -48,8 +48,10 @@ def duckdb_type_name_to_pyarrow_type(duckdb_type: str) -> pa.DataType:
         return pa.bool_()
     elif duckdb_type == "DATE":
         return pa.date32()
-    elif duckdb_type == "TIMESTAMP":
+    elif duckdb_type in ("TIMESTAMP", "TIMESTAMP_MS"):
         return pa.timestamp("ms")
+    elif duckdb_type == "TIMESTAMP_NS":
+        return pa.timestamp("ns")
     elif duckdb_type == "TIMESTAMP WITH TIME ZONE":
         return pa.timestamp("ms", tz="UTC")
     else:

--- a/python/vegafusion/vegafusion/connection/duckdb.py
+++ b/python/vegafusion/vegafusion/connection/duckdb.py
@@ -3,7 +3,7 @@ import warnings
 
 from . import SqlConnection, CsvReadOptions
 
-from typing import Dict, Union
+from typing import Dict, Optional
 from distutils.version import LooseVersion
 
 import duckdb
@@ -70,7 +70,7 @@ def duckdb_relation_to_schema(rel: duckdb.DuckDBPyRelation) -> pa.Schema:
     return pa.schema(schema_fields)
 
 
-def pyarrow_type_to_duckdb_type_name(field_type: pa.Schema) -> str | None:
+def pyarrow_type_to_duckdb_type_name(field_type: pa.Schema) -> Optional[str]:
     if field_type in (pa.utf8(), pa.large_utf8()):
         return "VARCHAR"
     elif field_type in (pa.float16(), pa.float32()):


### PR DESCRIPTION
This PR updates the DuckDB connection to convert categorical columns to strings rather than ignoring them.  The new test in `python/vegafusion/tests/test_transformed_data.py` now works.

```python
@pytest.mark.parametrize("connection", get_connections())
def test_categorical_columns(connection):
    vf.runtime.set_connection(connection)

    df = pd.DataFrame({
        "a": [0, 1, 2, 3, 4, 5],
        "categorical": pd.Categorical.from_codes([0, 1, 0, 1, 1, 0], ["A", "BB"])
    })

    chart = alt.Chart(df).mark_bar().encode(
        alt.X("categorical:N"), alt.Y("sum(a):Q")
    )
    transformed = vf.transformed_data(chart)
    expected = pd.DataFrame({"categorical": ["A", "BB"], "sum_a": [7, 8]})
    pd.testing.assert_frame_equal(transformed, expected)
```
