### PR TITLE
Update VegaFusionWidget's Vega deps to match Altair 5.0.0

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -401,7 +401,7 @@ jobs:
           python -m pip install vl-convert-python
       - name: Update to latest Altair 5
         run: |
-          pip install --pre -U altair
+          pip install -U altair
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/python/vegafusion-jupyter/package-lock.json
+++ b/python/vegafusion-jupyter/package-lock.json
@@ -6,15 +6,15 @@
   "packages": {
     "": {
       "name": "vegafusion-jupyter",
-      "version": "1.2.0",
+      "version": "1.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^4 || ^5 || ^6",
         "@jupyterlab/notebook": "^3 || ^4",
         "marked": "^4.0.10",
-        "vega": "^5.24.0",
-        "vega-lite": "^5.6.1",
-        "vega-themes": "^2.12.0",
+        "vega": "^5.25.0",
+        "vega-lite": "^5.8.0",
+        "vega-themes": "^2.13.0",
         "vegafusion-embed": "../../javascript/vegafusion-embed",
         "vegafusion-wasm": "../../vegafusion-wasm/pkg"
       },
@@ -53,7 +53,7 @@
       }
     },
     "../../javascript/vegafusion-embed": {
-      "version": "1.2.0",
+      "version": "1.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -63,6 +63,7 @@
       "devDependencies": {
         "@babel/core": "^7.5.0",
         "@babel/preset-env": "^7.5.0",
+        "@types/node": "17.0.21",
         "@typescript-eslint/eslint-plugin": "^3.6.0",
         "@typescript-eslint/parser": "^3.6.0",
         "acorn": "^7.2.0",
@@ -86,7 +87,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.2.0",
+      "version": "1.2.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",
@@ -8118,7 +8119,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -9810,7 +9811,7 @@
         "node": ">=14"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -14046,33 +14047,33 @@
       "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "node_modules/vega": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
-      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.25.0.tgz",
+      "integrity": "sha512-lr+uj0mhYlSN3JOKbMNp1RzZBenWp9DxJ7kR3lha58AFNCzzds7pmFa7yXPbtbaGhB7Buh/t6n+Bzk3Y0VnF5g==",
       "dependencies": {
         "vega-crossfilter": "~4.1.1",
         "vega-dataflow": "~5.7.5",
-        "vega-encode": "~4.9.1",
+        "vega-encode": "~4.9.2",
         "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.0.1",
+        "vega-expression": "~5.1.0",
         "vega-force": "~4.2.0",
         "vega-format": "~1.1.1",
-        "vega-functions": "~5.13.1",
+        "vega-functions": "~5.13.2",
         "vega-geo": "~4.4.1",
         "vega-hierarchy": "~4.1.1",
         "vega-label": "~1.2.1",
         "vega-loader": "~4.5.1",
         "vega-parser": "~6.2.0",
         "vega-projection": "~1.6.0",
-        "vega-regression": "~1.1.1",
+        "vega-regression": "~1.2.0",
         "vega-runtime": "~6.1.4",
         "vega-scale": "~7.3.0",
         "vega-scenegraph": "~4.10.2",
-        "vega-statistics": "~1.8.1",
+        "vega-statistics": "~1.9.0",
         "vega-time": "~2.1.1",
-        "vega-transforms": "~4.10.1",
+        "vega-transforms": "~4.10.2",
         "vega-typings": "~0.24.0",
-        "vega-util": "~1.17.1",
+        "vega-util": "~1.17.2",
         "vega-view": "~5.11.1",
         "vega-view-transforms": "~4.5.9",
         "vega-voronoi": "~4.2.1",
@@ -14105,9 +14106,9 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
-      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.2.tgz",
+      "integrity": "sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
@@ -14122,9 +14123,9 @@
       "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "node_modules/vega-expression": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
-      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.1"
@@ -14158,15 +14159,15 @@
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
-      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.2.tgz",
+      "integrity": "sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
         "d3-geo": "^3.1.0",
         "vega-dataflow": "^5.7.5",
-        "vega-expression": "^5.0.1",
+        "vega-expression": "^5.1.0",
         "vega-scale": "^7.3.0",
         "vega-scenegraph": "^4.10.2",
         "vega-selections": "^5.4.1",
@@ -14212,9 +14213,9 @@
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
-      "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.0.tgz",
+      "integrity": "sha512-VA3XDlF6nd/t46KDMfq8eNKOJKy9gpJuM+6CIl3jbWqS97jWXRWXp8DpUyDmbV+iq8n4hqNTaoPqDP/e03kifw==",
       "dependencies": {
         "@types/clone": "~2.1.1",
         "clone": "~2.1.2",
@@ -14222,10 +14223,10 @@
         "fast-json-stable-stringify": "~2.1.0",
         "json-stringify-pretty-compact": "~3.0.0",
         "tslib": "~2.5.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-util": "~1.17.0",
-        "yargs": "~17.6.2"
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-util": "~1.17.2",
+        "yargs": "~17.7.1"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -14234,10 +14235,10 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "vega": "^5.22.0"
+        "vega": "^5.24.0"
       }
     },
     "node_modules/vega-lite/node_modules/ansi-styles": {
@@ -14313,9 +14314,9 @@
       }
     },
     "node_modules/vega-lite/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -14372,13 +14373,13 @@
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
-      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.2.0.tgz",
+      "integrity": "sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
-        "vega-statistics": "^1.7.9",
+        "vega-statistics": "^1.9.0",
         "vega-util": "^1.15.2"
       }
     },
