### PR TITLE
Update tonic/tonic-web and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,10 +61,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -802,28 +836,46 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags 1.3.2",
+ "clap_lex 0.4.1",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -834,6 +886,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -854,6 +912,21 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -937,7 +1010,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.23",
  "criterion-plot",
  "futures",
  "itertools",
@@ -4012,6 +4085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,7 +4253,7 @@ name = "vegafusion-server"
 version = "1.2.0"
 dependencies = [
  "assert_cmd",
- "clap",
+ "clap 4.2.1",
  "futures-util",
  "h2",
  "predicates",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "const-random",
  "getrandom",
  "once_cell",
@@ -422,7 +422,7 @@ checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock",
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "concurrent-queue",
  "futures-lite",
  "log",
@@ -633,7 +633,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
  "digest",
 ]
@@ -753,12 +753,6 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -944,7 +938,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -997,7 +991,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1044,7 +1038,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -1054,7 +1048,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1066,7 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -1078,7 +1072,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1178,7 +1172,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1429,7 +1423,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1702,7 +1696,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1964,7 +1958,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2220,7 +2214,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "value-bag",
 ]
 
@@ -2293,12 +2287,6 @@ checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "mime"
@@ -2525,7 +2513,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -2539,7 +2527,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
@@ -2722,7 +2710,7 @@ checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "concurrent-queue",
  "libc",
  "log",
@@ -2885,7 +2873,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -3197,7 +3185,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3403,7 +3391,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3580,7 +3568,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
@@ -3617,7 +3605,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d10394d5d1e27794f772b6fc854c7e91a2dc26e2cbf807ad523370c2a59c0cee"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3958,7 +3946,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3996,7 +3984,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "static_assertions",
 ]
 
@@ -4308,7 +4296,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "wee_alloc",
 ]
 
 [[package]]
@@ -4370,7 +4357,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -4395,7 +4382,7 @@ version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4496,18 +4483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,9 +1825,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -3021,13 +3021,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3193,12 +3193,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3682,9 +3704,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3748,8 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
-source = "git+https://github.com/hyperium/tonic.git?rev=b3358dc6acf11ec800571735de1e1f1e449ec96a#b3358dc6acf11ec800571735de1e1f1e449ec96a"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bd8e87955eb13c1986671838177d6792cdc52af9bffced0d2c8a9a7f741ab3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3768,7 +3801,7 @@ dependencies = [
  "prost",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3791,8 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.5.0"
-source = "git+https://github.com/hyperium/tonic.git?rev=b3358dc6acf11ec800571735de1e1f1e449ec96a#b3358dc6acf11ec800571735de1e1f1e449ec96a"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea5a992300fc324dd8c529868ec7b07ac85510431f982e6f716c2cac56701d9"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,19 +1434,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -4183,7 +4170,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "deterministic-hash",
- "env_logger 0.9.3",
+ "env_logger",
  "log",
  "pyo3",
  "pythonize",
@@ -4215,7 +4202,7 @@ dependencies = [
  "datafusion-physical-expr",
  "deterministic-hash",
  "dssim",
- "env_logger 0.10.0",
+ "env_logger",
  "float-cmp",
  "futures",
  "futures-util",

--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-embed",
-      "version": "1.1.0-rc5",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -39,7 +39,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.1.0-rc5",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -1580,9 +1580,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -1603,17 +1604,19 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -1664,8 +1667,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "peer": true
     },
     "node_modules/@types/fast-json-stable-stringify": {
@@ -1675,15 +1679,22 @@
         "fast-json-stable-stringify": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "peer": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2221,8 +2232,9 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/call-bind": {
@@ -2323,9 +2335,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT",
-      "peer": true
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2430,8 +2446,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.2.1",
-      "license": "ISC",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
@@ -2442,15 +2459,17 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "peer": true,
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "license": "ISC",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "peer": true,
       "dependencies": {
         "delaunator": "5"
@@ -2461,7 +2480,8 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2469,7 +2489,8 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "peer": true,
       "dependencies": {
         "commander": "7",
@@ -2491,17 +2512,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/d3-force": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -2514,7 +2528,8 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2522,7 +2537,8 @@
     },
     "node_modules/d3-geo": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -2533,7 +2549,8 @@
     },
     "node_modules/d3-geo-projection": {
       "version": "4.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
       "peer": true,
       "dependencies": {
         "commander": "7",
@@ -2551,17 +2568,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-geo-projection/node_modules/commander": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2569,7 +2579,8 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
@@ -2580,7 +2591,8 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2588,7 +2600,8 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2596,7 +2609,8 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -2611,7 +2625,8 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
@@ -2622,7 +2637,8 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
@@ -2633,7 +2649,8 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
@@ -2644,7 +2661,8 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2684,7 +2702,8 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
       "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.0"
@@ -2802,9 +2821,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.9.3",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+      "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/es-to-primitive": {
@@ -3374,8 +3394,9 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true
     },
     "node_modules/globals": {
@@ -3554,7 +3575,8 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -3769,6 +3791,47 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -3801,6 +3864,13 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3943,8 +4013,9 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/micromatch": {
@@ -4040,8 +4111,9 @@
       "license": "MIT"
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -4056,25 +4128,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -4496,8 +4549,9 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -4672,12 +4726,14 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.1",
-      "license": "Unlicense",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
       "peer": true
     },
     "node_modules/rw": {
       "version": "1.3.3",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "peer": true
     },
     "node_modules/safe-buffer": {
@@ -4731,9 +4787,10 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -4876,8 +4933,9 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -4886,8 +4944,9 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5136,17 +5195,19 @@
     },
     "node_modules/tapable": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/terser": {
-      "version": "5.16.1",
+      "version": "5.16.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -5162,16 +5223,17 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.1",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^5.7.2"
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -5195,57 +5257,11 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.7.0",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -5253,6 +5269,13 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -5280,7 +5303,8 @@
     },
     "node_modules/topojson-client": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "peer": true,
       "dependencies": {
         "commander": "2"
@@ -5290,6 +5314,18 @@
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
       }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "peer": true
     },
     "node_modules/ts-loader": {
       "version": "8.3.0",
@@ -5516,158 +5552,171 @@
       }
     },
     "node_modules/vega": {
-      "version": "5.22.1",
-      "license": "BSD-3-Clause",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "peer": true,
       "dependencies": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.6",
-      "license": "BSD-3-Clause",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "peer": true
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.0",
-      "license": "BSD-3-Clause",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.4",
-      "license": "BSD-3-Clause",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "peer": true,
       "dependencies": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.9.0",
-      "license": "BSD-3-Clause",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.0",
-      "license": "BSD-3-Clause",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
       "peer": true
     },
     "node_modules/vega-expression": {
-      "version": "5.0.0",
-      "license": "BSD-3-Clause",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "peer": true,
       "dependencies": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.1.0",
-      "license": "BSD-3-Clause",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "peer": true,
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.13.0",
-      "license": "BSD-3-Clause",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.0",
-      "license": "BSD-3-Clause",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.0",
-      "license": "BSD-3-Clause",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "peer": true,
       "dependencies": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "peer": true,
       "dependencies": {
         "vega-canvas": "^1.2.6",
@@ -5797,182 +5846,214 @@
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.0",
-      "license": "BSD-3-Clause",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "peer": true,
       "dependencies": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.1.4",
-      "license": "BSD-3-Clause",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "peer": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.5.0",
-      "license": "BSD-3-Clause",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "peer": true,
       "dependencies": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.1.3",
-      "license": "BSD-3-Clause",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "peer": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.2.0",
-      "license": "BSD-3-Clause",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.10.1",
-      "license": "BSD-3-Clause",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "peer": true,
       "dependencies": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-selections": {
-      "version": "5.3.1",
-      "license": "BSD-3-Clause",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "peer": true,
       "dependencies": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections/node_modules/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+      "peer": true,
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.8.0",
-      "license": "BSD-3-Clause",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1"
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.0",
-      "license": "BSD-3-Clause",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.10.0",
-      "license": "BSD-3-Clause",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-typings": {
-      "version": "0.22.2",
-      "license": "BSD-3-Clause",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "peer": true,
       "dependencies": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.0",
-      "license": "BSD-3-Clause",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ==",
       "peer": true
     },
     "node_modules/vega-view": {
-      "version": "5.11.0",
-      "license": "BSD-3-Clause",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "peer": true,
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.5.8",
-      "license": "BSD-3-Clause",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "peer": true,
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.0",
-      "license": "BSD-3-Clause",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "peer": true,
       "dependencies": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.3",
-      "license": "BSD-3-Clause",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "peer": true,
       "dependencies": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vegafusion-wasm": {
@@ -5980,9 +6061,10 @@
       "link": true
     },
     "node_modules/watchpack": {
-      "version": "2.3.1",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -5992,35 +6074,42 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "peer": true
+    },
     "node_modules/webpack": {
-      "version": "5.70.0",
+      "version": "5.79.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.79.0.tgz",
+      "integrity": "sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/estree": "^1.0.0",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
-        "es-module-lexer": "^0.9.0",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.9",
-        "json-parse-better-errors": "^1.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "terser-webpack-plugin": "^5.3.7",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -6048,16 +6137,11 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/@types/estree": {
-      "version": "0.0.51",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.7.0",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -6076,9 +6160,10 @@
       }
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.9.2",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -6092,6 +6177,16 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7079,7 +7174,9 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7094,11 +7191,15 @@
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
       "peer": true
     },
     "@jridgewell/source-map": {
-      "version": "0.3.2",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7144,7 +7245,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.50",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "peer": true
     },
     "@types/fast-json-stable-stringify": {
@@ -7153,12 +7256,20 @@
         "fast-json-stable-stringify": "*"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "peer": true
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true,
       "peer": true
     },
@@ -7515,6 +7626,8 @@
     },
     "buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "peer": true
     },
