### PR TITLE
Add patch_pre_transformed_spec function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "treediff",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3973,6 +3985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "treediff"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4107,6 +4128,7 @@ dependencies = [
  "datafusion-common",
  "deterministic-hash",
  "itertools",
+ "json-patch",
  "lazy_static",
  "num-complex",
  "ordered-float 3.6.0",

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -384,6 +384,31 @@ class VegaFusionRuntime:
 
             return new_spec, datasets, warnings
 
+    def patch_pre_transformed_spec(self, spec1, pre_transformed_spec1, spec2):
+        """
+        Attempt to patch a Vega spec was returned by the pre_transform_spec method without
+        rerunning the pre_transform_spec logic. When possible, this can be significantly
+        faster than rerunning the pre_transform_spec method.
+
+        :param spec1: The input Vega spec to a prior call to pre_transform_spec
+        :param pre_transformed_spec1: The prior result of passing spec1 to pre_transform_spec
+        :param spec2: A Vega spec that is assumed to be a small delta compared to spec1
+
+        :return: dict or None
+            If the delta between spec1 and spec2 is in the portions of spec1 that were not
+            modified by pre_transform_spec, then this delta can be applied cleanly to
+            pre_transform_spec1 and the result is returned. If the delta cannot be
+            applied cleanly, None is returned and spec2 should be passed through the
+            pre_transform_spec method.
+        """
+        if self._grpc_channel:
+            raise ValueError("patch_pre_transformed_spec not yet supported over gRPC")
+        else:
+            pre_transformed_spec2 = self.embedded_runtime.patch_pre_transformed_spec(
+                spec1, pre_transformed_spec1, spec2
+            )
+            return pre_transformed_spec2
+
     @property
     def worker_threads(self):
         return self._worker_threads

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -23,6 +23,7 @@ deterministic-hash = "1.0.1"
 chrono = "0.4.23"
 num-complex = "0.4.2"
 rand = "0.8.5"
+json-patch = "1.0.0"
 
 [dependencies.sqlparser]
 version = "0.32.0"

--- a/vegafusion-core/src/lib.rs
+++ b/vegafusion-core/src/lib.rs
@@ -3,6 +3,7 @@ extern crate lazy_static;
 
 pub mod data;
 pub mod expression;
+pub mod patch;
 pub mod planning;
 pub mod proto;
 pub mod spec;

--- a/vegafusion-core/src/patch.rs
+++ b/vegafusion-core/src/patch.rs
@@ -1,0 +1,482 @@
+use crate::error::Result;
+use crate::planning::plan::{PlannerConfig, SpecPlan};
+use crate::spec::chart::{ChartSpec, ChartVisitor};
+use crate::spec::data::DataSpec;
+use crate::spec::values::StringOrSignalSpec;
+use json_patch::{diff, patch};
+
+/// Attempt to apply the difference between two vega specs to a third pre-transformed spec
+pub fn patch_pre_transformed_spec(
+    spec1: &ChartSpec,
+    pre_transformed_spec1: &ChartSpec,
+    spec2: &ChartSpec,
+) -> Result<Option<ChartSpec>> {
+    // Run spec1 and spec2 through the client portion of the pre_transform_spec logic.
+    // This performs domain splitting and introduces projection pushdown transforms.
+    let planner_config = PlannerConfig {
+        extract_server_data: false,
+        ..Default::default()
+    };
+    let plan1 = SpecPlan::try_new(spec1, &planner_config)?;
+    let planned_spec1 = plan1.client_spec;
+
+    let plan2 = SpecPlan::try_new(spec2, &planner_config)?;
+    let planned_spec2 = plan2.client_spec;
+
+    // Diff the planned specs to create patch between them
+    let spec_patch = diff(
+        &serde_json::to_value(planned_spec1)?,
+        &serde_json::to_value(planned_spec2)?,
+    );
+
+    // Attempt to apply patch to pre-transformed spec
+    let mut pre_transformed_spec2 = serde_json::to_value(pre_transformed_spec1)?;
+    if patch(&mut pre_transformed_spec2, spec_patch.0.as_slice()).is_err() {
+        // Patch failed to apply, return None
+        Ok(None)
+    } else {
+        // Patch applied successfully, check validity
+        let pre_transformed_spec2: ChartSpec = serde_json::from_value(pre_transformed_spec2)?;
+
+        // Check for presence of inline dataset URLs, this indicates an invalid pre transformed spec
+        let mut visitor = AnyInlineDatasetUrlsVisitor::new();
+        pre_transformed_spec2.walk(&mut visitor)?;
+        if visitor.any_inline_dataset_urls {
+            return Ok(None);
+        }
+
+        Ok(Some(pre_transformed_spec2))
+    }
+}
+
+struct AnyInlineDatasetUrlsVisitor {
+    pub any_inline_dataset_urls: bool,
+}
+
+impl AnyInlineDatasetUrlsVisitor {
+    pub fn new() -> Self {
+        Self {
+            any_inline_dataset_urls: false,
+        }
+    }
+}
+
+impl ChartVisitor for AnyInlineDatasetUrlsVisitor {
+    fn visit_data(&mut self, data: &DataSpec, _scope: &[u32]) -> Result<()> {
+        if let Some(StringOrSignalSpec::String(url)) = &data.url {
+            if url.starts_with("table://") || url.starts_with("vegafusion+dataset://") {
+                self.any_inline_dataset_urls = true;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::patch::patch_pre_transformed_spec;
+    use crate::spec::chart::ChartSpec;
+    use crate::spec::values::StringOrSignalSpec;
+    use serde_json::json;
+
+    fn histogram(color: &str, max_bins: u32) -> ChartSpec {
+        serde_json::from_value(json!(
+            {
+              "$schema": "https://vega.github.io/schema/vega/v5.json",
+              "background": "white",
+              "padding": 5,
+              "width": 200,
+              "height": 200,
+              "style": "cell",
+              "data": [
+                {
+                  "name": "source_0",
+                  "url": "data/movies.json",
+                  "format": {"type": "json"},
+                  "transform": [
+                    {
+                      "type": "extent",
+                      "field": "IMDB Rating",
+                      "signal": "bin_maxbins_10_IMDB_Rating_extent"
+                    },
+                    {
+                      "type": "bin",
+                      "field": "IMDB Rating",
+                      "as": [
+                        "bin_maxbins_10_IMDB Rating",
+                        "bin_maxbins_10_IMDB Rating_end"
+                      ],
+                      "signal": "bin_maxbins_10_IMDB_Rating_bins",
+                      "extent": {"signal": "bin_maxbins_10_IMDB_Rating_extent"},
+                      "maxbins": max_bins
+                    },
+                    {
+                      "type": "aggregate",
+                      "groupby": [
+                        "bin_maxbins_10_IMDB Rating",
+                        "bin_maxbins_10_IMDB Rating_end"
+                      ],
+                      "ops": ["count"],
+                      "fields": [null],
+                      "as": ["__count"]
+                    },
+                    {
+                      "type": "filter",
+                      "expr": "isValid(datum[\"bin_maxbins_10_IMDB Rating\"]) && isFinite(+datum[\"bin_maxbins_10_IMDB Rating\"])"
+                    }
+                  ]
+                }
+              ],
+              "marks": [
+                {
+                  "name": "marks",
+                  "type": "rect",
+                  "style": ["bar"],
+                  "from": {"data": "source_0"},
+                  "encode": {
+                    "update": {
+                      "fill": {"value": color},
+                      "ariaRoleDescription": {"value": "bar"},
+                      "x2": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_IMDB Rating",
+                        "offset": 1
+                      },
+                      "x": {"scale": "x", "field": "bin_maxbins_10_IMDB Rating_end"},
+                      "y": {"scale": "y", "field": "__count"},
+                      "y2": {"scale": "y", "value": 0}
+                    }
+                  }
+                }
+              ],
+              "scales": [
+                {
+                  "name": "x",
+                  "type": "linear",
+                  "domain": {
+                    "signal": "[bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop]"
+                  },
+                  "range": [0, {"signal": "width"}],
+                  "bins": {"signal": "bin_maxbins_10_IMDB_Rating_bins"},
+                  "zero": false
+                },
+                {
+                  "name": "y",
+                  "type": "linear",
+                  "domain": {"data": "source_0", "field": "__count"},
+                  "range": [{"signal": "height"}, 0],
+                  "nice": true,
+                  "zero": true
+                }
+              ],
+              "axes": [
+                {
+                  "scale": "y",
+                  "orient": "left",
+                  "gridScale": "x",
+                  "grid": true,
+                  "tickCount": {"signal": "ceil(height/40)"},
+                  "domain": false,
+                  "labels": false,
+                  "aria": false,
+                  "maxExtent": 0,
+                  "minExtent": 0,
+                  "ticks": false,
+                  "zindex": 0
+                },
+                {
+                  "scale": "x",
+                  "orient": "bottom",
+                  "grid": false,
+                  "title": "IMDB Rating (binned)",
+                  "labelFlush": true,
+                  "labelOverlap": true,
+                  "tickCount": {"signal": "ceil(width/10)"},
+                  "zindex": 0
+                },
+                {
+                  "scale": "y",
+                  "orient": "left",
+                  "grid": false,
+                  "title": "Count of Records",
+                  "labelOverlap": true,
+                  "tickCount": {"signal": "ceil(height/40)"},
+                  "zindex": 0
+                }
+              ]
+            }
+        )).unwrap()
+    }
+
+    fn pre_transformed_histogram(color: &str) -> ChartSpec {
+        serde_json::from_value(json!(
+            {
+              "$schema": "https://vega.github.io/schema/vega/v5.json",
+              "data": [
+                {
+                  "name": "source_0",
+                  "values": [
+                    {
+                      "__count": 985,
+                      "bin_maxbins_10_IMDB Rating": 6.0,
+                      "bin_maxbins_10_IMDB Rating_end": 7.0
+                    },
+                    {
+                      "__count": 100,
+                      "bin_maxbins_10_IMDB Rating": 3.0,
+                      "bin_maxbins_10_IMDB Rating_end": 4.0
+                    },
+                    {
+                      "__count": 741,
+                      "bin_maxbins_10_IMDB Rating": 7.0,
+                      "bin_maxbins_10_IMDB Rating_end": 8.0
+                    },
+                    {
+                      "__count": 633,
+                      "bin_maxbins_10_IMDB Rating": 5.0,
+                      "bin_maxbins_10_IMDB Rating_end": 6.0
+                    },
+                    {
+                      "__count": 204,
+                      "bin_maxbins_10_IMDB Rating": 8.0,
+                      "bin_maxbins_10_IMDB Rating_end": 9.0
+                    },
+                    {
+                      "__count": 43,
+                      "bin_maxbins_10_IMDB Rating": 2.0,
+                      "bin_maxbins_10_IMDB Rating_end": 3.0
+                    },
+                    {
+                      "__count": 273,
+                      "bin_maxbins_10_IMDB Rating": 4.0,
+                      "bin_maxbins_10_IMDB Rating_end": 5.0
+                    },
+                    {
+                      "__count": 4,
+                      "bin_maxbins_10_IMDB Rating": 9.0,
+                      "bin_maxbins_10_IMDB Rating_end": 10.0
+                    },
+                    {
+                      "__count": 5,
+                      "bin_maxbins_10_IMDB Rating": 1.0,
+                      "bin_maxbins_10_IMDB Rating_end": 2.0
+                    }
+                  ]
+                },
+                {
+                  "name": "source_0_y_domain___count",
+                  "values": [
+                    {
+                      "min": 4,
+                      "max": 985
+                    }
+                  ]
+                }
+              ],
+              "signals": [
+                {
+                  "name": "bin_maxbins_10_IMDB_Rating_bins",
+                  "value": {
+                    "fields": [
+                      "IMDB Rating"
+                    ],
+                    "fname": "bin_IMDB Rating",
+                    "start": 1.0,
+                    "step": 1.0,
+                    "stop": 10.0
+                  }
+                }
+              ],
+              "marks": [
+                {
+                  "type": "rect",
+                  "name": "marks",
+                  "from": {
+                    "data": "source_0"
+                  },
+                  "encode": {
+                    "update": {
+                      "x": {
+                        "field": "bin_maxbins_10_IMDB Rating_end",
+                        "scale": "x"
+                      },
+                      "ariaRoleDescription": {
+                        "value": "bar"
+                      },
+                      "y": {
+                        "field": "__count",
+                        "scale": "y"
+                      },
+                      "y2": {
+                        "value": 0,
+                        "scale": "y"
+                      },
+                      "fill": {
+                        "value": color
+                      },
+                      "x2": {
+                        "field": "bin_maxbins_10_IMDB Rating",
+                        "scale": "x",
+                        "offset": 1
+                      }
+                    }
+                  },
+                  "style": [
+                    "bar"
+                  ]
+                }
+              ],
+              "scales": [
+                {
+                  "name": "x",
+                  "type": "linear",
+                  "domain": {
+                    "signal": "[bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop]"
+                  },
+                  "range": [
+                    0,
+                    {
+                      "signal": "width"
+                    }
+                  ],
+                  "bins": {
+                    "signal": "bin_maxbins_10_IMDB_Rating_bins"
+                  },
+                  "zero": false
+                },
+                {
+                  "name": "y",
+                  "type": "linear",
+                  "domain": [
+                    {
+                      "signal": "(data(\"source_0_y_domain___count\")[0] || {}).min"
+                    },
+                    {
+                      "signal": "(data(\"source_0_y_domain___count\")[0] || {}).max"
+                    }
+                  ],
+                  "range": [
+                    {
+                      "signal": "height"
+                    },
+                    0
+                  ],
+                  "zero": true,
+                  "nice": true
+                }
+              ],
+              "axes": [
+                {
+                  "scale": "y",
+                  "grid": true,
+                  "gridScale": "x",
+                  "labels": false,
+                  "minExtent": 0,
+                  "tickCount": {
+                    "signal": "ceil(height/40)"
+                  },
+                  "maxExtent": 0,
+                  "domain": false,
+                  "zindex": 0,
+                  "aria": false,
+                  "ticks": false,
+                  "orient": "left"
+                },
+                {
+                  "scale": "x",
+                  "orient": "bottom",
+                  "labelOverlap": true,
+                  "grid": false,
+                  "title": "IMDB Rating (binned)",
+                  "labelFlush": true,
+                  "tickCount": {
+                    "signal": "ceil(width/10)"
+                  },
+                  "zindex": 0
+                },
+                {
+                  "scale": "y",
+                  "zindex": 0,
+                  "grid": false,
+                  "labelOverlap": true,
+                  "tickCount": {
+                    "signal": "ceil(height/40)"
+                  },
+                  "orient": "left",
+                  "title": "Count of Records"
+                }
+              ],
+              "height": 200,
+              "style": "cell",
+              "background": "white",
+              "padding": 5,
+              "width": 200
+            }
+        )).unwrap()
+    }
+
+    #[test]
+    fn test_patch_color_succeeds() {
+        let spec1: ChartSpec = histogram("blue", 10);
+
+        let spec2: ChartSpec = histogram("red", 10);
+
+        let pre_transformed_spec1: ChartSpec = pre_transformed_histogram("blue");
+
+        let pre_transform_spec2 =
+            patch_pre_transformed_spec(&spec1, &pre_transformed_spec1, &spec2)
+                .expect("Expected patch_pre_transformed_spec to succeed")
+                .expect("Expected patch_pre_transformed_spec to return Some");
+
+        assert_eq!(pre_transform_spec2, pre_transformed_histogram("red"))
+    }
+
+    #[test]
+    fn test_patch_max_bins_fails() {
+        let spec1: ChartSpec = histogram("blue", 10);
+
+        let spec2: ChartSpec = histogram("blue", 20);
+
+        let pre_transformed_spec1: ChartSpec = pre_transformed_histogram("blue");
+
+        let pre_transform_spec2 =
+            patch_pre_transformed_spec(&spec1, &pre_transformed_spec1, &spec2)
+                .expect("Expected patch_pre_transformed_spec to succeed");
+        assert!(pre_transform_spec2.is_none());
+    }
+
+    #[test]
+    fn test_patch_adds_inline_dataset() {
+        let spec1: ChartSpec = serde_json::from_value(json!(
+            {
+                "data": [
+                    {
+                        "name": "data1",
+                        "url": "something.csv"
+                    }
+                ]
+            }
+        ))
+        .unwrap();
+
+        let spec2: ChartSpec = serde_json::from_value(json!(
+            {
+                "data": [
+                    {
+                        "name": "data1",
+                        "url": "table://something"
+                    }
+                ]
+            }
+        ))
+        .unwrap();
+
+        let pre_transformed_spec1 = spec1.clone();
+
+        let pre_transform_spec2 =
+            patch_pre_transformed_spec(&spec1, &pre_transformed_spec1, &spec2)
+                .expect("Expected patch_pre_transformed_spec to succeed");
+
+        assert!(pre_transform_spec2.is_none());
+    }
+}

--- a/vegafusion-core/src/planning/stitch.rs
+++ b/vegafusion-core/src/planning/stitch.rs
@@ -8,7 +8,7 @@ use crate::task_graph::scope::TaskScope;
 use serde_json::Value;
 use std::collections::HashSet;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CommPlan {
     pub server_to_client: Vec<ScopedVariable>,
     pub client_to_server: Vec<ScopedVariable>,

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -17,6 +17,7 @@ use env_logger::{Builder, Target};
 use pythonize::depythonize;
 use serde::{Deserialize, Serialize};
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_core::patch::patch_pre_transformed_spec;
 use vegafusion_core::proto::gen::tasks::Variable;
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::task_graph::graph::ScopedVariable;
@@ -291,6 +292,25 @@ impl PyVegaFusionRuntime {
             let warnings = pythonize::pythonize(py, &warnings)?;
 
             Ok((tx_spec, datasets, warnings))
+        })
+    }
+
+    pub fn patch_pre_transformed_spec(
+        &self,
+        spec1: PyObject,
+        pre_transformed_spec1: PyObject,
+        spec2: PyObject,
+    ) -> PyResult<Option<PyObject>> {
+        let spec1 = parse_json_spec(spec1)?;
+        let pre_transformed_spec1 = parse_json_spec(pre_transformed_spec1)?;
+        let spec2 = parse_json_spec(spec2)?;
+        Python::with_gil(|py| {
+            match patch_pre_transformed_spec(&spec1, &pre_transformed_spec1, &spec2)? {
+                None => Ok(None),
+                Some(pre_transformed_spec2) => {
+                    Ok(Some(pythonize::pythonize(py, &pre_transformed_spec2)?))
+                }
+            }
         })
     }
 


### PR DESCRIPTION
This PR adds a new function to the Rust and Python APIs called `patch_pre_transformed_spec`.
