### PR TITLE
Add Java arg for number of worker threads

### DIFF
--- a/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
+++ b/java/lib/src/main/java/io/vegafusion/VegaFusionRuntime.java
@@ -24,9 +24,10 @@ public class VegaFusionRuntime {
      *
      * @param capacity The capacity of the runtime cache
      * @param memoryLimit The memory limit for the runtime cache
+     * @param numThreads The number of worker threads
      * @return A long representing a pointer to the native runtime.
      */
-    private static native long innerCreate(long capacity, long memoryLimit);
+    private static native long innerCreate(long capacity, long memoryLimit, int numThreads);
 
     /**
      * Destroys a native VegaFusionRuntime object.
@@ -150,9 +151,10 @@ public class VegaFusionRuntime {
      *
      * @param capacity The cache capacity (in number of cache entries)
      * @param memoryLimit The cache memory limit (in bytes)
+     * @param numThreads The number of worker threads
      */
-    public VegaFusionRuntime(long capacity, long memoryLimit) {
-        state_ptr = VegaFusionRuntime.innerCreate(capacity, memoryLimit);
+    public VegaFusionRuntime(long capacity, long memoryLimit, int numThreads) {
+        state_ptr = VegaFusionRuntime.innerCreate(capacity, memoryLimit, numThreads);
     }
 
     /**

--- a/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
+++ b/java/lib/src/test/java/io/vegafusion/VegaFusionRuntimeTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class VegaFusionRuntimeTest {
     private VegaFusionRuntime makeRuntime() {
-        return new VegaFusionRuntime(32, 1000000000);
+        return new VegaFusionRuntime(32, 1000000000, 4);
     }
 
     @Test

--- a/vegafusion-jni/src/lib.rs
+++ b/vegafusion-jni/src/lib.rs
@@ -52,8 +52,9 @@ pub extern "system" fn Java_io_vegafusion_VegaFusionRuntime_innerCreate<'local>(
     _class: JClass<'local>,
     capacity: jlong,
     memory_limit: jlong,
+    num_threads: jint,
 ) -> jlong {
-    let result = panic::catch_unwind(|| inner_create(capacity, memory_limit));
+    let result = panic::catch_unwind(|| inner_create(capacity, memory_limit, num_threads));
 
     match result {
         Ok(Ok(state)) => Box::into_raw(Box::new(state)) as jlong,
@@ -68,7 +69,11 @@ pub extern "system" fn Java_io_vegafusion_VegaFusionRuntime_innerCreate<'local>(
     }
 }
 
-fn inner_create(capacity: jlong, memory_limit: jlong) -> Result<VegaFusionRuntimeState> {
+fn inner_create(
+    capacity: jlong,
+    memory_limit: jlong,
+    num_threads: jint,
+) -> Result<VegaFusionRuntimeState> {
     // Use DataFusion connection and multi-threaded tokio runtime
     let conn = Arc::new(DataFusionConnection::default()) as Arc<dyn Connection>;
     let capacity = if capacity < 1 {
@@ -86,7 +91,7 @@ fn inner_create(capacity: jlong, memory_limit: jlong) -> Result<VegaFusionRuntim
     // Build tokio runtime
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
-    let worker_threads = 4;
+    let worker_threads = num_threads as i32;
     builder.worker_threads(worker_threads.max(1) as usize);
     let tokio_runtime = builder.build()?;
 

--- a/vegafusion-jni/src/lib.rs
+++ b/vegafusion-jni/src/lib.rs
@@ -91,8 +91,7 @@ fn inner_create(
     // Build tokio runtime
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
-    let worker_threads = num_threads as i32;
-    builder.worker_threads(worker_threads.max(1) as usize);
+    builder.worker_threads(num_threads.max(1) as usize);
     let tokio_runtime = builder.build()?;
 
     Ok(VegaFusionRuntimeState {


### PR DESCRIPTION
Add `numThreads` argument to the VegaFusionRuntime Java constructor. This controls the number of threads in the embedded tokio runtime.