@@ -7577,7 +7690,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.20.3",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "peer": true
     },
     "concat-map": {
@@ -7646,7 +7761,9 @@
       "dev": true
     },
     "d3-array": {
-      "version": "3.2.1",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "peer": true,
       "requires": {
         "internmap": "1 - 2"
@@ -7654,10 +7771,14 @@
     },
     "d3-color": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "peer": true
     },
     "d3-delaunay": {
-      "version": "6.0.2",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "peer": true,
       "requires": {
         "delaunator": "5"
@@ -7665,25 +7786,25 @@
     },
     "d3-dispatch": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "peer": true
     },
     "d3-dsv": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "peer": true,
       "requires": {
         "commander": "7",
         "iconv-lite": "0.6",
         "rw": "1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "peer": true
-        }
       }
     },
     "d3-force": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "peer": true,
       "requires": {
         "d3-dispatch": "1 - 3",
@@ -7693,10 +7814,14 @@
     },
     "d3-format": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "peer": true
     },
     "d3-geo": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "peer": true,
       "requires": {
         "d3-array": "2.5.0 - 3"
@@ -7704,25 +7829,25 @@
     },
     "d3-geo-projection": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
       "peer": true,
       "requires": {
         "commander": "7",
         "d3-array": "1 - 3",
         "d3-geo": "1.12.0 - 3"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "peer": true
-        }
       }
     },
     "d3-hierarchy": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "peer": true
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "peer": true,
       "requires": {
         "d3-color": "1 - 3"
@@ -7730,14 +7855,20 @@
     },
     "d3-path": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "peer": true
     },
     "d3-quadtree": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "peer": true
     },
     "d3-scale": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "peer": true,
       "requires": {
         "d3-array": "2.10.0 - 3",
@@ -7749,6 +7880,8 @@
     },
     "d3-shape": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "peer": true,
       "requires": {
         "d3-path": "^3.1.0"
@@ -7756,6 +7889,8 @@
     },
     "d3-time": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "peer": true,
       "requires": {
         "d3-array": "2 - 3"
@@ -7763,6 +7898,8 @@
     },
     "d3-time-format": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "peer": true,
       "requires": {
         "d3-time": "1 - 3"
@@ -7770,6 +7907,8 @@
     },
     "d3-timer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "peer": true
     },
     "debug": {
@@ -7792,6 +7931,8 @@
     },
     "delaunator": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
       "peer": true,
       "requires": {
         "robust-predicates": "^3.0.0"
@@ -7878,7 +8019,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+      "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
       "dev": true,
       "peer": true
     },
@@ -8225,6 +8368,8 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "peer": true
     },
@@ -8334,6 +8479,8 @@
     },
     "internmap": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "peer": true
     },
     "is-arrayish": {
@@ -8450,6 +8597,37 @@
       "version": "2.0.0",
       "dev": true
     },
+    "jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "dev": true
@@ -8469,6 +8647,13 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "peer": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -8567,6 +8752,8 @@
     },
     "merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "peer": true
     },
@@ -8631,28 +8818,12 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "peer": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "peer": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "peer": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
       }
     },
     "node-releases": {
@@ -8906,6 +9077,8 @@
     },
     "randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -9025,10 +9198,14 @@
     },
     "robust-predicates": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
       "peer": true
     },
     "rw": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "peer": true
     },
     "safe-buffer": {
@@ -9061,7 +9238,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -9153,6 +9332,8 @@
     },
     "source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -9162,6 +9343,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "peer": true
         }
