### PR TITLE
Build JNI libs on Ubuntu 20.04 for older GLIBC

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize]
 jobs:
   build-test-java-linux64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -158,7 +158,7 @@ jobs:
             native
 
   build-jar:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build-test-java-linux64
       - build-test-java-osx64
@@ -194,7 +194,7 @@ jobs:
     strategy:
       matrix:
         os:
-         - ubuntu-latest
+         - ubuntu-20.04
          - macos-11
          - windows-2022
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Previously, the JNI libs were being built with GitHub Actions `ubuntu-latest` which is currently Ubuntu `22.04`. This results in a GLIB_C requirement of `2.35` so the shared libs won't work on older Ubuntu versions. This drops the required GLIBC version to `2.31`

This PR downgrades the linux CI images to 20.04 for improved compatibility.