@@ -14427,17 +14428,17 @@
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
-      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "dependencies": {
         "d3-array": "^3.2.2"
       }
     },
     "node_modules/vega-themes": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.12.0.tgz",
-      "integrity": "sha512-gHNYCzDgexSQDmGzQsxH57OYgFVbAOmvhIYN3MPOvVucyI+zhbUawBVIVNzG9ftucRp0MaaMVXi6ctC5HLnBsg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.13.0.tgz",
+      "integrity": "sha512-SVr/YDqGhkVDO2bRS62TeGyr1dVuXaNLJNCu42b1tbcnnmX2m9cyaq8G6gcputPeibArvHT1MsTF7MUzboOIWg==",
       "peerDependencies": {
         "vega": "*",
         "vega-lite": "*"
@@ -14454,9 +14455,9 @@
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
-      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.2.tgz",
+      "integrity": "sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.5",
@@ -14477,9 +14478,9 @@
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
-      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
     },
     "node_modules/vega-view": {
       "version": "5.11.1",
@@ -15155,7 +15156,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15173,7 +15174,7 @@
         "lib0": "^0.2.31"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "peerDependencies": {
@@ -15188,7 +15189,7 @@
         "lib0": "^0.2.42"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -15206,7 +15207,7 @@
         "y-websocket-server": "bin/server.js"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       },
       "optionalDependencies": {
@@ -15290,7 +15291,7 @@
         "lib0": "^0.2.49"
       },
       "funding": {
-        "type": "GitHub Sponsors \u2764",
+        "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
       }
     },
@@ -26042,33 +26043,33 @@
       "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "vega": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
-      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.25.0.tgz",
+      "integrity": "sha512-lr+uj0mhYlSN3JOKbMNp1RzZBenWp9DxJ7kR3lha58AFNCzzds7pmFa7yXPbtbaGhB7Buh/t6n+Bzk3Y0VnF5g==",
       "requires": {
         "vega-crossfilter": "~4.1.1",
         "vega-dataflow": "~5.7.5",
-        "vega-encode": "~4.9.1",
+        "vega-encode": "~4.9.2",
         "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.0.1",
+        "vega-expression": "~5.1.0",
         "vega-force": "~4.2.0",
         "vega-format": "~1.1.1",
-        "vega-functions": "~5.13.1",
+        "vega-functions": "~5.13.2",
         "vega-geo": "~4.4.1",
         "vega-hierarchy": "~4.1.1",
         "vega-label": "~1.2.1",
         "vega-loader": "~4.5.1",
         "vega-parser": "~6.2.0",
         "vega-projection": "~1.6.0",
-        "vega-regression": "~1.1.1",
+        "vega-regression": "~1.2.0",
         "vega-runtime": "~6.1.4",
         "vega-scale": "~7.3.0",
         "vega-scenegraph": "~4.10.2",
-        "vega-statistics": "~1.8.1",
+        "vega-statistics": "~1.9.0",
         "vega-time": "~2.1.1",
-        "vega-transforms": "~4.10.1",
+        "vega-transforms": "~4.10.2",
         "vega-typings": "~0.24.0",
-        "vega-util": "~1.17.1",
+        "vega-util": "~1.17.2",
         "vega-view": "~5.11.1",
         "vega-view-transforms": "~4.5.9",
         "vega-voronoi": "~4.2.1",
@@ -26101,9 +26102,9 @@
       }
     },
     "vega-encode": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