@@ -9331,11 +9514,15 @@
     },
     "tapable": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
       "peer": true
     },
     "terser": {
-      "version": "5.16.1",
+      "version": "5.16.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -9346,52 +9533,33 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+          "dev": true,
+          "peer": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "peer": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.1",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
       "dev": true,
       "peer": true,
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^5.7.2"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true,
-          "peer": true
-        },
-        "jest-worker": {
-          "version": "27.5.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "dev": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
       }
     },
     "text-table": {
@@ -9411,10 +9579,26 @@
     },
     "topojson-client": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "peer": true,
       "requires": {
         "commander": "2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "peer": true
+        }
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "peer": true
     },
     "ts-loader": {
       "version": "8.3.0",
@@ -9553,145 +9737,171 @@
       }
     },
     "vega": {
-      "version": "5.22.1",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "peer": true,
       "requires": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "vega-canvas": {
-      "version": "1.2.6",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
       "peer": true
     },
     "vega-crossfilter": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-dataflow": {
-      "version": "5.7.4",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "peer": true,
       "requires": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-encode": {
-      "version": "4.9.0",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-event-selector": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
       "peer": true
     },
     "vega-expression": {
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "peer": true,
       "requires": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-force": {
-      "version": "4.1.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "peer": true,
       "requires": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-format": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-functions": {
-      "version": "5.13.0",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-geo": {
-      "version": "4.4.0",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-hierarchy": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "peer": true,
       "requires": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-label": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "peer": true,
       "requires": {
         "vega-canvas": "^1.2.6",
@@ -9781,165 +9991,213 @@
       }
     },
     "vega-loader": {
-      "version": "4.5.0",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "peer": true,
       "requires": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-parser": {
-      "version": "6.1.4",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "peer": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-projection": {
-      "version": "1.5.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "peer": true,
       "requires": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "vega-regression": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "vega-runtime": {
-      "version": "6.1.3",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "peer": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scale": {
-      "version": "7.2.0",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scenegraph": {
-      "version": "4.10.1",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "peer": true,
       "requires": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-selections": {
-      "version": "5.3.1",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "peer": true,
       "requires": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+          "peer": true,
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        }
       }
     },
     "vega-statistics": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1"
+        "d3-array": "^3.2.2"
       }
     },
     "vega-time": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-transforms": {
-      "version": "4.10.0",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-typings": {
-      "version": "0.22.2",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "peer": true,
       "requires": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-util": {
-      "version": "1.17.0",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ==",
       "peer": true
     },
     "vega-view": {
-      "version": "5.11.0",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "peer": true,
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-view-transforms": {
-      "version": "4.5.8",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "peer": true,
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-voronoi": {
-      "version": "4.2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "peer": true,
       "requires": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-wordcloud": {
-      "version": "4.1.3",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "peer": true,
       "requires": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vegafusion-wasm": {
@@ -9954,7 +10212,9 @@
       }
     },
     "watchpack": {
-      "version": "2.3.1",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -9962,44 +10222,49 @@
         "graceful-fs": "^4.1.2"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "peer": true
+    },
     "webpack": {
-      "version": "5.70.0",
+      "version": "5.79.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.79.0.tgz",
+      "integrity": "sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==",
       "dev": true,
       "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/estree": "^1.0.0",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
-        "es-module-lexer": "^0.9.0",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.9",
-        "json-parse-better-errors": "^1.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "terser-webpack-plugin": "^5.3.7",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {
-        "@types/estree": {
-          "version": "0.0.51",
-          "dev": true,
-          "peer": true
-        },
         "acorn": {
-          "version": "8.7.0",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
           "dev": true,
           "peer": true
         },
@@ -10010,7 +10275,9 @@
           "requires": {}
         },
         "enhanced-resolve": {
-          "version": "5.9.2",
+          "version": "5.12.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+          "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -10028,6 +10295,16 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "peer": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@babel/core": "^7.5.0",
         "@babel/preset-env": "^7.5.0",
+        "@types/node": "17.0.21",
         "@typescript-eslint/eslint-plugin": "^3.6.0",
         "@typescript-eslint/parser": "^3.6.0",
         "acorn": "^7.2.0",
@@ -1691,11 +1692,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true,
-      "peer": true
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
@@ -7267,11 +7267,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true,
-      "peer": true
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",

--- a/javascript/vegafusion-embed/package.json
+++ b/javascript/vegafusion-embed/package.json
@@ -50,6 +50,7 @@
     "vegafusion-wasm": "../../vegafusion-wasm/pkg"
   },
   "devDependencies": {
+    "@types/node": "17.0.21",
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^3.6.0",

--- a/python/vegafusion-jupyter/package-lock.json
+++ b/python/vegafusion-jupyter/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-jupyter",
-      "version": "1.1.0-rc4",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^4 || ^5 || ^6",
@@ -53,7 +53,7 @@
       }
     },
     "../../javascript/vegafusion-embed": {
-      "version": "1.1.0-rc4",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -86,7 +86,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.1.0-rc4",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -8118,7 +8118,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -9810,7 +9810,7 @@
         "node": ">=14"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -15155,7 +15155,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15173,7 +15173,7 @@
         "lib0": "^0.2.31"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15188,7 +15188,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -15206,7 +15206,7 @@
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "optionalDependencies": {
@@ -15290,7 +15290,7 @@
         "lib0": "^0.2.49"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -49,10 +49,8 @@ version = "1.0.137"
 features = [ "derive",]
 
 [dependencies.tonic]
-version = "0.8.3"
+version = "0.9.1"
 optional = true
-git = "https://github.com/hyperium/tonic.git"
-rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
 
 [build-dependencies.prost-build]
 version = "0.11.4"

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -14,7 +14,7 @@ protobuf-src = [ "vegafusion-core/protobuf-src",]
 
 [dependencies]
 log = "0.4.17"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 pythonize = "0.18.0"
 async-trait = "0.1.53"
 uuid = "1.3.0"

--- a/vegafusion-runtime/tests/util/vegajs_runtime/package-lock.json
+++ b/vegafusion-runtime/tests/util/vegajs_runtime/package-lock.json
@@ -45,9 +45,14 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -137,9 +142,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -206,156 +214,209 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "dependencies": {
-        "internmap": "^1.0.0"
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-delaunay": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
-      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dependencies": {
-        "delaunator": "4"
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-dispatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
-      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-dsv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
-      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
+        "commander": "7",
+        "iconv-lite": "0.6",
         "rw": "1"
       },
       "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-force": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
-      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "dependencies": {
-        "d3-dispatch": "1 - 2",
-        "d3-quadtree": "1 - 2",
-        "d3-timer": "1 - 2"
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-geo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
-      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "dependencies": {
-        "d3-array": "^2.5.0"
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-geo-projection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
-      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
       "dependencies": {
-        "commander": "2",
-        "d3-array": "1 - 2",
-        "d3-geo": "1.12.0 - 2",
-        "resolve": "^1.1.10"
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
       },
       "bin": {
-        "geo2svg": "bin/geo2svg",
-        "geograticule": "bin/geograticule",
-        "geoproject": "bin/geoproject",
-        "geoquantize": "bin/geoquantize",
-        "geostitch": "bin/geostitch"
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-hierarchy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
-      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dependencies": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-quadtree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
-      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-shape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dependencies": {
-        "d3-path": "1 - 2"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": {
-        "d3-array": "2"
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dependencies": {
-        "d3-time": "1 - 2"
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-timer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -385,9 +446,12 @@
       }
     },
     "node_modules/delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -485,11 +549,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "node_modules/gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -524,17 +583,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -553,11 +601,11 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -578,19 +626,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-    },
-    "node_modules/is-core-module": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -664,9 +704,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -709,9 +749,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -818,11 +858,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -842,18 +877,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -868,10 +891,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -1001,14 +1029,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/tar": {
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -1038,6 +1058,11 @@
         "topoquantize": "bin/topoquantize"
       }
     },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -1049,343 +1074,357 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/vega": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.21.0.tgz",
