### PR TITLE
Add q1 and q3 aggregations

### DIFF
--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -84,6 +84,7 @@ def get_connections():
         ("line/with_points", 100, ["x", "f(x)"]),
         ("other/beckers_barley_wrapped_facet", 120, ["variety", "site", "median_yield"]),
         ("other/binned_heatmap", 378, ["__count", "bin_maxbins_60_IMDB_Rating_end"]),
+        ("other/boxplot", 19, ["age", "mid_box_people"]),
         ("other/comet_chart", 120, ["variety", "1932", "delta"]),
         ("other/gantt_chart", 3, ["task", "start", "end"]),
         ("other/hexbins", 84, ["month_date", "xFeaturePos", "mean_temp_max"]),

--- a/vegafusion-core/src/spec/transform/aggregate.rs
+++ b/vegafusion-core/src/spec/transform/aggregate.rs
@@ -94,6 +94,8 @@ impl TransformSpecTrait for AggregateTransformSpec {
                     | Stdev
                     | Stdevp
                     | Median
+                    | Q1
+                    | Q3
             ) {
                 // Unsupported aggregation op
                 return false;

--- a/vegafusion-core/src/spec/transform/joinaggregate.rs
+++ b/vegafusion-core/src/spec/transform/joinaggregate.rs
@@ -45,6 +45,8 @@ impl TransformSpecTrait for JoinAggregateTransformSpec {
                     | Stdev
                     | Stdevp
                     | Median
+                    | Q1
+                    | Q3
             ) {
                 // Unsupported aggregation op
                 return false;

--- a/vegafusion-core/src/spec/transform/window.rs
+++ b/vegafusion-core/src/spec/transform/window.rs
@@ -100,6 +100,8 @@ impl TransformSpecTrait for WindowTransformSpec {
                             | Variancep
                             | Stdev
                             | Stdevp
+                            | Q1
+                            | Q3
                     ) {
                         // Unsupported aggregation op
                         return false;

--- a/vegafusion-core/src/transform/aggregate.rs
+++ b/vegafusion-core/src/transform/aggregate.rs
@@ -1,7 +1,7 @@
-use itertools::Itertools;
 use crate::proto::gen::transforms::{Aggregate, AggregateOp};
 use crate::spec::transform::aggregate::{AggregateOpSpec, AggregateTransformSpec};
 use crate::transform::TransformDependencies;
+use itertools::Itertools;
 
 impl Aggregate {
     pub fn new(transform: &AggregateTransformSpec) -> Self {
@@ -11,7 +11,12 @@ impl Aggregate {
             .map(|f| f.as_ref().map(|f| f.field()).unwrap_or_default())
             .collect();
 
-        let groupby: Vec<_> = transform.groupby.iter().map(|f| f.field()).unique().collect();
+        let groupby: Vec<_> = transform
+            .groupby
+            .iter()
+            .map(|f| f.field())
+            .unique()
+            .collect();
 
         // Initialize aliases with those potentially provided in field objects
         // (e.g. {"field": "foo", "as": "bar"}

--- a/vegafusion-core/src/transform/aggregate.rs
+++ b/vegafusion-core/src/transform/aggregate.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use crate::proto::gen::transforms::{Aggregate, AggregateOp};
 use crate::spec::transform::aggregate::{AggregateOpSpec, AggregateTransformSpec};
 use crate::transform::TransformDependencies;
@@ -10,7 +11,7 @@ impl Aggregate {
             .map(|f| f.as_ref().map(|f| f.field()).unwrap_or_default())
             .collect();
 
-        let groupby: Vec<_> = transform.groupby.iter().map(|f| f.field()).collect();
+        let groupby: Vec<_> = transform.groupby.iter().map(|f| f.field()).unique().collect();
 
         // Initialize aliases with those potentially provided in field objects
         // (e.g. {"field": "foo", "as": "bar"}

--- a/vegafusion-core/src/transform/joinaggregate.rs
+++ b/vegafusion-core/src/transform/joinaggregate.rs
@@ -1,8 +1,8 @@
-use itertools::Itertools;
 use crate::proto::gen::transforms::{AggregateOp, JoinAggregate};
 use crate::spec::transform::aggregate::AggregateOpSpec;
 use crate::spec::transform::joinaggregate::JoinAggregateTransformSpec;
 use crate::transform::TransformDependencies;
+use itertools::Itertools;
 
 impl JoinAggregate {
     pub fn new(transform: &JoinAggregateTransformSpec) -> Self {

--- a/vegafusion-core/src/transform/joinaggregate.rs
+++ b/vegafusion-core/src/transform/joinaggregate.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use crate::proto::gen::transforms::{AggregateOp, JoinAggregate};
 use crate::spec::transform::aggregate::AggregateOpSpec;
 use crate::spec::transform::joinaggregate::JoinAggregateTransformSpec;
@@ -14,7 +15,7 @@ impl JoinAggregate {
         let groupby: Vec<_> = transform
             .groupby
             .as_ref()
-            .map(|groupby| groupby.iter().map(|f| f.field()).collect())
+            .map(|groupby| groupby.iter().map(|f| f.field()).unique().collect())
             .unwrap_or_default();
 
         // Initialize aliases with those potentially provided in field objects

--- a/vegafusion-datafusion-udfs/src/lib.rs
+++ b/vegafusion-datafusion-udfs/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+pub mod udafs;
 pub mod udfs;
 
 #[cfg(test)]

--- a/vegafusion-datafusion-udfs/src/udafs/mod.rs
+++ b/vegafusion-datafusion-udfs/src/udafs/mod.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+use vegafusion_common::arrow::array::{Array, ArrayRef, UInt32Array};
+use vegafusion_common::arrow::compute::sort_to_indices;
+use vegafusion_common::arrow::datatypes::{DataType, Field, FieldRef};
+use vegafusion_common::data::scalar::ScalarValueHelpers;
+use vegafusion_common::datafusion_common::{DataFusionError, ScalarValue};
+use vegafusion_common::datafusion_expr::{create_udaf, Accumulator, AggregateUDF, Volatility};
+
+#[derive(Debug)]
+/// The percentile_cont accumulator accumulates the raw input values
+/// as `ScalarValue`s
+///
+/// The intermediate state is represented as a List of those scalars
+pub(crate) struct PercentileContAccumulator {
+    pub data_type: DataType,
+    pub all_values: Vec<ScalarValue>,
+    pub percentile: f64,
+}
+
+impl Accumulator for PercentileContAccumulator {
+    fn state(&self) -> Result<Vec<ScalarValue>, DataFusionError> {
+        let state = ScalarValue::new_list(Some(self.all_values.clone()), self.data_type.clone());
+        Ok(vec![state])
+    }
+
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<(), DataFusionError> {
+        let array = &values[0];
+
+        assert_eq!(array.data_type(), &self.data_type);
+        self.all_values.reserve(array.len());
+        for index in 0..array.len() {
+            self.all_values
+                .push(ScalarValue::try_from_array(array, index)?);
+        }
+
+        Ok(())
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<(), DataFusionError> {
+        assert_eq!(states.len(), 1);
+
+        let array = &states[0];
+        assert!(matches!(array.data_type(), DataType::List(_)));
+        for index in 0..array.len() {
+            match ScalarValue::try_from_array(array, index)? {
+                ScalarValue::List(Some(values), _) => {
+                    for scalar in values {
+                        if !scalar_is_non_finite(&scalar) {
+                            self.all_values.push(scalar);
+                        }
+                    }
+                }
+                ScalarValue::List(None, _) => {} // skip empty state
+                v => {
+                    return Err(DataFusionError::Internal(format!(
+                        "unexpected state in percentile_cont. Expected DataType::List, got {v:?}"
+                    )))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&self) -> Result<ScalarValue, DataFusionError> {
+        if !self.all_values.iter().any(|v| !v.is_null()) {
+            return ScalarValue::try_from(&self.data_type);
+        }
+
+        // Create an array of all the non null values and find the
+        // sorted indexes
+        let array = ScalarValue::iter_to_array(
+            self.all_values
+                .iter()
+                // ignore null values
+                .filter(|v| !v.is_null())
+                .cloned(),
+        )?;
+
+        // find the mid point
+        let len = array.len();
+        let r = (len - 1) as f64 * self.percentile;
+
+        let limit = Some(r.ceil() as usize + 1);
+        let options = None;
+        let indices = sort_to_indices(&array, options, limit)?;
+
+        let r_lower = r.floor() as usize;
+        let r_upper = r.ceil() as usize;
+
+        let result = if r_lower == r_upper {
+            // Exact value found, pick that one
+            scalar_at_index(&array, &indices, r_lower)?
+        } else {
+            // Interpolate between upper and lower values
+            let s_lower = scalar_at_index(&array, &indices, r_lower)?;
+            let s_upper = scalar_at_index(&array, &indices, r_upper)?;
+
+            let f_lower = s_lower
+                .to_f64()
+                .map_err(|err| DataFusionError::Internal(err.to_string()))?;
+            let f_upper = s_upper
+                .to_f64()
+                .map_err(|err| DataFusionError::Internal(err.to_string()))?;
+
+            let result = f_lower + (f_upper - f_lower) * r.fract();
+            ScalarValue::from(result)
+        };
+
+        Ok(result)
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self) + ScalarValue::size_of_vec(&self.all_values)
+            - std::mem::size_of_val(&self.all_values)
+            + self.data_type.size()
+            - std::mem::size_of_val(&self.data_type)
+    }
+}
+
+fn scalar_is_non_finite(v: &ScalarValue) -> bool {
+    match v {
+        ScalarValue::Float32(Some(v)) => !v.is_finite(),
+        ScalarValue::Float64(Some(v)) => !v.is_finite(),
+        _ => false,
+    }
+}
+
+/// Given a returns `array[indicies[indicie_index]]` as a `ScalarValue`
+fn scalar_at_index(
+    array: &dyn Array,
+    indices: &UInt32Array,
+    indicies_index: usize,
+) -> Result<ScalarValue, DataFusionError> {
+    let array_index = indices
+        .value(indicies_index)
+        .try_into()
+        .expect("Convert uint32 to usize");
+    ScalarValue::try_from_array(array, array_index)
+}
+
+lazy_static! {
+    pub static ref Q1_UDF: AggregateUDF = create_udaf(
+        "q1",
+        // input type
+        DataType::Float64,
+        // the return type
+        Arc::new(DataType::Float64),
+        Volatility::Immutable,
+        // Accumulator factory
+        Arc::new(|dtype| Ok(Box::new(PercentileContAccumulator {
+            data_type: dtype.clone(),
+            all_values: Default::default(),
+            percentile: 0.25,
+        }))),
+        // This is the description of the state. `state()` must match the types here.
+        Arc::new(vec![
+            DataType::List(FieldRef::new(Field::new("item", DataType::Float64, true)))
+        ]),
+    );
+
+    pub static ref Q3_UDF: AggregateUDF = create_udaf(
+        "q3",
+        // input type
+        DataType::Float64,
+        // the return type
+        Arc::new(DataType::Float64),
+        Volatility::Immutable,
+        // Accumulator factory
+        Arc::new(|dtype| Ok(Box::new(PercentileContAccumulator {
+            data_type: dtype.clone(),
+            all_values: Default::default(),
+            percentile: 0.75,
+        }))),
+        // This is the description of the state. `state()` must match the types here.
+        Arc::new(vec![
+            DataType::List(FieldRef::new(Field::new("item", DataType::Float64, true)))
+        ]),
+    );
+}

--- a/vegafusion-runtime/src/transform/aggregate.rs
+++ b/vegafusion-runtime/src/transform/aggregate.rs
@@ -19,6 +19,7 @@ use vegafusion_core::proto::gen::transforms::{Aggregate, AggregateOp};
 use vegafusion_core::task_graph::task_value::TaskValue;
 use vegafusion_core::transform::aggregate::op_name;
 use vegafusion_dataframe::dataframe::DataFrame;
+use vegafusion_datafusion_udfs::udafs::{Q1_UDF, Q3_UDF};
 
 #[async_trait]
 impl TransformTrait for Aggregate {
@@ -206,6 +207,18 @@ pub fn make_agg_expr_for_col_expr(
             });
             count_distinct(column) + max(missing)
         }
+        AggregateOp::Q1 => Expr::AggregateUDF(expr::AggregateUDF {
+            fun: Arc::new((*Q1_UDF).clone()),
+            args: vec![numeric_column()?],
+            filter: None,
+            order_by: None,
+        }),
+        AggregateOp::Q3 => Expr::AggregateUDF(expr::AggregateUDF {
+            fun: Arc::new((*Q3_UDF).clone()),
+            args: vec![numeric_column()?],
+            filter: None,
+            order_by: None,
+        }),
         _ => {
             return Err(VegaFusionError::specification(format!(
                 "Unsupported aggregation op: {op:?}"

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal_custom_mark.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal_custom_mark.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal_explicit.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_horizontal_explicit.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_vertical.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_1D_vertical.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_horizontal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_horizontal.comm_plan.json
@@ -2,7 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_y_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_y_domain_Species_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_horizontal_color_size.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_horizontal_color_size.comm_plan.json
@@ -2,7 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_y_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_y_domain_Species_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_vertical.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_2D_vertical.comm_plan.json
@@ -2,7 +2,42 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_color_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_x_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_x_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_color_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_x_domain_Species_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_groupped.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_groupped.comm_plan.json
@@ -2,7 +2,57 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_color_domain_Origin_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_xOffset_domain_Origin_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_x_domain_Cylinders_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_xOffset_domain_Origin_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_x_domain_Cylinders_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_color_domain_Origin_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_xOffset_domain_Origin_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_x_domain_Cylinders_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_horizontal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_horizontal.comm_plan.json
@@ -2,7 +2,12 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_y_domain_Species",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_horizontal_custom_midtick_color.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_horizontal_custom_midtick_color.comm_plan.json
@@ -2,7 +2,12 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_y_domain_Species",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_vertical.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_minmax_2D_vertical.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_color_domain_Species",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_x_domain_Species",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_tooltip_aggregate.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_tooltip_aggregate.comm_plan.json
@@ -2,7 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_y_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_y_domain_Species_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/boxplot_tooltip_not_aggregate.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/boxplot_tooltip_not_aggregate.comm_plan.json
@@ -2,7 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_Species_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_2_y_domain_Species_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_3_y_domain_Species_2",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/layer_boxplot_circle.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/layer_boxplot_circle.comm_plan.json
@@ -2,17 +2,32 @@
   "server_to_client": [
     {
       "namespace": "data",
+      "name": "data_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_0_y_domain_age_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_age_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
       "name": "data_2",
       "scope": []
     },
     {
       "namespace": "data",
       "name": "data_2_y_domain_age_2",
-      "scope": []
-    },
-    {
-      "namespace": "data",
-      "name": "source_0",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/layer_point_errorbar_2d_horizontal_iqr.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/layer_point_errorbar_2d_horizontal_iqr.comm_plan.json
@@ -2,7 +2,22 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "data_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_0_y_domain_variety_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_1_y_domain_variety_0",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/test_transform_aggregate.rs
+++ b/vegafusion-runtime/tests/test_transform_aggregate.rs
@@ -28,7 +28,9 @@ mod test_aggregate_single {
         case(AggregateOpSpec::Average),
         case(AggregateOpSpec::Min),
         case(AggregateOpSpec::Max),
-        case(AggregateOpSpec::Median)
+        case(AggregateOpSpec::Median),
+        case(AggregateOpSpec::Q1),
+        case(AggregateOpSpec::Q3)
     )]
     fn test(op: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");
@@ -75,7 +77,8 @@ mod test_aggregate_multi {
         case(AggregateOpSpec::Average, AggregateOpSpec::Mean),
         case(AggregateOpSpec::Min, AggregateOpSpec::Average),
         case(AggregateOpSpec::Max, AggregateOpSpec::Min),
-        case(AggregateOpSpec::Median, AggregateOpSpec::Average)
+        case(AggregateOpSpec::Median, AggregateOpSpec::Average),
+        case(AggregateOpSpec::Q1, AggregateOpSpec::Q3)
     )]
     fn test(op1: AggregateOpSpec, op2: AggregateOpSpec) {
         let dataset = vega_json_dataset("penguins");

--- a/vegafusion-sql/src/connection/datafusion_conn.rs
+++ b/vegafusion-sql/src/connection/datafusion_conn.rs
@@ -28,6 +28,7 @@ use vegafusion_common::error::{Result, ResultWithContext, ToExternalError, VegaF
 use vegafusion_dataframe::connection::Connection;
 use vegafusion_dataframe::csv::CsvReadOptions;
 use vegafusion_dataframe::dataframe::DataFrame;
+use vegafusion_datafusion_udfs::udafs::{Q1_UDF, Q3_UDF};
 use vegafusion_datafusion_udfs::udfs::array::constructor::ARRAY_CONSTRUCTOR_UDF;
 use vegafusion_datafusion_udfs::udfs::array::indexof::INDEXOF_UDF;
 use vegafusion_datafusion_udfs::udfs::array::length::LENGTH_UDF;
@@ -398,6 +399,10 @@ pub fn make_datafusion_context() -> SessionContext {
     ctx.register_udf((*ARRAY_CONSTRUCTOR_UDF).clone());
     ctx.register_udf((*LENGTH_UDF).clone());
     ctx.register_udf((*INDEXOF_UDF).clone());
+
+    // q1/q3 aggregate functions
+    ctx.register_udaf((*Q1_UDF).clone());
+    ctx.register_udaf((*Q3_UDF).clone());
 
     ctx
 }

--- a/vegafusion-sql/src/dialect/mod.rs
+++ b/vegafusion-sql/src/dialect/mod.rs
@@ -789,6 +789,8 @@ impl Dialect {
                 "covar",
                 "covar_pop",
                 "corr",
+                "q1",
+                "q3",
             ]
             .iter()
             .map(|s| s.to_string())


### PR DESCRIPTION
This PR adds implementations of the Vega q1 and q3 aggregations using a custom DataFusion UDAF.

If VegaFusion eventually supports the `percentile_cont` aggregation function, then this UDF could be replaced.

As one common application, this makes it possible for VegaFusion to support all of the data transformations associated with the Vega-Lite [`boxplot` mark](https://vega.github.io/vega-lite/docs/boxplot.html).