### PR TITLE
Java API updates

### DIFF
--- a/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
+++ b/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
@@ -177,7 +177,7 @@ public class VegaFusionRuntime {
      * @throws IllegalStateException if the destroy method was called previously
      */
     public String patchPreTransformedSpec(String spec1, String preTransformedSpec1, String spec2) {
-        validatePtr();
+        validate();
         return innerPatchPreTransformedSpec(spec1, preTransformedSpec1, spec2);
     }
 
@@ -197,7 +197,7 @@ public class VegaFusionRuntime {
      * @throws IllegalStateException if the destroy method was called previously
      */
     public String preTransformSpec(String spec, String localTz, String defaultInputTz, int rowLimit, boolean preserveInteractivity) {
-        validatePtr();
+        validate();
         return innerPreTransformSpec(state_ptr, spec, localTz, defaultInputTz, rowLimit, preserveInteractivity);
     }
 
@@ -205,18 +205,18 @@ public class VegaFusionRuntime {
      * Checks if the VegaFusionRuntime state is valid
      * (if the destroy method was not called previously)
      *
-     * @return A boolean indicating whether the state is valid.
+     * @return A boolean indicating whether the runtime is valid.
      */
-    public boolean valid() {
+    public boolean isValid() {
         return state_ptr != 0;
     }
 
     /**
-     * Validates the pointer to the native VegaFusionRuntime
+     * Validates the native VegaFusionRuntime
      *
-     * @throws IllegalStateException If the VegaFusionRuntime pointer is invalid.
+     * @throws IllegalStateException If the native VegaFusionRuntime is invalid.
      */
-    private void validatePtr() throws IllegalStateException {
+    public void validate() throws IllegalStateException {
         if (state_ptr == 0) {
             throw new IllegalStateException("VegaFusionRuntime may not be used after calling destroy()");
         }

--- a/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
+++ b/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
@@ -63,9 +63,10 @@ public class VegaFusionRuntime {
      *                 If zero then no limit is imposed.
      * @param preserveInteractivity Whether to preserve interactivity in the resulting
      *                              Vega specification
-     * @return A PreTransformSpecResult containing the transformed specification and any warnings.
+     * @return String containing the transformed specification.
+               Any warnings are added to the spec under usermeta.vegafusion_warnings
      */
-    private static native PreTransformSpecResult innerPreTransformSpec(
+    private static native String innerPreTransformSpec(
             long pointer, String spec, String localTz, String defaultInputTz, int rowLimit, boolean preserveInteractivity
     );
 
@@ -181,11 +182,6 @@ public class VegaFusionRuntime {
     }
 
     /**
-     * This class encapsulates the results of the preTransformSpec method
-     */
-    record PreTransformSpecResult(String preTransformedSpec, String preTransformWarnings) {}
-
-    /**
      * Evaluate the transforms in a Vega specification, returning a new
      * specification with transformed data included inline.
      *
@@ -196,10 +192,11 @@ public class VegaFusionRuntime {
      *                 If zero then no limit is imposed.
      * @param preserveInteractivity Whether to preserve interactivity in the resulting
      *                              Vega specification
-     * @return A PreTransformSpecResult containing the transformed specification and any warnings.
+     * @return String containing the transformed specification.
+               Any warnings are added to the spec under usermeta.vegafusion_warnings.
      * @throws IllegalStateException if the destroy method was called previously
      */
-    public PreTransformSpecResult preTransformSpec(String spec, String localTz, String defaultInputTz, int rowLimit, boolean preserveInteractivity) {
+    public String preTransformSpec(String spec, String localTz, String defaultInputTz, int rowLimit, boolean preserveInteractivity) {
         validatePtr();
         return innerPreTransformSpec(state_ptr, spec, localTz, defaultInputTz, rowLimit, preserveInteractivity);
     }

--- a/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
+++ b/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
@@ -30,15 +30,15 @@ public class VegaFusionRuntimeTest {
     @Test
     void testCreate() {
         VegaFusionRuntime runtime = makeRuntime();
-        assertTrue(runtime.valid());
+        assertTrue(runtime.isValid());
 
         // Destroy should invalidate
         runtime.destroy();
-        assertFalse(runtime.valid());
+        assertFalse(runtime.isValid());
 
         // Destroy should be idempotent
         runtime.destroy();
-        assertFalse(runtime.valid());
+        assertFalse(runtime.isValid());
     }
 
     @Test

--- a/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
+++ b/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
@@ -2,6 +2,7 @@ package io.vegafusion;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.List;
 
@@ -141,20 +142,30 @@ public class VegaFusionRuntimeTest {
         String spec = histSpec();
 
         // Pre-transform spec with rowLimit of 3 so that inline data is truncated
-        VegaFusionRuntime.PreTransformSpecResult preTransformedSpecResult = runtime.preTransformSpec(
+        String preTransformedSpecResult = runtime.preTransformSpec(
                 spec, "UTC", null, 3, true
         );
 
-        // Check that resulting spec is reasonable
-        String preTransformedSpec = preTransformedSpecResult.preTransformedSpec();
-        assertTrue(preTransformedSpec.startsWith("{\"$schema\":\"https://vega.github.io/schema/vega/v5.json\""));
-
-        // Parse warnings as JSON
-        String preTransformedSpecWarnings = preTransformedSpecResult.preTransformWarnings();
+        // Parse spec as JSON
         ObjectMapper mapper = new ObjectMapper();
-        List<Map<String, JsonNode>> warningList = mapper.readValue(
-                preTransformedSpecWarnings, new TypeReference<>(){}
+        Map<String, JsonNode> preTransformedSpec = mapper.readValue(
+                preTransformedSpecResult, new TypeReference<>(){}
         );
+
+        assertEquals(
+                preTransformedSpec.get("$schema").asText(),
+                "https://vega.github.io/schema/vega/v5.json"
+        );
+
+        // Collect list of warnings
+        JsonNode usermetaNode = preTransformedSpec.get("usermeta");
+        JsonNode vegafusionWarningsNode = usermetaNode.get("vegafusion_warnings");
+        assertTrue(vegafusionWarningsNode.isArray());
+        List<JsonNode> warningList = new ArrayList<>();
+        var elements = vegafusionWarningsNode.elements();
+        while (elements.hasNext()) {
+            warningList.add(elements.next());
+        }
 
         // We should have 1 RowLimitExceeded warning
         assertEquals(warningList.size(), 1);

--- a/vegafusion-core/src/spec/chart.rs
+++ b/vegafusion-core/src/spec/chart.rs
@@ -40,6 +40,9 @@ pub struct ChartSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<TitleSpec>,
 
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub usermeta: HashMap<String, Value>,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }

--- a/vegafusion-jni/src/lib.rs
+++ b/vegafusion-jni/src/lib.rs
@@ -263,7 +263,7 @@ unsafe fn inner_pre_transform_spec(pointer: jlong, args: PreTransformSpecArgs) -
     // Add warnings to usermeta
     pre_transformed_spec.usermeta.insert(
         "vegafusion_warnings".to_string(),
-        serde_json::to_value(&warnings)?,
+        serde_json::to_value(warnings)?,
     );
 
     let pre_transformed_spec = serde_json::to_string(&pre_transformed_spec)?;


### PR DESCRIPTION
A few updates to the new Java API for the first release.
 - preTransformSpec now returns a string containing the new Vega spec with the warnings included under `usermeta.vegafusion_warnings`.
 - `valid` renamed to `isValid`
 - `validate` exposed as a public method