-      "integrity": "sha512-yqqRa9nAqYoAxe7sVhRpsh0b001fly7Yx05klPkXmrvzjxXd07gClW1mOuGgSnVQqo7jTp/LYgbO1bD37FbEig==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "dependencies": {
-        "vega-crossfilter": "~4.0.5",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.8.3",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.0.7",
-        "vega-format": "~1.0.4",
-        "vega-functions": "~5.12.1",
-        "vega-geo": "~4.3.8",
-        "vega-hierarchy": "~4.0.9",
-        "vega-label": "~1.1.0",
-        "vega-loader": "~4.4.1",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.4.5",
-        "vega-regression": "~1.0.9",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.1.1",
-        "vega-scenegraph": "~4.9.4",
-        "vega-statistics": "~1.7.10",
-        "vega-time": "~2.0.4",
-        "vega-transforms": "~4.9.4",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.10.1",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.1.5",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
-      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "dependencies": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
-      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-interpolate": "^2.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "node_modules/vega-expression": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
-      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "dependencies": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
-      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "dependencies": {
-        "d3-force": "^2.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
-      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-format": "^2.0.0",
-        "d3-time-format": "^3.0.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
-      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-color": "^2.0.0",
-        "d3-geo": "^2.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.1.1",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.8.tgz",
-      "integrity": "sha512-fsGxV96Q/QRgPqOPtMBZdI+DneIiROKTG3YDZvGn0EdV16OG5LzFhbNgLT5GPzI+kTwgLpAsucBHklexlB4kfg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-color": "^2.0.0",
-        "d3-geo": "^2.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
-      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "dependencies": {
-        "d3-hierarchy": "^2.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.1.0.tgz",
-      "integrity": "sha512-LAThIiDEsZxYvbSkvPLJ93eJF+Ts8RXv1IpBh8gmew8XGmaLJvVkzdsMe7WJJwuaVEsK7ZZFyB/Inkp842GW6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "dependencies": {
-        "vega-canvas": "^1.2.5",
+        "vega-canvas": "^1.2.6",
         "vega-dataflow": "^5.7.3",
         "vega-scenegraph": "^4.9.2",
         "vega-util": "^1.15.2"
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
-      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "dependencies": {
-        "d3-dsv": "^2.0.0",
-        "node-fetch": "^2.6.1",
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.0.4",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
-      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "dependencies": {
-        "d3-geo": "^2.0.1",
-        "d3-geo-projection": "^3.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
-      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "dependencies": {
-        "d3-array": "^2.7.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
-      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-interpolate": "^2.0.1",
-        "d3-scale": "^3.2.2",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz",
-      "integrity": "sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "dependencies": {
-        "d3-path": "^2.0.0",
-        "d3-shape": "^2.0.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.3.3",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-selections": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
-      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "dependencies": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections/node_modules/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
-      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "dependencies": {
-        "d3-array": "^2.7.1"
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
-      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-time": "^2.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.4.tgz",
-      "integrity": "sha512-JGBhm5Bf6fiGTUSB5Qr5ckw/KU9FJcSV5xIe/y4IobM/i/KNwI1i1fP45LzP4F4yZc0DMTwJod2UvFHGk9plKA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-typings": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.0.tgz",
-      "integrity": "sha512-TgBGRkZHQgcduGsoFKq3Scpn6eNY4L3p0YKRhgCPVU3HEaCeYkPFGaR8ynK+XrKmvrqpDv0YHIOwCt7Gn3RpCA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "dependencies": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
     },
     "node_modules/vega-view": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.10.1.tgz",
-      "integrity": "sha512-4xvQ5KZcgKdZx1Z7jjenCUumvlyr/j4XcHLRf9gyeFrFvvS596dVpL92V8twhV6O++DmS2+fj+rHagO8Di4nMg==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "dependencies": {
-        "d3-array": "^2.7.1",
-        "d3-timer": "^2.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.0.4",
-        "vega-functions": "^5.10.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.9.4",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
-      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "dependencies": {
-        "d3-delaunay": "^5.3.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "dependencies": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/webidl-conversions": {
@@ -1444,9 +1483,14 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1520,9 +1564,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1574,138 +1618,137 @@
       }
     },
     "d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "requires": {
-        "internmap": "^1.0.0"
+        "internmap": "1 - 2"
       }
     },
     "d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-delaunay": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
-      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "requires": {
-        "delaunator": "4"
+        "delaunator": "5"
       }
     },
     "d3-dispatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
-      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
     },
     "d3-dsv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
-      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "requires": {
-        "commander": "2",
-        "iconv-lite": "0.4",
+        "commander": "7",
+        "iconv-lite": "0.6",
         "rw": "1"
       }
     },
     "d3-force": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
-      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "requires": {
-        "d3-dispatch": "1 - 2",
-        "d3-quadtree": "1 - 2",
-        "d3-timer": "1 - 2"
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
       }
     },
     "d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-geo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
-      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "requires": {
-        "d3-array": "^2.5.0"
+        "d3-array": "2.5.0 - 3"
       }
     },
     "d3-geo-projection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
-      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
       "requires": {
-        "commander": "2",
-        "d3-array": "1 - 2",
-        "d3-geo": "1.12.0 - 2",
-        "resolve": "^1.1.10"
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
       }
     },
     "d3-hierarchy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
