### PR TITLE
Support transformed_data for Layered and Concatenated charts 

### DIFF
--- a/python/vegafusion/tests/altair_mocks/interactive/casestudy-seattle_weather_interactive/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/casestudy-seattle_weather_interactive/mock.py
@@ -1,5 +1,3 @@
-# https://altair-viz.github.io/gallery/seattle_weather_interactive.html
-
 import altair as alt
 from vega_datasets import data
 
@@ -13,7 +11,7 @@ color = alt.Color('weather:N', scale=scale)
 # - a brush that is active on the top panel
 # - a multi-click that is active on the bottom panel
 brush = alt.selection_interval(encodings=['x'])
-click = alt.selection_multi(encodings=['color'])
+click = alt.selection_point(encodings=['color'])
 
 # Top panel is scatter plot of temperature vs time
 points = alt.Chart().mark_point().encode(
@@ -27,7 +25,7 @@ points = alt.Chart().mark_point().encode(
 ).properties(
     width=550,
     height=300
-).add_selection(
+).add_params(
     brush
 ).transform_filter(
     click
@@ -42,7 +40,7 @@ bars = alt.Chart().mark_bar().encode(
     brush
 ).properties(
     width=550,
-).add_selection(
+).add_params(
     click
 )
 

--- a/python/vegafusion/tests/altair_mocks/interactive/casestudy-us_population_pyramid_over_time/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/casestudy-us_population_pyramid_over_time/mock.py
@@ -1,15 +1,14 @@
 # https://altair-viz.github.io/gallery/us_population_pyramid_over_time.html
-
 import altair as alt
 from vega_datasets import data
 
 source = data.population.url
 
 slider = alt.binding_range(min=1850, max=2000, step=10)
-select_year = alt.selection_single(name='year', fields=['year'],
-                                   bind=slider, init={'year': 2000})
+select_year = alt.selection_point(name='year', fields=['year'],
+                                  bind=slider, value={'year': 2000})
 
-base = alt.Chart(source).add_selection(
+base = alt.Chart(source).add_params(
     select_year
 ).transform_filter(
     select_year

--- a/python/vegafusion/tests/altair_mocks/interactive/cross_highlight/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/cross_highlight/mock.py
@@ -1,12 +1,9 @@
-# https://altair-viz.github.io/gallery/interactive_cross_highlight.html
-# - Selection count legend removed to keep from shifting bar chart
-
 import altair as alt
 from vega_datasets import data
 
 source = data.movies.url
 
-pts = alt.selection(type="single", encodings=['x'])
+pts = alt.selection_point(encodings=['x'])
 
 rect = alt.Chart(data.movies.url).mark_rect().encode(
     alt.X('IMDB_Rating:Q', bin=True),
@@ -15,19 +12,15 @@ rect = alt.Chart(data.movies.url).mark_rect().encode(
               scale=alt.Scale(scheme='greenblue'),
               legend=alt.Legend(title='Total Records')
               )
-).properties(
-    width=500,
-    height=250
 )
 
 circ = rect.mark_point().encode(
     alt.ColorValue('grey'),
-    alt.Size('count()', legend=None)
+    alt.Size('count()',
+             legend=alt.Legend(title='Records in Selection')
+             )
 ).transform_filter(
     pts
-).properties(
-    width=500,
-    height=250
 )
 
 bar = alt.Chart(source).mark_bar().encode(
@@ -35,9 +28,9 @@ bar = alt.Chart(source).mark_bar().encode(
     y='count()',
     color=alt.condition(pts, alt.ColorValue("steelblue"), alt.ColorValue("grey"))
 ).properties(
-    width=500,
-    height=100
-).add_selection(pts)
+    width=550,
+    height=200
+).add_params(pts)
 
 alt.vconcat(
     rect + circ,

--- a/python/vegafusion/tests/altair_mocks/interactive/multiline_highlight/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/multiline_highlight/mock.py
@@ -1,12 +1,10 @@
-# https://altair-viz.github.io/gallery/multiline_highlight.html
-
 import altair as alt
 from vega_datasets import data
 
 source = data.stocks()
 
-highlight = alt.selection(type='single', on='mouseover',
-                          fields=['symbol'], nearest=True)
+highlight = alt.selection_point(on='mouseover',
+                                fields=['symbol'], nearest=True)
 
 base = alt.Chart(source).encode(
     x='date:T',
@@ -16,10 +14,10 @@ base = alt.Chart(source).encode(
 
 points = base.mark_circle().encode(
     opacity=alt.value(0)
-).add_selection(
+).add_params(
     highlight
 ).properties(
-    width=500
+    width=600
 )
 
 lines = base.mark_line().encode(

--- a/python/vegafusion/tests/altair_mocks/interactive/multiline_tooltip/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/multiline_tooltip/mock.py
@@ -1,5 +1,3 @@
-# https://altair-viz.github.io/gallery/multiline_tooltip.html
-
 import altair as alt
 import pandas as pd
 import numpy as np
@@ -10,8 +8,8 @@ source = pd.DataFrame(np.cumsum(np.random.randn(100, 3), 0).round(2),
 source = source.reset_index().melt('x', var_name='category', value_name='y')
 
 # Create a selection that chooses the nearest point & selects based on x-value
-nearest = alt.selection(type='single', nearest=True, on='mouseover',
-                        fields=['x'], empty='none')
+nearest = alt.selection_point(nearest=True, on='mouseover',
+                              fields=['x'], empty=False)
 
 # The basic line
 line = alt.Chart(source).mark_line(interpolate='basis').encode(
@@ -25,7 +23,7 @@ line = alt.Chart(source).mark_line(interpolate='basis').encode(
 selectors = alt.Chart(source).mark_point().encode(
     x='x:Q',
     opacity=alt.value(0),
-).add_selection(
+).add_params(
     nearest
 )
 
@@ -50,5 +48,5 @@ rules = alt.Chart(source).mark_rule(color='gray').encode(
 alt.layer(
     line, selectors, points, rules, text
 ).properties(
-    width=500, height=300
+    width=600, height=300
 )

--- a/python/vegafusion/tests/altair_mocks/interactive/scatter-with_linked_table/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/scatter-with_linked_table/mock.py
@@ -1,19 +1,17 @@
-# https://altair-viz.github.io/gallery/scatter_linked_table.html
-
 import altair as alt
 from vega_datasets import data
 
 source = data.cars()
 
 # Brush for selection
-brush = alt.selection(type='interval')
+brush = alt.selection_interval()
 
 # Scatter Plot
 points = alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Cylinders:O', alt.value('grey'))
-).add_selection(brush)
+).add_params(brush)
 
 # Base chart for data tables
 ranked_text = alt.Chart(source).mark_text().encode(

--- a/python/vegafusion/tests/altair_mocks/interactive/scatter-with_minimap/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/scatter-with_minimap/mock.py
@@ -1,6 +1,3 @@
-# https://altair-viz.github.io/gallery/scatter_with_minimap.html
-# with smaller subplots
-
 import altair as alt
 from vega_datasets import data
 
@@ -10,33 +7,34 @@ zoom = alt.selection_interval(encodings=["x", "y"])
 
 minimap = (
     alt.Chart(source)
-        .mark_point()
-        .add_selection(zoom)
-        .encode(
+    .mark_point()
+    .add_params(zoom)
+    .encode(
         x="date:T",
         y="temp_max:Q",
         color=alt.condition(zoom, "weather", alt.value("lightgray")),
     )
-        .properties(
+    .properties(
         width=200,
         height=200,
         title="Minimap -- click and drag to zoom in the detail view",
     )
-).properties(width=250, height=300)
+)
 
 detail = (
     alt.Chart(source)
-        .mark_point()
-        .encode(
+    .mark_point()
+    .encode(
         x=alt.X(
-            "date:T", scale=alt.Scale(domain={"selection": zoom.name, "encoding": "x"})
+            "date:T", scale=alt.Scale(domain={"param": zoom.name, "encoding": "x"})
         ),
         y=alt.Y(
             "temp_max:Q",
-            scale=alt.Scale(domain={"selection": zoom.name, "encoding": "y"}),
+            scale=alt.Scale(domain={"param": zoom.name, "encoding": "y"}),
         ),
         color="weather",
-    ).properties(width=250, height=300, title="Seattle weather -- detail view")
+    )
+    .properties(width=600, height=400, title="Seattle weather -- detail view")
 )
 
 detail | minimap

--- a/python/vegafusion/tests/altair_mocks/interactive/scatter_with_histogram/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/scatter_with_histogram/mock.py
@@ -1,11 +1,6 @@
-# https://altair-viz.github.io/gallery/scatter_with_histogram.html
-# With smaller subplots and a random seed
-
 import altair as alt
 import pandas as pd
 import numpy as np
-
-np.random.seed(1)
 
 x = np.random.normal(size=100)
 y = np.random.normal(size=100)
@@ -15,7 +10,7 @@ m = np.random.normal(15, 1, size=100)
 source = pd.DataFrame({"x": x, "y":y, "m":m})
 
 # interval selection in the scatter plot
-pts = alt.selection(type="interval", encodings=["x"])
+pts = alt.selection_interval(encodings=["x"])
 
 # left panel: scatter plot
 points = alt.Chart().mark_point(filled=True, color="black").encode(
@@ -24,7 +19,7 @@ points = alt.Chart().mark_point(filled=True, color="black").encode(
 ).transform_filter(
     pts
 ).properties(
-    width=250,
+    width=300,
     height=300
 )
 
@@ -34,9 +29,9 @@ mag = alt.Chart().mark_bar().encode(
     y="count()",
     color=alt.condition(pts, alt.value("black"), alt.value("lightgray"))
 ).properties(
-    width=250,
+    width=300,
     height=300
-).add_selection(pts)
+).add_params(pts)
 
 # build the chart:
 alt.hconcat(

--- a/python/vegafusion/tests/altair_mocks/interactive/scatter_with_layered_histogram/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/scatter_with_layered_histogram/mock.py
@@ -1,26 +1,22 @@
-# https://altair-viz.github.io/gallery/scatter_with_layered_histogram.html
-# With smaller subplots, random seed, and sorting of dataframe for tie-breaker consistency
-#
-
 import altair as alt
 import pandas as pd
 import numpy as np
 
-np.random.seed(1)
-
 # generate fake data
-source = pd.DataFrame({'gender': ['M']*1000 + ['F']*1000,
-                       'height':np.concatenate((np.random.normal(69, 7, 1000),
-                                                np.random.normal(64, 6, 1000))),
-                       'weight': np.concatenate((np.random.normal(195.8, 144, 1000),
-                                                 np.random.normal(167, 100, 1000))),
-                       'age': np.concatenate((np.random.normal(45, 8, 1000),
-                                              np.random.normal(51, 6, 1000)))
-                       })
+source = pd.DataFrame({
+    'gender': ['M']*1000 + ['F']*1000,
+    'height':np.concatenate((
+        np.random.normal(69, 7, 1000), np.random.normal(64, 6, 1000)
+    )),
+    'weight': np.concatenate((
+        np.random.normal(195.8, 144, 1000), np.random.normal(167, 100, 1000)
+    )),
+    'age': np.concatenate((
+        np.random.normal(45, 8, 1000), np.random.normal(51, 6, 1000)
+    ))
+})
 
-source = source.sort_values("gender", ascending=True)
-
-selector = alt.selection_single(empty='all', fields=['gender'])
+selector = alt.selection_point(fields=['gender'])
 
 color_scale = alt.Scale(domain=['M', 'F'],
                         range=['#1FC3AA', '#8624F5'])
@@ -28,28 +24,26 @@ color_scale = alt.Scale(domain=['M', 'F'],
 base = alt.Chart(source).properties(
     width=250,
     height=250
-).add_selection(selector)
+).add_params(selector)
 
 points = base.mark_point(filled=True, size=200).encode(
-    x=alt.X('mean(height):Q',
-            scale=alt.Scale(domain=[0,84])),
-    y=alt.Y('mean(weight):Q',
-            scale=alt.Scale(domain=[0,250])),
-    color=alt.condition(selector,
-                        'gender:N',
-                        alt.value('lightgray'),
-                        scale=color_scale),
+    x=alt.X('mean(height):Q').scale(domain=[0,84]),
+    y=alt.Y('mean(weight):Q').scale(domain=[0,250]),
+    color=alt.condition(
+        selector,
+        'gender:N',
+        alt.value('lightgray'),
+        scale=color_scale),
 )
 
 hists = base.mark_bar(opacity=0.5, thickness=100).encode(
-    x=alt.X('age',
-            bin=alt.Bin(step=5), # step keeps bin size the same
-            scale=alt.Scale(domain=[0,100])),
-    y=alt.Y('count()',
-            stack=None,
-            scale=alt.Scale(domain=[0,350])),
-    color=alt.Color('gender:N',
-                    scale=color_scale)
+    x=alt.X('age')
+    .bin(step=5) # step keeps bin size the same
+    .scale(domain=[0,100]),
+    y=alt.Y('count()')
+    .stack(None)
+    .scale(domain=[0,350]),
+    color=alt.Color('gender:N', scale=color_scale)
 ).transform_filter(
     selector
 )

--- a/python/vegafusion/tests/altair_mocks/interactive/select_mark_area/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/select_mark_area/mock.py
@@ -1,5 +1,3 @@
-# https://altair-viz.github.io/gallery/select_mark_area.html
-
 import altair as alt
 from vega_datasets import data
 
@@ -13,8 +11,8 @@ base = alt.Chart(source).mark_area(
     y='sum(count):Q',
 )
 
-brush = alt.selection_interval(encodings=['x'],empty='all')
-background = base.add_selection(brush)
+brush = alt.selection_interval(encodings=['x'])
+background = base.add_params(brush)
 selected = base.transform_filter(brush).mark_area(color='goldenrod')
 
 background + selected

--- a/python/vegafusion/tests/altair_mocks/interactive/selection_histogram/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/selection_histogram/mock.py
@@ -1,17 +1,15 @@
-# https://altair-viz.github.io/gallery/selection_histogram.html
-
 import altair as alt
 from vega_datasets import data
 
 source = data.cars()
 
-brush = alt.selection(type='interval')
+brush = alt.selection_interval()
 
 points = alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Origin:N', alt.value('lightgray'))
-).add_selection(
+).add_params(
     brush
 )
 

--- a/python/vegafusion/tests/altair_mocks/interactive/selection_layer_bar_month/mock.py
+++ b/python/vegafusion/tests/altair_mocks/interactive/selection_layer_bar_month/mock.py
@@ -1,15 +1,14 @@
-# https://altair-viz.github.io/gallery/selection_layer_bar_month.html
 import altair as alt
 from vega_datasets import data
 
 source = data.seattle_weather()
-brush = alt.selection(type='interval', encodings=['x'])
+brush = alt.selection_interval(encodings=['x'])
 
 bars = alt.Chart().mark_bar().encode(
     x='month(date):O',
     y='mean(precipitation):Q',
     opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),
-).add_selection(
+).add_params(
     brush
 )
 

--- a/python/vegafusion/tests/altair_mocks/scatter/dot_dash_plot/mock.py
+++ b/python/vegafusion/tests/altair_mocks/scatter/dot_dash_plot/mock.py
@@ -1,13 +1,11 @@
-# https://altair-viz.github.io/gallery/dot_dash_plot.html
-
 import altair as alt
 from vega_datasets import data
 
 source = data.cars()
 
 # Configure the options common to all layers
-brush = alt.selection(type='interval')
-base = alt.Chart(source).add_selection(brush)
+brush = alt.selection_interval()
+base = alt.Chart(source).add_params(brush)
 
 # Configure the points
 points = base.mark_point().encode(

--- a/python/vegafusion/vegafusion/evaluation.py
+++ b/python/vegafusion/vegafusion/evaluation.py
@@ -1,57 +1,118 @@
 import json
 
-from altair import data_transformers, Chart, FacetChart
+import altair as alt
+from altair import (
+    data_transformers, Chart, FacetChart, LayerChart, HConcatChart, VConcatChart
+)
 from altair.utils.schemapi import Undefined
 
-MAGIC_MARK_NAME = "_vf_mark"
+MAGIC_MARK_NAME = "_vf_mark{}"
 
 
-def transformed_data(chart: Chart, row_limit=None):
+def make_magic_mark_name(i):
+    return MAGIC_MARK_NAME.format(i)
+
+
+def transformed_data(chart, row_limit=None, exclude=None):
     """
     Evaluate the transform associated with a Chart and return the transformed
     data as a DataFrame
 
-    :param chart: altair Chart object
+    :param chart: altair Chart, LayerChart, HConcatChart or VConcatChart
     :param row_limit: Maximum number of rows to return. None (default) for unlimited
-    :return: pandas DataFrame of transformed data
+    :param exclude: list of mark names to exclude.
+        Not supported for simple (non-compound) Charts
+    :return:
+        - DataFrame of transformed data for Chart input
+        - list of DataFrames for LayerChart, HConcatChart, VConcatChart
     """
 
     from . import runtime, get_local_tz, get_inline_datasets_for_spec, vegalite_compilers
-
-    if not isinstance(chart, (Chart, FacetChart)):
-        raise ValueError(
-            "transformed_data accepts an instance of "
-            "Chart or FacetChart\n"
-            f"Received value of type: {type(chart)}"
-        )
-
-    # Perform shallow copy of chart so that we can change
-    # the name
-    chart = chart.copy(deep=False)
-    chart.name = MAGIC_MARK_NAME
 
     if isinstance(chart, Chart):
         # Add dummy mark if None specified
         if chart.mark == Undefined:
             chart = chart.mark_point()
 
+    # Deep copy chart so that we can rename marks without affecting caller
+    chart = chart.copy(deep=True)
+
+    # Rename leaf chart with magic names
+    magic_names = magic_name_chart(chart, 0, exclude=exclude)
+
+    # Compile to vega and retrieve inline datasets
     with data_transformers.enable("vegafusion-inline"):
         vega_spec = vegalite_compilers.get()(chart.to_json(validate=False))
         inline_datasets = get_inline_datasets_for_spec(vega_spec)
 
-    dataset = get_dataset_for_magic_mark(vega_spec)
-    if dataset is None:
-        raise ValueError("Failed to identify mark for Altair chart")
+    # Build mapping from magic mark names to vega datasets
+    facet_mapping = get_facet_mapping(vega_spec)
+    dataset_mapping = get_datasets_for_magic_marks(vega_spec, magic_names, facet_mapping)
 
-    (data,), warnings = runtime.pre_transform_datasets(
+    # Build a list of vega dataset names that corresponds to the order
+    # of the chart components
+    dataset_names = []
+    for magic_name in magic_names:
+        if magic_name in dataset_mapping:
+            dataset_names.append(dataset_mapping[magic_name])
+        else:
+            raise ValueError("Failed to locate all datasets")
+
+    # Extract transformed datasets
+    datasets, warnings = runtime.pre_transform_datasets(
         vega_spec,
-        [dataset],
+        dataset_names,
         get_local_tz(),
         row_limit=row_limit,
         inline_datasets=inline_datasets
     )
 
-    return data
+    if isinstance(chart, Chart):
+        # Return DataFrame if input was a simple Chart
+        return datasets[0]
+    else:
+        # Otherwise return the list of DataFrames
+        return datasets
+
+
+def magic_name_chart(chart, i=0, exclude=None):
+    """
+    Rename charts (and subcharts) with unique names that we can look up
+    later in the compiled Vega spec
+
+    :param chart: Chart instance
+    :param i: starting name index
+    :return:
+    """
+    exclude = exclude or []
+    if isinstance(chart, (Chart, FacetChart)):
+        # Perform shallow copy of chart so that we can change
+        # the name
+        if chart.name not in exclude:
+            name = make_magic_mark_name(i)
+            chart.name = name
+            return [name]
+        else:
+            return []
+    else:
+        if isinstance(chart, LayerChart):
+            subcharts = chart.layer
+        elif isinstance(chart, HConcatChart):
+            subcharts = chart.hconcat
+        elif isinstance(chart, VConcatChart):
+            subcharts = chart.vconcat
+        else:
+            raise ValueError(
+                "transformed_data accepts an instance of "
+                "Chart, FacetChart, LayerChart, HConcatChart, or VConcatChart\n"
+                f"Received value of type: {type(chart)}"
+            )
+
+        magic_names = []
+        for subchart in subcharts:
+            for name in magic_name_chart(subchart, i=i + len(magic_names), exclude=exclude):
+                magic_names.append(name)
+        return magic_names
 
 
 def get_facet_mapping(vega_spec):
@@ -68,24 +129,25 @@ def get_facet_mapping(vega_spec):
     return facet_mapping
 
 
-def get_dataset_for_magic_mark(vega_spec):
-    facet_mapping = get_facet_mapping(vega_spec)
-    data_name = None
+def get_datasets_for_magic_marks(vega_spec, magic_names, facet_mapping):
+    data_names = {}
+    group_index = 0
     for mark in vega_spec.get("marks", []):
         name = mark.get("name", "")
-        if name.startswith(MAGIC_MARK_NAME) and name.endswith("_marks"):
-            data_name = mark.get("from", {}).get("data", None)
+        if mark.get("type", "") == "group":
+            group_data_names = get_datasets_for_magic_marks(mark, magic_names, facet_mapping)
+            data_names.update(group_data_names)
+            group_index += 1
+        else:
+            for magic_name in magic_names:
+                if name.startswith(magic_name) and name.endswith("_marks"):
+                    data_name = mark.get("from", {}).get("data", None)
+                    data_names[magic_name] = facet_mapping.get(data_name, data_name)
+                    break
 
-        elif mark.get("name", "") == f"{MAGIC_MARK_NAME}_cell":
-            data_name = mark.get("from", {}).get("facet", None).get("data", None)
+                elif mark.get("name", "") == f"{magic_name}_cell":
+                    data_name = mark.get("from", {}).get("facet", None).get("data", None)
+                    data_names[magic_name] = facet_mapping.get(data_name, data_name)
+                    break
 
-        elif mark.get("type", "") == "group":
-            dataset = get_dataset_for_magic_mark(mark)
-            if dataset is not None:
-                data_name = dataset
-
-    if data_name is not None:
-        return facet_mapping.get(data_name, data_name)
-    else:
-        return None
-
+    return data_names

--- a/python/vegafusion/vegafusion/evaluation.py
+++ b/python/vegafusion/vegafusion/evaluation.py
@@ -1,8 +1,5 @@
-import json
-
-import altair as alt
 from altair import (
-    data_transformers, Chart, FacetChart, LayerChart, HConcatChart, VConcatChart
+    data_transformers, Chart, FacetChart, LayerChart, HConcatChart, VConcatChart, ConcatChart
 )
 from altair.utils.schemapi import Undefined
 
@@ -16,15 +13,14 @@ def make_magic_mark_name(i):
 def transformed_data(chart, row_limit=None, exclude=None):
     """
     Evaluate the transform associated with a Chart and return the transformed
-    data as a DataFrame
+    data as one or more DataFrames
 
-    :param chart: altair Chart, LayerChart, HConcatChart or VConcatChart
+    :param chart: altair Chart, LayerChart, HConcatChart, VConcatChart, or ConcatChart
     :param row_limit: Maximum number of rows to return. None (default) for unlimited
     :param exclude: list of mark names to exclude.
-        Not supported for simple (non-compound) Charts
     :return:
         - DataFrame of transformed data for Chart input
-        - list of DataFrames for LayerChart, HConcatChart, VConcatChart
+        - list of DataFrames for LayerChart, HConcatChart, VConcatChart, ConcatChart
     """
 
     from . import runtime, get_local_tz, get_inline_datasets_for_spec, vegalite_compilers
@@ -38,23 +34,23 @@ def transformed_data(chart, row_limit=None, exclude=None):
     chart = chart.copy(deep=True)
 
     # Rename leaf chart with magic names
-    magic_names = magic_name_chart(chart, 0, exclude=exclude)
+    chart_names = name_chart(chart, 0, exclude=exclude)
 
     # Compile to vega and retrieve inline datasets
     with data_transformers.enable("vegafusion-inline"):
         vega_spec = vegalite_compilers.get()(chart.to_json(validate=False))
         inline_datasets = get_inline_datasets_for_spec(vega_spec)
 
-    # Build mapping from magic mark names to vega datasets
+    # Build mapping from mark names to vega datasets
     facet_mapping = get_facet_mapping(vega_spec)
-    dataset_mapping = get_datasets_for_magic_marks(vega_spec, magic_names, facet_mapping)
+    dataset_mapping = get_datasets_for_named_marks(vega_spec, chart_names, facet_mapping)
 
     # Build a list of vega dataset names that corresponds to the order
     # of the chart components
     dataset_names = []
-    for magic_name in magic_names:
-        if magic_name in dataset_mapping:
-            dataset_names.append(dataset_mapping[magic_name])
+    for chart_name in chart_names:
+        if chart_name in dataset_mapping:
+            dataset_names.append(dataset_mapping[chart_name])
         else:
             raise ValueError("Failed to locate all datasets")
 
@@ -67,15 +63,18 @@ def transformed_data(chart, row_limit=None, exclude=None):
         inline_datasets=inline_datasets
     )
 
-    if isinstance(chart, Chart):
-        # Return DataFrame if input was a simple Chart
-        return datasets[0]
+    if isinstance(chart, (Chart, FacetChart)):
+        # Return DataFrame (or None if it was excluded) if input was a simple Chart
+        if not datasets:
+            return None
+        else:
+            return datasets[0]
     else:
         # Otherwise return the list of DataFrames
         return datasets
 
 
-def magic_name_chart(chart, i=0, exclude=None):
+def name_chart(chart, i=0, exclude=None):
     """
     Rename charts (and subcharts) with unique names that we can look up
     later in the compiled Vega spec
@@ -89,9 +88,10 @@ def magic_name_chart(chart, i=0, exclude=None):
         # Perform shallow copy of chart so that we can change
         # the name
         if chart.name not in exclude:
-            name = make_magic_mark_name(i)
-            chart.name = name
-            return [name]
+            if chart.name in (None, Undefined):
+                name = make_magic_mark_name(i)
+                chart.name = name
+            return [chart.name]
         else:
             return []
     else:
@@ -101,53 +101,124 @@ def magic_name_chart(chart, i=0, exclude=None):
             subcharts = chart.hconcat
         elif isinstance(chart, VConcatChart):
             subcharts = chart.vconcat
+        elif isinstance(chart, ConcatChart):
+            subcharts = chart.concat
         else:
             raise ValueError(
                 "transformed_data accepts an instance of "
-                "Chart, FacetChart, LayerChart, HConcatChart, or VConcatChart\n"
+                "Chart, FacetChart, LayerChart, HConcatChart, VConcatChart, or ConcatChart\n"
                 f"Received value of type: {type(chart)}"
             )
 
-        magic_names = []
+        chart_names = []
         for subchart in subcharts:
-            for name in magic_name_chart(subchart, i=i + len(magic_names), exclude=exclude):
-                magic_names.append(name)
-        return magic_names
+            for name in name_chart(subchart, i=i + len(chart_names), exclude=exclude):
+                chart_names.append(name)
+        return chart_names
 
 
-def get_facet_mapping(vega_spec):
+def get_facet_mapping(vega_spec, scope=()):
     facet_mapping = {}
-    for mark in vega_spec.get("marks", []):
+    group_index = 0
+    mark_group = get_mark_group_for_scope(vega_spec, scope) or {}
+    for mark in mark_group.get("marks", []):
         if mark.get("type", None) == "group":
+            # Get facet for this group
+            group_scope = scope + (group_index,)
             facet = mark.get("from", {}).get("facet", None)
             if facet is not None:
                 facet_name = facet.get("name", None)
                 facet_data = facet.get("data", None)
                 if facet_name is not None and facet_data is not None:
-                    facet_mapping[facet_name] = facet_data
+                    scoped_facet_data = get_scoped_data_reference(vega_spec, facet_data, scope)
+                    if scoped_facet_data is not None:
+                        facet_mapping[(facet_name, group_scope)] = scoped_facet_data
+
+            # Handle children recursively
+            child_mapping = get_facet_mapping(vega_spec, scope=group_scope)
+            facet_mapping.update(child_mapping)
+            group_index += 1
 
     return facet_mapping
 
 
-def get_datasets_for_magic_marks(vega_spec, magic_names, facet_mapping):
-    data_names = {}
+def get_datasets_for_named_marks(vega_spec, magic_names, facet_mapping, scope=()):
+    datasets = {}
     group_index = 0
-    for mark in vega_spec.get("marks", []):
+    mark_group = get_mark_group_for_scope(vega_spec, scope) or {}
+    for mark in mark_group.get("marks", []):
+        for magic_name in magic_names:
+            if mark.get("name", "") == f"{magic_name}_cell":
+                data_name = mark.get("from", {}).get("facet", None).get("data", None)
+                scoped_data_name = (data_name, scope)
+                datasets[magic_name] = get_from_facet_mapping(scoped_data_name, facet_mapping)
+                break
+
         name = mark.get("name", "")
         if mark.get("type", "") == "group":
-            group_data_names = get_datasets_for_magic_marks(mark, magic_names, facet_mapping)
-            data_names.update(group_data_names)
+            group_data_names = get_datasets_for_named_marks(
+                vega_spec, magic_names, facet_mapping, scope=scope + (group_index,)
+            )
+            for k, v in group_data_names.items():
+                datasets.setdefault(k, v)
             group_index += 1
         else:
             for magic_name in magic_names:
                 if name.startswith(magic_name) and name.endswith("_marks"):
                     data_name = mark.get("from", {}).get("data", None)
-                    data_names[magic_name] = facet_mapping.get(data_name, data_name)
-                    break
+                    scoped_data_name = get_scoped_data_reference(vega_spec, data_name, scope)
+                    if scoped_data_name is not None:
+                        datasets[magic_name] = get_from_facet_mapping(scoped_data_name, facet_mapping)
+                        break
 
-                elif mark.get("name", "") == f"{magic_name}_cell":
-                    data_name = mark.get("from", {}).get("facet", None).get("data", None)
-                    data_names[magic_name] = facet_mapping.get(data_name, data_name)
-                    break
+    return datasets
 
-    return data_names
+
+def get_from_facet_mapping(data_name, facet_mapping):
+    while data_name in facet_mapping:
+        data_name = facet_mapping[data_name]
+    return data_name
+
+
+def get_mark_group_for_scope(vega_spec, scope):
+    group = vega_spec
+
+    # Find group at scope
+    for scope_value in scope:
+        group_index = 0
+        child_group = None
+        for mark in group.get("marks", []):
+            if mark.get("type") == "group":
+                if group_index == scope_value:
+                    child_group = mark
+                    break
+                group_index += 1
+        if child_group is None:
+            return None
+        group = child_group
+
+    return group
+
+
+def get_datasets_for_scope(vega_spec, scope):
+    group = get_mark_group_for_scope(vega_spec, scope) or {}
+
+    # get datasets from group
+    datasets = []
+    for dataset in group.get("data", []):
+        datasets.append(dataset["name"])
+
+    # Add facet dataset
+    facet_dataset = group.get("from", {}).get("facet", {}).get("name", None)
+    if facet_dataset:
+        datasets.append(facet_dataset)
+    return datasets
+
+
+def get_scoped_data_reference(vega_spec, data_name, usage_scope):
+    for i in reversed(range(len(usage_scope) + 1)):
+        scope = usage_scope[:i]
+        datasets = get_datasets_for_scope(vega_spec, scope) or []
+        if data_name in datasets:
+            return (data_name, scope)
+    return None


### PR DESCRIPTION
Closes #307

Extends the `transformed_data` function to support extract transformed datasets from compound charts. In this case, a list of DataFrames is returned, one for each non-excluded subchart.

Logic is tested against all of the compound charts in the chart mock library.