-      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.2.tgz",
+      "integrity": "sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==",
       "requires": {
         "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
@@ -26118,9 +26119,9 @@
       "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "vega-expression": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
-      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
       "requires": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.1"
@@ -26156,15 +26157,15 @@
       }
     },
     "vega-functions": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
-      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.2.tgz",
+      "integrity": "sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==",
       "requires": {
         "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
         "d3-geo": "^3.1.0",
         "vega-dataflow": "^5.7.5",
-        "vega-expression": "^5.0.1",
+        "vega-expression": "^5.1.0",
         "vega-scale": "^7.3.0",
         "vega-scenegraph": "^4.10.2",
         "vega-selections": "^5.4.1",
@@ -26210,9 +26211,9 @@
       }
     },
     "vega-lite": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
-      "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.0.tgz",
+      "integrity": "sha512-VA3XDlF6nd/t46KDMfq8eNKOJKy9gpJuM+6CIl3jbWqS97jWXRWXp8DpUyDmbV+iq8n4hqNTaoPqDP/e03kifw==",
       "requires": {
         "@types/clone": "~2.1.1",
         "clone": "~2.1.2",
@@ -26220,10 +26221,10 @@
         "fast-json-stable-stringify": "~2.1.0",
         "json-stringify-pretty-compact": "~3.0.0",
         "tslib": "~2.5.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-util": "~1.17.0",
-        "yargs": "~17.6.2"
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-util": "~1.17.2",
+        "yargs": "~17.7.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -26278,9 +26279,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -26333,13 +26334,13 @@
       }
     },
     "vega-regression": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
-      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.2.0.tgz",
+      "integrity": "sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==",
       "requires": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
-        "vega-statistics": "^1.7.9",
+        "vega-statistics": "^1.9.0",
         "vega-util": "^1.15.2"
       }
     },
@@ -26388,17 +26389,17 @@
       }
     },
     "vega-statistics": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
-      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "requires": {
         "d3-array": "^3.2.2"
       }
     },
     "vega-themes": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.12.0.tgz",
-      "integrity": "sha512-gHNYCzDgexSQDmGzQsxH57OYgFVbAOmvhIYN3MPOvVucyI+zhbUawBVIVNzG9ftucRp0MaaMVXi6ctC5HLnBsg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.13.0.tgz",
+      "integrity": "sha512-SVr/YDqGhkVDO2bRS62TeGyr1dVuXaNLJNCu42b1tbcnnmX2m9cyaq8G6gcputPeibArvHT1MsTF7MUzboOIWg==",
       "requires": {}
     },
     "vega-time": {
@@ -26412,9 +26413,9 @@
       }
     },
     "vega-transforms": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
-      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.2.tgz",
+      "integrity": "sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==",
       "requires": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.5",
@@ -26435,9 +26436,9 @@
       }
     },
     "vega-util": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
-      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
     },
     "vega-view": {
       "version": "5.11.1",
@@ -26491,6 +26492,7 @@
       "requires": {
         "@babel/core": "^7.5.0",
         "@babel/preset-env": "^7.5.0",
+        "@types/node": "17.0.21",
         "@typescript-eslint/eslint-plugin": "^3.6.0",
         "@typescript-eslint/parser": "^3.6.0",
         "acorn": "^7.2.0",

--- a/python/vegafusion-jupyter/package.json
+++ b/python/vegafusion-jupyter/package.json
@@ -56,9 +56,9 @@
     "@jupyter-widgets/base": "^4 || ^5 || ^6",
     "@jupyterlab/notebook": "^3 || ^4",
     "marked": "^4.0.10",
-    "vega": "^5.24.0",
-    "vega-lite": "^5.6.1",
-    "vega-themes": "^2.12.0",
+    "vega": "^5.25.0",
+    "vega-lite": "^5.8.0",
+    "vega-themes": "^2.13.0",
     "vegafusion-embed": "../../javascript/vegafusion-embed",
     "vegafusion-wasm": "../../vegafusion-wasm/pkg"
   },


### PR DESCRIPTION
Update vega dependency versions to match Altair 5.0.0
 - vega to 0.25.0
 - vega-lite to 5.8.0
 - vega-embed to 2.13.0