-      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
     },
     "d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "requires": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3"
       }
     },
     "d3-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
     },
     "d3-quadtree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
-      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
     },
     "d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "requires": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
       }
     },
     "d3-shape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "requires": {
-        "d3-path": "1 - 2"
+        "d3-path": "^3.1.0"
       }
     },
     "d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "requires": {
-        "d3-array": "2"
+        "d3-array": "2 - 3"
       }
     },
     "d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "requires": {
-        "d3-time": "1 - 2"
+        "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
-      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
     },
     "debug": {
       "version": "4.3.2",
@@ -1724,9 +1767,12 @@
       }
     },
     "delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "requires": {
+        "robust-predicates": "^3.0.0"
+      }
     },
     "delegates": {
       "version": "1.0.0",
@@ -1794,11 +1840,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -1827,14 +1868,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1850,11 +1883,11 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "inflight": {
@@ -1872,17 +1905,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-    },
-    "is-core-module": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
-      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
-      "requires": {
-        "has": "^1.0.3"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -1936,9 +1961,9 @@
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1966,9 +1991,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -2043,11 +2068,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2067,15 +2087,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      }
-    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2084,10 +2095,15 @@
         "glob": "^7.1.3"
       }
     },
+    "robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2180,13 +2196,6 @@
         "csso": "^4.2.0",
         "nanocolors": "^0.1.12",
         "stable": "^0.1.8"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "tar": {
@@ -2208,6 +2217,13 @@
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "requires": {
         "commander": "2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
       }
     },
     "tr46": {
@@ -2221,343 +2237,356 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vega": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.21.0.tgz",
-      "integrity": "sha512-yqqRa9nAqYoAxe7sVhRpsh0b001fly7Yx05klPkXmrvzjxXd07gClW1mOuGgSnVQqo7jTp/LYgbO1bD37FbEig==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "requires": {
-        "vega-crossfilter": "~4.0.5",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.8.3",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.0.7",
-        "vega-format": "~1.0.4",
-        "vega-functions": "~5.12.1",
-        "vega-geo": "~4.3.8",
-        "vega-hierarchy": "~4.0.9",
-        "vega-label": "~1.1.0",
-        "vega-loader": "~4.4.1",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.4.5",
-        "vega-regression": "~1.0.9",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.1.1",
-        "vega-scenegraph": "~4.9.4",
-        "vega-statistics": "~1.7.10",
-        "vega-time": "~2.0.4",
-        "vega-transforms": "~4.9.4",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.10.1",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.1.5",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
     },
     "vega-crossfilter": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
-      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "requires": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-encode": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
-      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-interpolate": "^2.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "vega-expression": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
-      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "requires": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-force": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
-      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "requires": {
-        "d3-force": "^2.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-format": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
-      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-format": "^2.0.0",
-        "d3-time-format": "^3.0.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-functions": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
-      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-color": "^2.0.0",
-        "d3-geo": "^2.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.1.1",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-geo": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.8.tgz",
-      "integrity": "sha512-fsGxV96Q/QRgPqOPtMBZdI+DneIiROKTG3YDZvGn0EdV16OG5LzFhbNgLT5GPzI+kTwgLpAsucBHklexlB4kfg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-color": "^2.0.0",
-        "d3-geo": "^2.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-hierarchy": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
-      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "requires": {
-        "d3-hierarchy": "^2.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-label": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.1.0.tgz",
-      "integrity": "sha512-LAThIiDEsZxYvbSkvPLJ93eJF+Ts8RXv1IpBh8gmew8XGmaLJvVkzdsMe7WJJwuaVEsK7ZZFyB/Inkp842GW6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "requires": {
-        "vega-canvas": "^1.2.5",
+        "vega-canvas": "^1.2.6",
         "vega-dataflow": "^5.7.3",
         "vega-scenegraph": "^4.9.2",
         "vega-util": "^1.15.2"
       }
     },
     "vega-loader": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
-      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "requires": {
-        "d3-dsv": "^2.0.0",
-        "node-fetch": "^2.6.1",
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.0.4",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-projection": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
-      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "requires": {
-        "d3-geo": "^2.0.1",
-        "d3-geo-projection": "^3.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "vega-regression": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
-      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "requires": {
-        "d3-array": "^2.7.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scale": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
-      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-interpolate": "^2.0.1",
-        "d3-scale": "^3.2.2",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scenegraph": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz",
-      "integrity": "sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "requires": {
-        "d3-path": "^2.0.0",
-        "d3-shape": "^2.0.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.3.3",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-selections": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
-      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "requires": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        }
       }
     },
     "vega-statistics": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
-      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "requires": {
-        "d3-array": "^2.7.1"
+        "d3-array": "^3.2.2"
       }
     },
     "vega-time": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
-      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-time": "^2.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-transforms": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.4.tgz",
-      "integrity": "sha512-JGBhm5Bf6fiGTUSB5Qr5ckw/KU9FJcSV5xIe/y4IobM/i/KNwI1i1fP45LzP4F4yZc0DMTwJod2UvFHGk9plKA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.0.4",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-typings": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.0.tgz",
-      "integrity": "sha512-TgBGRkZHQgcduGsoFKq3Scpn6eNY4L3p0YKRhgCPVU3HEaCeYkPFGaR8ynK+XrKmvrqpDv0YHIOwCt7Gn3RpCA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "requires": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
     },
     "vega-view": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.10.1.tgz",
-      "integrity": "sha512-4xvQ5KZcgKdZx1Z7jjenCUumvlyr/j4XcHLRf9gyeFrFvvS596dVpL92V8twhV6O++DmS2+fj+rHagO8Di4nMg==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "requires": {
-        "d3-array": "^2.7.1",
-        "d3-timer": "^2.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.0.4",
-        "vega-functions": "^5.10.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.9.4",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-voronoi": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
-      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "requires": {
-        "d3-delaunay": "^5.3.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "requires": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "webidl-conversions": {

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -50,15 +50,11 @@ version = "1.27.0"
 features = [ "rt-multi-thread", "macros",]
 
 [dependencies.tonic-web]
-version = "0.5.0"
-git = "https://github.com/hyperium/tonic.git"
-rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
+version = "0.9.1"
 
 [dependencies.tonic]
-version = "0.8.3"
+version = "0.9.1"
 features = [ "tls",]
-git = "https://github.com/hyperium/tonic.git"
-rev = "b3358dc6acf11ec800571735de1e1f1e449ec96a"
 
 [dependencies.clap]
 version = "3.2.22"

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -57,7 +57,7 @@ version = "0.9.1"
 features = [ "tls",]
 
 [dependencies.clap]
-version = "3.2.22"
+version = "4.2.1"
 features = [ "derive",]
 
 [target."cfg(target_family = \"unix\")".build-dependencies]

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -106,7 +106,7 @@ struct Args {
     pub memory_limit: Option<String>,
 
     /// Include compatibility with gRPC-Web
-    #[clap(long, takes_value = false)]
+    #[clap(long, num_args = 0)]
     pub web: bool,
 }
 

--- a/vegafusion-wasm/Cargo.toml
+++ b/vegafusion-wasm/Cargo.toml
@@ -51,9 +51,6 @@ features = [ "wasmbind",]
 version = "0.1.6"
 optional = true
 
-[dependencies.wee_alloc]
-version = "0.4.5"
-
 [dependencies.web-sys]
 version = "0.3.55"
 features = [ "Document", "Element", "HtmlElement", "Node", "Window",]

--- a/vegafusion-wasm/package-lock.json
+++ b/vegafusion-wasm/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-wasm",
-      "version": "1.0.0-rc1",
+      "version": "1.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -28,9 +28,14 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/bootstrap": {
       "version": "5.1.3",
@@ -45,14 +50,17 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -69,9 +77,9 @@
       }
     },
     "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dependencies": {
         "delaunator": "5"
       },
@@ -109,14 +117,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/d3-force": {
@@ -169,14 +169,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo-projection/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/d3-hierarchy": {
@@ -308,9 +300,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -354,165 +346,170 @@
         "topoquantize": "bin/topoquantize"
       }
     },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/vega": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.22.1.tgz",
-      "integrity": "sha512-KJBI7OWSzpfCPbmWl3GQCqBqbf2TIdpWS0mzO6MmWbvdMhWHf74P9IVnx1B1mhg0ZTqWFualx9ZYhWzMMwudaQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "dependencies": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.0.tgz",
-      "integrity": "sha512-aiOJcvVpiEDIu5uNc4Kf1hakkkPaVOO5fw5T4RSFAw6GEDbdqcB6eZ1xePcsLVic1hxYD5SGiUPdiiIs0SMh2g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "dependencies": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.0.tgz",
-      "integrity": "sha512-etv2BHuCn9bzEc0cxyA2TnbtcAFQGVFmsaqmB4sgBCaqTSEfXMoX68LK3yxBrsdm5LU+y3otJVoewi3qWYCx2g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "node_modules/vega-expression": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
-      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "dependencies": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.1.0.tgz",
-      "integrity": "sha512-Sssf8iH48vYlz+E7/RpU+SUaJbuLoIL87U4tG2Av4gf/hRiImU49x2TI3EuhFWg1zpaCFxlz0CAaX++Oh/gjdw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.0.tgz",
-      "integrity": "sha512-6mgpeWw8yGdG0Zdi8aVkx5oUrpJGOpNxqazC2858RSDPvChM/jDFlgRMTYw52qk7cxU0L08ARp4BwmXaI75j0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.0.tgz",
-      "integrity": "sha512-Mf53zNyx+c9fFqagEI0T8zc9nMlx0zozOngr8oOpG1tZDKOgwOnUgN99zQKbLHjyv+UzWrq3LYTnSLyVe0ZmhQ==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.0.tgz",
-      "integrity": "sha512-3YX41y+J5pu0PMjvBCASg0/lgvu9+QXWJZ+vl6FFKa8AlsIopQ67ZL7ObwqjZcoZMolJ4q0rc+ZO8aj1pXCYcw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.0.tgz",
-      "integrity": "sha512-DWBK39IEt4FiQru12twzKSFUvFFZ7KtlH9+lAaqrJnKuIZFCyQ1XOUfKScfbKIlk4KS+DuCTNLI/pxC/f7Sk9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "dependencies": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.0.tgz",
-      "integrity": "sha512-1prOqkCAfXaUvMqavbGI0nbYGqV8UQR9qvuVwrPJ6Yxm3GIUIOA/JRqNY8eZR8USwMP/kzsqlfVEixj9+Y75VQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "dependencies": {
         "vega-canvas": "^1.2.6",
         "vega-dataflow": "^5.7.3",
@@ -521,108 +518,121 @@
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.0.tgz",
-      "integrity": "sha512-EkAyzbx0pCYxH3v3wghGVCaKINWxHfgbQ2pYDiYv0yo8e04S8Mv/IlRGTt6BAe7cLhrk1WZ4zh20QOppnGG05w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "dependencies": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.5.0.tgz",
-      "integrity": "sha512-aob7qojh555x3hQWZ/tr8cIJNSWQbm6EoWTJaheZgFOY2x3cDa4Qrg3RJbGw6KwVj/IQk2p40paRzixKZ2kr+A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "dependencies": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.0.tgz",
-      "integrity": "sha512-09K0RemY6cdaXBAyakDUNFfEkRcLkGjkDJyWQPAUqGK59hV2J+G3i4uxkZp18Vu0t8oqU7CgzwWim1s5uEpOcA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.2.0.tgz",
-      "integrity": "sha512-QYltO/otrZHLrCGGf06Y99XtPtqWXITr6rw7rO9oL+l3d9o5RFl9sjHrVxiM7v+vGoZVWbBd5IPbFhPsXZ6+TA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.1.tgz",
-      "integrity": "sha512-takIpkmNxYHhJYALOYzhTin3EDzbys6U4g+l1yJZVlXG9YTdiCMuEVAdtaQOCqF9/7qytD6pCrMxJY2HaoN0qQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "dependencies": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-selections": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
-      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "dependencies": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections/node_modules/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.0.tgz",
-      "integrity": "sha512-dl+LCRS6qS4jWDme/NEdPVt5r649uB4IK6Kyr2/czmGA5JqjuFmtQ9lHQOnRu8945XLkqLf+JIQQo7vnw+nslA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "dependencies": {
-        "d3-array": "^3.1.1"
+        "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.0.tgz",
-      "integrity": "sha512-Q9/l3S6Br1RPX5HZvyLD/cQ4K6K8DtpR09/1y7D66gxNorg2+HGzYZINH9nUvN3mxoXcBWg4cCUh3+JvmkDaEg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-tooltip": {
@@ -634,88 +644,89 @@
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.0.tgz",
-      "integrity": "sha512-Yk6ByzVq5F2niFfPlSsrU5wi+NZhsF7IBpJCcTfms4U7eoyNepUXagdFEJ3VWBD/Lit6GorLXFgO17NYcyS5gg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "dependencies": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-typings": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.1.tgz",
-      "integrity": "sha512-88cIrjmoTxo/0nWTf+GuitkFhirHWVWCfymADiCUXt6s9arpQ6XPP5xjrN5KDc0LZd9xr7p4FIiEgADghgLTgw==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "dependencies": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
     },
     "node_modules/vega-view": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.0.tgz",
-      "integrity": "sha512-MI9NTRFmtFX6ADk6KOHhi8bhHjC9pPm42Bj2+74c6l1d3NQZf9Jv7lkiGqKohdkQDNH9LPwz/6slhKwPU9JdkQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "dependencies": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "dependencies": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.0.tgz",
-      "integrity": "sha512-1iuNAVZgUHRlBpdq4gSga3KlQmrgFfwy+KpyDgPLQ8HbLkhcVeT7RDh2L6naluqD7Op0xVLms3clR920WsYryQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "dependencies": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "dependencies": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -730,9 +741,14 @@
       "peer": true
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "bootstrap": {
       "version": "5.1.3",
@@ -741,14 +757,14 @@
       "requires": {}
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -759,9 +775,9 @@
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "requires": {
         "delaunator": "5"
       }
@@ -779,13 +795,6 @@
         "commander": "7",
         "iconv-lite": "0.6",
         "rw": "1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "d3-force": {
@@ -819,13 +828,6 @@
         "commander": "7",
         "d3-array": "1 - 3",
         "d3-geo": "1.12.0 - 3"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        }
       }
     },
     "d3-hierarchy": {
@@ -924,9 +926,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -952,167 +954,174 @@
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "requires": {
         "commander": "2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
       }
     },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "vega": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.22.1.tgz",
-      "integrity": "sha512-KJBI7OWSzpfCPbmWl3GQCqBqbf2TIdpWS0mzO6MmWbvdMhWHf74P9IVnx1B1mhg0ZTqWFualx9ZYhWzMMwudaQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
       "requires": {
-        "vega-crossfilter": "~4.1.0",
-        "vega-dataflow": "~5.7.4",
-        "vega-encode": "~4.9.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-force": "~4.1.0",
-        "vega-format": "~1.1.0",
-        "vega-functions": "~5.13.0",
-        "vega-geo": "~4.4.0",
-        "vega-hierarchy": "~4.1.0",
-        "vega-label": "~1.2.0",
-        "vega-loader": "~4.5.0",
-        "vega-parser": "~6.1.4",
-        "vega-projection": "~1.5.0",
-        "vega-regression": "~1.1.0",
-        "vega-runtime": "~6.1.3",
-        "vega-scale": "~7.2.0",
-        "vega-scenegraph": "~4.10.1",
-        "vega-statistics": "~1.8.0",
-        "vega-time": "~2.1.0",
-        "vega-transforms": "~4.10.0",
-        "vega-typings": "~0.22.0",
-        "vega-util": "~1.17.0",
-        "vega-view": "~5.11.0",
-        "vega-view-transforms": "~4.5.8",
-        "vega-voronoi": "~4.2.0",
-        "vega-wordcloud": "~4.1.3"
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
       }
     },
     "vega-canvas": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
-      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
     },
     "vega-crossfilter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.0.tgz",
-      "integrity": "sha512-aiOJcvVpiEDIu5uNc4Kf1hakkkPaVOO5fw5T4RSFAw6GEDbdqcB6eZ1xePcsLVic1hxYD5SGiUPdiiIs0SMh2g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-dataflow": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.4.tgz",
-      "integrity": "sha512-JGHTpUo8XGETH3b1V892we6hdjzCWB977ybycIu8DPqRoyrZuj6t1fCVImazfMgQD1LAfJlQybWP+alwKDpKig==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
       "requires": {
-        "vega-format": "^1.0.4",
-        "vega-loader": "^4.3.2",
-        "vega-util": "^1.16.1"
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-encode": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.0.tgz",
-      "integrity": "sha512-etv2BHuCn9bzEc0cxyA2TnbtcAFQGVFmsaqmB4sgBCaqTSEfXMoX68LK3yxBrsdm5LU+y3otJVoewi3qWYCx2g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.0.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-event-selector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.0.tgz",
-      "integrity": "sha512-Gls93/+7tEJGE3kUuUnxrBIxtvaNeF01VIFB2Q2Of2hBIBvtHX74jcAdDtkh5UhhoYGD8Q1J30P5cqEBEwtPoQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "vega-expression": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.0.tgz",
-      "integrity": "sha512-y5+c2frq0tGwJ7vYXzZcfVcIRF/QGfhf2e+bV1Z0iQs+M2lI1II1GPDdmOcMKimpoCVp/D61KUJDIGE1DSmk2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
       "requires": {
-        "@types/estree": "^0.0.50",
-        "vega-util": "^1.16.0"
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-force": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.1.0.tgz",
-      "integrity": "sha512-Sssf8iH48vYlz+E7/RpU+SUaJbuLoIL87U4tG2Av4gf/hRiImU49x2TI3EuhFWg1zpaCFxlz0CAaX++Oh/gjdw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "requires": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.0.tgz",
-      "integrity": "sha512-6mgpeWw8yGdG0Zdi8aVkx5oUrpJGOpNxqazC2858RSDPvChM/jDFlgRMTYw52qk7cxU0L08ARp4BwmXaI75j0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-format": "^3.1.0",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.0.3",
-        "vega-util": "^1.15.2"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-functions": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.0.tgz",
-      "integrity": "sha512-Mf53zNyx+c9fFqagEI0T8zc9nMlx0zozOngr8oOpG1tZDKOgwOnUgN99zQKbLHjyv+UzWrq3LYTnSLyVe0ZmhQ==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-expression": "^5.0.0",
-        "vega-scale": "^7.2.0",
-        "vega-scenegraph": "^4.9.3",
-        "vega-selections": "^5.3.1",
-        "vega-statistics": "^1.7.9",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-geo": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.0.tgz",
-      "integrity": "sha512-3YX41y+J5pu0PMjvBCASg0/lgvu9+QXWJZ+vl6FFKa8AlsIopQ67ZL7ObwqjZcoZMolJ4q0rc+ZO8aj1pXCYcw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-color": "^3.0.1",
-        "d3-geo": "^3.0.1",
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-projection": "^1.4.5",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-hierarchy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.0.tgz",
-      "integrity": "sha512-DWBK39IEt4FiQru12twzKSFUvFFZ7KtlH9+lAaqrJnKuIZFCyQ1XOUfKScfbKIlk4KS+DuCTNLI/pxC/f7Sk9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
       "requires": {
-        "d3-hierarchy": "^3.1.0",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-label": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.0.tgz",
-      "integrity": "sha512-1prOqkCAfXaUvMqavbGI0nbYGqV8UQR9qvuVwrPJ6Yxm3GIUIOA/JRqNY8eZR8USwMP/kzsqlfVEixj9+Y75VQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
       "requires": {
         "vega-canvas": "^1.2.6",
         "vega-dataflow": "^5.7.3",
@@ -1121,108 +1130,120 @@
       }
     },
     "vega-loader": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.0.tgz",
-      "integrity": "sha512-EkAyzbx0pCYxH3v3wghGVCaKINWxHfgbQ2pYDiYv0yo8e04S8Mv/IlRGTt6BAe7cLhrk1WZ4zh20QOppnGG05w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
       "requires": {
         "d3-dsv": "^3.0.1",
         "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.0",
-        "vega-util": "^1.16.0"
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-parser": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
-      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-event-selector": "^3.0.0",
-        "vega-functions": "^5.12.1",
-        "vega-scale": "^7.1.1",
-        "vega-util": "^1.16.0"
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-projection": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.5.0.tgz",
-      "integrity": "sha512-aob7qojh555x3hQWZ/tr8cIJNSWQbm6EoWTJaheZgFOY2x3cDa4Qrg3RJbGw6KwVj/IQk2p40paRzixKZ2kr+A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
       "requires": {
-        "d3-geo": "^3.0.1",
-        "d3-geo-projection": "^4.0.0"
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
       }
     },
     "vega-regression": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.0.tgz",
-      "integrity": "sha512-09K0RemY6cdaXBAyakDUNFfEkRcLkGjkDJyWQPAUqGK59hV2J+G3i4uxkZp18Vu0t8oqU7CgzwWim1s5uEpOcA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
         "vega-statistics": "^1.7.9",
         "vega-util": "^1.15.2"
       }
     },
     "vega-runtime": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
-      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scale": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.2.0.tgz",
-      "integrity": "sha512-QYltO/otrZHLrCGGf06Y99XtPtqWXITr6rw7rO9oL+l3d9o5RFl9sjHrVxiM7v+vGoZVWbBd5IPbFhPsXZ6+TA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.17.0"
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-scenegraph": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.1.tgz",
-      "integrity": "sha512-takIpkmNxYHhJYALOYzhTin3EDzbys6U4g+l1yJZVlXG9YTdiCMuEVAdtaQOCqF9/7qytD6pCrMxJY2HaoN0qQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
       "requires": {
-        "d3-path": "^3.0.1",
-        "d3-shape": "^3.1.0",
-        "vega-canvas": "^1.2.5",
-        "vega-loader": "^4.4.0",
-        "vega-scale": "^7.2.0",
-        "vega-util": "^1.15.2"
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-selections": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.1.tgz",
-      "integrity": "sha512-cm4Srw1WHjcLGXX7GpxiUlfESv8XPu5b6Vh3mqMDPU94P2FO91SR9gei+EtRdt+KCFgIjr//MnRUjg/hAWwjkQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
       "requires": {
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.16.0"
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        }
       }
     },
     "vega-statistics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.0.tgz",
-      "integrity": "sha512-dl+LCRS6qS4jWDme/NEdPVt5r649uB4IK6Kyr2/czmGA5JqjuFmtQ9lHQOnRu8945XLkqLf+JIQQo7vnw+nslA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
       "requires": {
-        "d3-array": "^3.1.1"
+        "d3-array": "^3.2.2"
       }
     },
     "vega-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.0.tgz",
-      "integrity": "sha512-Q9/l3S6Br1RPX5HZvyLD/cQ4K6K8DtpR09/1y7D66gxNorg2+HGzYZINH9nUvN3mxoXcBWg4cCUh3+JvmkDaEg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
       "requires": {
-        "d3-array": "^3.1.1",
-        "d3-time": "^3.0.0",
-        "vega-util": "^1.15.2"
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-tooltip": {
@@ -1234,88 +1255,89 @@
       }
     },
     "vega-transforms": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.0.tgz",
-      "integrity": "sha512-Yk6ByzVq5F2niFfPlSsrU5wi+NZhsF7IBpJCcTfms4U7eoyNepUXagdFEJ3VWBD/Lit6GorLXFgO17NYcyS5gg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
       "requires": {
-        "d3-array": "^3.1.1",
-        "vega-dataflow": "^5.7.4",
-        "vega-statistics": "^1.8.0",
-        "vega-time": "^2.1.0",
-        "vega-util": "^1.16.1"
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-typings": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.22.1.tgz",
-      "integrity": "sha512-88cIrjmoTxo/0nWTf+GuitkFhirHWVWCfymADiCUXt6s9arpQ6XPP5xjrN5KDc0LZd9xr7p4FIiEgADghgLTgw==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
       "requires": {
-        "vega-event-selector": "^3.0.0",
-        "vega-expression": "^5.0.0",
-        "vega-util": "^1.15.2"
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-util": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.0.tgz",
-      "integrity": "sha512-HTaydZd9De3yf+8jH66zL4dXJ1d1p5OIFyoBzFiOli4IJbwkL1jrefCKz6AHDm1kYBzDJ0X4bN+CzZSCTvNk1w=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
     },
     "vega-view": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.0.tgz",
-      "integrity": "sha512-MI9NTRFmtFX6ADk6KOHhi8bhHjC9pPm42Bj2+74c6l1d3NQZf9Jv7lkiGqKohdkQDNH9LPwz/6slhKwPU9JdkQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
       "requires": {
-        "d3-array": "^3.1.1",
+        "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.3",
-        "vega-format": "^1.1.0",
-        "vega-functions": "^5.13.0",
-        "vega-runtime": "^6.1.3",
-        "vega-scenegraph": "^4.10.0",
-        "vega-util": "^1.16.1"
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-view-transforms": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
-      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
       "requires": {
-        "vega-dataflow": "^5.7.3",
-        "vega-scenegraph": "^4.9.2",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-voronoi": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.0.tgz",
-      "integrity": "sha512-1iuNAVZgUHRlBpdq4gSga3KlQmrgFfwy+KpyDgPLQ8HbLkhcVeT7RDh2L6naluqD7Op0xVLms3clR920WsYryQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
       "requires": {
         "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.3",
-        "vega-util": "^1.15.2"
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
       }
     },
     "vega-wordcloud": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
-      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
       "requires": {
-        "vega-canvas": "^1.2.5",
-        "vega-dataflow": "^5.7.3",
-        "vega-scale": "^7.1.1",
-        "vega-statistics": "^1.7.9",
-        "vega-util": "^1.15.2"
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
       }
     },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -24,12 +24,6 @@ use vegafusion_core::task_graph::graph::ScopedVariable;
 use vegafusion_core::planning::plan::SpecPlan;
 use web_sys::Element;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then


### PR DESCRIPTION
Updates tonic/tonic-web to 0.9.1 to no longer depend on git revision. This means we'll be able to publish vegafusion-server to crates.io again.

Also updates other Rust and JS dependencies