### PR TITLE
Support keeping select signals and datasets in pre-transformed specs

### DIFF
--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -990,6 +990,228 @@ def date32_timeunit_spec():
 }
 
 """)
+
+
+def gh_268_hang_spec():
+    return json.loads(r""" 
+    {
+      "$schema": "https://vega.github.io/schema/vega/v5.json",
+      "data": [
+        {
+          "name": "interval_intervalselection__store"
+        },
+        {
+          "name": "legend_pointselection__store"
+        },
+        {
+          "name": "pivot_hover_32f2e9aa_f08a_4fb5_aa8a_ab3f2cc94a1d_store"
+        },
+        {
+          "name": "movies_clean",
+          "url": "vegafusion+dataset://movies_clean"
+        },
+        {
+          "name": "data_0",
+          "source": "movies_clean",
+          "transform": [
+            {
+              "type": "formula",
+              "expr": "toDate(datum[\"Release Date\"])",
+              "as": "Release Date"
+            }
+          ]
+        },
+        {
+          "name": "data_2",
+          "source": "data_0",
+          "transform": [
+            {
+              "field": "Release Date",
+              "type": "timeunit",
+              "units": [
+                "year"
+              ],
+              "as": [
+                "year_Release Date",
+                "year_Release Date_end"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "data_3",
+          "source": "data_2",
+          "transform": [
+            {
+              "type": "filter",
+              "expr": "!length(data(\"interval_intervalselection__store\")) || vlSelectionTest(\"interval_intervalselection__store\", datum)"
+            },
+            {
+              "type": "filter",
+              "expr": "time('1986-11-09T18:28:05.617') <= time(datum[\"year_Release Date\"]) && time(datum[\"year_Release Date\"]) <= time('2001-09-16T22:23:39.144')"
+            },
+            {
+              "type": "filter",
+              "expr": "!length(data(\"legend_pointselection__store\")) || vlSelectionTest(\"legend_pointselection__store\", datum)"
+            }
+          ]
+        }
+      ]
+    }
+    """)
+
+
+def manual_histogram_spec():
+    return json.loads(r"""
+    {
+      "$schema": "https://vega.github.io/schema/vega/v5.json",
+      "background": "white",
+      "padding": 5,
+      "width": 200,
+      "height": 200,
+      "style": "cell",
+      "data": [
+        {
+          "name": "movies",
+          "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/movies.json",
+          "format": {"type": "json"},
+          "transform": [
+            {
+              "type": "extent",
+              "field": "IMDB_Rating",
+              "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent"
+            },
+            {
+              "type": "bin",
+              "field": "IMDB_Rating",
+              "as": ["__bin_field_name", "__bin_field_name_end"],
+              "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins",
+              "extent": {
+                "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent"
+              },
+              "maxbins": 10
+            },
+            {
+              "type": "aggregate",
+              "groupby": ["__bin_field_name", "__bin_field_name_end"],
+              "ops": ["count"],
+              "fields": [null],
+              "as": ["__count"]
+            },
+            {
+              "type": "formula",
+              "expr": "'[' + toString(datum[\"__bin_field_name\"]) + ', ' + toString(datum[\"__bin_field_name_end\"]) + ')'",
+              "as": "__bin_range"
+            },
+            {
+              "type": "filter",
+              "expr": "isValid(datum[\"__bin_field_name\"]) && isFinite(+datum[\"__bin_field_name\"]) && isValid(datum[\"__count\"]) && isFinite(+datum[\"__count\"])"
+            }
+          ]
+        }
+      ],
+      "marks": [
+        {
+          "name": "layer_0_layer_0_marks",
+          "type": "rect",
+          "clip": true,
+          "style": ["bar"],
+          "from": {"data": "movies"},
+          "encode": {
+            "update": {
+              "fill": {"value": "#4C78A8"},
+              "opacity": {"value": 1},
+              "ariaRoleDescription": {"value": "bar"},
+              "description": {
+                "signal": "\"IMDB_Rating (start): \" + (format(datum[\"__bin_field_name\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\")) + \"; __bin_field_name_end: \" + (format(datum[\"__bin_field_name_end\"], \"\"))"
+              },
+              "x": {"scale": "x", "field": "__bin_field_name"},
+              "x2": {"scale": "x", "field": "__bin_field_name_end", "offset": -1},
+              "y": {"scale": "y", "field": "__count"},
+              "y2": {"scale": "y", "value": 0}
+            }
+          }
+        }
+      ],
+      "scales": [
+        {
+          "name": "x",
+          "type": "linear",
+          "domain": {
+            "data": "movies",
+            "fields": ["__bin_field_name", "__bin_field_name_end"]
+          },
+          "range": [0, {"signal": "width"}],
+          "nice": true,
+          "zero": true
+        },
+        {
+          "name": "y",
+          "type": "linear",
+          "domain": {"fields": [{"data": "movies", "field": "__count"}, [0]]},
+          "range": [{"signal": "height"}, 0],
+          "nice": true,
+          "zero": true
+        }
+      ],
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": true,
+          "tickCount": 10,
+          "gridScale": "y",
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": true,
+          "gridScale": "x",
+          "tickCount": {"signal": "ceil(height/40)"},
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "IMDB_Rating (start)",
+          "labelFlush": false,
+          "labels": true,
+          "tickCount": 10,
+          "ticks": true,
+          "labelOverlap": true,
+          "zindex": 0
+        },
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": false,
+          "title": "Count of Records",
+          "labelFlush": false,
+          "labels": true,
+          "ticks": true,
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(height/40)"},
+          "zindex": 0
+        }
+      ]
+    }
+    """)
+
+
 def test_pre_transform_multi_partition():
     n = 4050
     order_items = pd.DataFrame({
@@ -1390,70 +1612,37 @@ def test_pivot_mixed_case(connection):
     assert set(datasets[0].columns.tolist()) == {"gold", "Gold", "silver", "bronze", "country"}
 
 
-def gh_268_hang_spec():
-    return json.loads(r""" 
-    {
-      "$schema": "https://vega.github.io/schema/vega/v5.json",
-      "data": [
-        {
-          "name": "interval_intervalselection__store"
-        },
-        {
-          "name": "legend_pointselection__store"
-        },
-        {
-          "name": "pivot_hover_32f2e9aa_f08a_4fb5_aa8a_ab3f2cc94a1d_store"
-        },
-        {
-          "name": "movies_clean",
-          "url": "vegafusion+dataset://movies_clean"
-        },
-        {
-          "name": "data_0",
-          "source": "movies_clean",
-          "transform": [
-            {
-              "type": "formula",
-              "expr": "toDate(datum[\"Release Date\"])",
-              "as": "Release Date"
-            }
-          ]
-        },
-        {
-          "name": "data_2",
-          "source": "data_0",
-          "transform": [
-            {
-              "field": "Release Date",
-              "type": "timeunit",
-              "units": [
-                "year"
-              ],
-              "as": [
-                "year_Release Date",
-                "year_Release Date_end"
-              ]
-            }
-          ]
-        },
-        {
-          "name": "data_3",
-          "source": "data_2",
-          "transform": [
-            {
-              "type": "filter",
-              "expr": "!length(data(\"interval_intervalselection__store\")) || vlSelectionTest(\"interval_intervalselection__store\", datum)"
-            },
-            {
-              "type": "filter",
-              "expr": "time('1986-11-09T18:28:05.617') <= time(datum[\"year_Release Date\"]) && time(datum[\"year_Release Date\"]) <= time('2001-09-16T22:23:39.144')"
-            },
-            {
-              "type": "filter",
-              "expr": "!length(data(\"legend_pointselection__store\")) || vlSelectionTest(\"legend_pointselection__store\", datum)"
-            }
-          ]
-        }
-      ]
-    }
-    """)
+def test_keep_signals():
+    spec = manual_histogram_spec()
+
+    # pre-transform without keep_signals. No signals should be present in pre-transformed spec
+    tx_spec, warnings = vf.runtime.pre_transform_spec(spec, "UTC")
+    assert len(tx_spec.get("signals", [])) == 0
+
+    # Specify single keep_signal as a string
+    tx_spec, warnings = vf.runtime.pre_transform_spec(
+        spec,
+        "UTC",
+        keep_signals="layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins"
+    )
+    assert len(tx_spec.get("signals", [])) == 1
+    sig0 = tx_spec["signals"][0]
+    assert sig0["name"] == "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins"
+    assert sig0["value"]["step"] == 1.0
+
+    # Specify multiple keep_signals as a list
+    tx_spec, warnings = vf.runtime.pre_transform_spec(
+        spec,
+        "UTC",
+        keep_signals=[
+            "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins",
+            ("layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent", [])
+        ]
+    )
+    assert len(tx_spec.get("signals", [])) == 2
+    sig0 = tx_spec["signals"][0]
+    sig1 = tx_spec["signals"][1]
+    [sig0, sig1] = sorted([sig0, sig1], key=lambda v: v["name"])
+    assert sig0["name"] == "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins"
+    assert sig1["name"] == "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent"
+    assert sig1["value"] == [1.4, 9.2]

--- a/vegafusion-core/src/lib.rs
+++ b/vegafusion-core/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate lazy_static;
+extern crate core;
 
 pub mod data;
 pub mod expression;

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -76,6 +76,7 @@ pub struct PlannerConfig {
     pub extract_server_data: bool,
     pub allow_client_to_server_comms: bool,
     pub client_only_vars: Vec<ScopedVariable>,
+    pub keep_variables: Vec<ScopedVariable>,
 }
 
 impl Default for PlannerConfig {
@@ -89,6 +90,7 @@ impl Default for PlannerConfig {
             extract_server_data: true,
             allow_client_to_server_comms: true,
             client_only_vars: Default::default(),
+            keep_variables: Default::default(),
         }
     }
 }
@@ -135,7 +137,12 @@ impl SpecPlan {
             let mut task_scope = client_spec.to_task_scope()?;
             let input_client_spec = client_spec.clone();
             let mut server_spec = extract_server_data(&mut client_spec, &mut task_scope, config)?;
-            let mut comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
+            let mut comm_plan = stitch_specs(
+                &task_scope,
+                &mut server_spec,
+                &mut client_spec,
+                config.keep_variables.as_slice(),
+            )?;
 
             if !config.allow_client_to_server_comms && !comm_plan.client_to_server.is_empty() {
                 // Client to server comms are not allowed and the initial planning
@@ -147,7 +154,12 @@ impl SpecPlan {
 
                 client_spec = input_client_spec;
                 server_spec = extract_server_data(&mut client_spec, &mut task_scope, &config)?;
-                comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut client_spec)?;
+                comm_plan = stitch_specs(
+                    &task_scope,
+                    &mut server_spec,
+                    &mut client_spec,
+                    config.keep_variables.as_slice(),
+                )?;
             }
 
             if config.split_url_data_nodes {

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -8,6 +8,7 @@ message PreTransformSpecOpts {
   optional uint32 row_limit = 1;
   repeated PreTransformInlineDataset inline_datasets = 2;
   bool preserve_interactivity = 3;
+  repeated PreTransformVariable keep_variables = 4;
 }
 
 message PreTransformSpecRequest {

--- a/vegafusion-core/src/proto/prost_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/prost_gen/pretransform.rs
@@ -8,6 +8,8 @@ pub struct PreTransformSpecOpts {
     pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
     #[prost(bool, tag = "3")]
     pub preserve_interactivity: bool,
+    #[prost(message, repeated, tag = "4")]
+    pub keep_variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/vegafusion-core/src/proto/tonic_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/tonic_gen/pretransform.rs
@@ -8,6 +8,8 @@ pub struct PreTransformSpecOpts {
     pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
     #[prost(bool, tag = "3")]
     pub preserve_interactivity: bool,
+    #[prost(message, repeated, tag = "4")]
+    pub keep_variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/vegafusion-jni/src/lib.rs
+++ b/vegafusion-jni/src/lib.rs
@@ -256,6 +256,7 @@ unsafe fn inner_pre_transform_spec(pointer: jlong, args: PreTransformSpecArgs) -
                 args.row_limit,
                 args.preserve_interactivity,
                 Default::default(),
+                Default::default(),
             ))?;
 
     // Convert warnings to JSON compatible PreTransformSpecWarningSpec

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -118,10 +118,21 @@ impl PyVegaFusionRuntime {
         row_limit: Option<u32>,
         preserve_interactivity: Option<bool>,
         inline_datasets: Option<&PyDict>,
+        keep_signals: Option<Vec<(String, Vec<u32>)>>,
+        keep_datasets: Option<Vec<(String, Vec<u32>)>>,
     ) -> PyResult<(PyObject, PyObject)> {
         let inline_datasets = process_inline_datasets(inline_datasets)?;
         let spec = parse_json_spec(spec)?;
         let preserve_interactivity = preserve_interactivity.unwrap_or(false);
+
+        // Build keep_variables
+        let mut keep_variables: Vec<ScopedVariable> = Vec::new();
+        for (name, scope) in keep_signals.unwrap_or_default() {
+            keep_variables.push((Variable::new_signal(&name), scope))
+        }
+        for (name, scope) in keep_datasets.unwrap_or_default() {
+            keep_variables.push((Variable::new_data(&name), scope))
+        }
 
         let (spec, warnings) = self
             .tokio_runtime
@@ -132,6 +143,7 @@ impl PyVegaFusionRuntime {
                 row_limit,
                 preserve_interactivity,
                 inline_datasets,
+                keep_variables,
             ))?;
 
         let warnings: Vec<_> = warnings

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -110,6 +110,7 @@ impl PyVegaFusionRuntime {
         Python::with_gil(|py| Ok(PyBytes::new(py, &response_bytes).into()))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn pre_transform_spec(
         &self,
         spec: PyObject,

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -247,6 +247,7 @@ impl VegaFusionRuntime {
         Ok(response)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn pre_transform_spec(
         &self,
         spec: &ChartSpec,

--- a/vegafusion-runtime/tests/specs/pre_transform/manual_histogram.vg.json
+++ b/vegafusion-runtime/tests/specs/pre_transform/manual_histogram.vg.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "movies",
+      "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/movies.json",
+      "format": {"type": "json"},
+      "transform": [
+        {
+          "type": "extent",
+          "field": "IMDB_Rating",
+          "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent"
+        },
+        {
+          "type": "bin",
+          "field": "IMDB_Rating",
+          "as": ["__bin_field_name", "__bin_field_name_end"],
+          "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins",
+          "extent": {
+            "signal": "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_extent"
+          },
+          "maxbins": 10
+        },
+        {
+          "type": "aggregate",
+          "groupby": ["__bin_field_name", "__bin_field_name_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "formula",
+          "expr": "'[' + toString(datum[\"__bin_field_name\"]) + ', ' + toString(datum[\"__bin_field_name_end\"]) + ')'",
+          "as": "__bin_range"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"__bin_field_name\"]) && isFinite(+datum[\"__bin_field_name\"]) && isValid(datum[\"__count\"]) && isFinite(+datum[\"__count\"])"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "layer_0_layer_0_marks",
+      "type": "rect",
+      "clip": true,
+      "style": ["bar"],
+      "from": {"data": "movies"},
+      "encode": {
+        "update": {
+          "fill": {"value": "#4C78A8"},
+          "opacity": {"value": 1},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"IMDB_Rating (start): \" + (format(datum[\"__bin_field_name\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\")) + \"; __bin_field_name_end: \" + (format(datum[\"__bin_field_name_end\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "__bin_field_name"},
+          "x2": {"scale": "x", "field": "__bin_field_name_end", "offset": -1},
+          "y": {"scale": "y", "field": "__count"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {
+        "data": "movies",
+        "fields": ["__bin_field_name", "__bin_field_name_end"]
+      },
+      "range": [0, {"signal": "width"}],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"fields": [{"data": "movies", "field": "__count"}, [0]]},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": true,
+      "tickCount": 10,
+      "gridScale": "y",
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": true,
+      "gridScale": "x",
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "IMDB_Rating (start)",
+      "labelFlush": false,
+      "labels": true,
+      "tickCount": 10,
+      "ticks": true,
+      "labelOverlap": true,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Count of Records",
+      "labelFlush": false,
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "zindex": 0
+    }
+  ]
+}

--- a/vegafusion-runtime/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-runtime/tests/test_destringify_selection_datasets.rs
@@ -26,7 +26,15 @@ mod tests {
         );
 
         let (chart_spec, _warnings) = runtime
-            .pre_transform_spec(&spec, "UTC", &None, None, true, Default::default())
+            .pre_transform_spec(
+                &spec,
+                "UTC",
+                &None,
+                None,
+                true,
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -1188,6 +1188,7 @@ mod test_pre_transform_inline {
             row_limit: None,
             inline_datasets,
             preserve_interactivity: true,
+            ..Default::default()
         };
         let request = PreTransformSpecRequest {
             spec: serde_json::to_string(&inline_spec).unwrap(),
@@ -1341,6 +1342,7 @@ async fn check_pre_transform_spec_from_files(spec_name: &str, tolerance: f64) {
         row_limit: None,
         inline_datasets: vec![],
         preserve_interactivity: true,
+        ..Default::default()
     };
     let request = PreTransformSpecRequest {
         spec: serde_json::to_string(&full_spec).unwrap(),

--- a/vegafusion-runtime/tests/test_planning.rs
+++ b/vegafusion-runtime/tests/test_planning.rs
@@ -104,7 +104,7 @@ async fn test_extract_stitch_data() {
 
     let mut server_spec =
         extract_server_data(&mut spec, &mut task_scope, &Default::default()).unwrap();
-    let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
+    let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec, &[]).unwrap();
 
     println!("{comm_plan:#?}");
 
@@ -123,7 +123,7 @@ async fn try_extract_split_server_data() {
 
     let mut server_spec =
         extract_server_data(&mut spec, &mut task_scope, &Default::default()).unwrap();
-    let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec).unwrap();
+    let comm_plan = stitch_specs(&task_scope, &mut server_spec, &mut spec, &[]).unwrap();
 
     println!("{comm_plan:#?}");
 

--- a/vegafusion-runtime/tests/test_pre_transform_keep_variables.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_keep_variables.rs
@@ -1,0 +1,103 @@
+#[cfg(test)]
+mod tests {
+    use crate::crate_dir;
+
+    use std::fs;
+    use std::sync::Arc;
+    use vegafusion_common::error::VegaFusionError;
+    use vegafusion_core::proto::gen::tasks::Variable;
+
+    use vegafusion_core::spec::chart::ChartSpec;
+
+    use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
+    use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
+
+    #[tokio::test]
+    async fn test_pre_transform_keep_variables() {
+        // Load spec
+        let spec_path = format!(
+            "{}/tests/specs/pre_transform/manual_histogram.vg.json",
+            crate_dir()
+        );
+        let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
+
+        // Initialize task graph runtime
+        let runtime = VegaFusionRuntime::new(
+            Arc::new(DataFusionConnection::default()),
+            Some(16),
+            Some(1024_i32.pow(3) as usize),
+        );
+
+        let (tx_spec, warnings) = runtime
+            .pre_transform_spec(
+                &spec,
+                "UTC",
+                &None,
+                None,
+                true,
+                Default::default(),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        // Check there are no warnings
+        assert!(warnings.is_empty());
+
+        // Without keep_variables, there should be no signals
+        assert!(tx_spec.signals.is_empty());
+
+        // Now rerun with keep_variables to keep the bin signal
+        let (tx_spec, warnings) = runtime
+            .pre_transform_spec(
+                &spec,
+                "UTC",
+                &None,
+                None,
+                true,
+                Default::default(),
+                vec![(
+                    Variable::new_signal("layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins"),
+                    Vec::new(),
+                )],
+            )
+            .await
+            .unwrap();
+
+        assert!(warnings.is_empty());
+        assert_eq!(tx_spec.signals.len(), 1);
+
+        let signal0 = tx_spec.signals.get(0).unwrap();
+        assert_eq!(
+            signal0.name,
+            "layer_0_layer_0_bin_maxbins_10_IMDB_Rating_bins"
+        );
+
+        // Rerun with non-existent signal
+        let pre_transform_result = runtime
+            .pre_transform_spec(
+                &spec,
+                "UTC",
+                &None,
+                None,
+                true,
+                Default::default(),
+                vec![(Variable::new_signal("does_not_exist"), Vec::new())],
+            )
+            .await;
+
+        if !matches!(
+            pre_transform_result,
+            Err(VegaFusionError::PreTransformError(_, _))
+        ) {
+            panic!("Expected error when keep variable does not exist")
+        }
+    }
+}
+
+fn crate_dir() -> String {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .display()
+        .to_string()
+}

--- a/vegafusion-runtime/tests/test_stringify_datetimes.rs
+++ b/vegafusion-runtime/tests/test_stringify_datetimes.rs
@@ -95,6 +95,7 @@ mod test_stringify_datetimes {
                 None,
                 true,
                 Default::default(),
+                Default::default(),
             )
             .await
             .unwrap();
@@ -150,6 +151,7 @@ mod test_stringify_datetimes {
                 &Some(default_input_tz),
                 None,
                 true,
+                Default::default(),
                 Default::default(),
             )
             .await
@@ -235,6 +237,7 @@ mod test_stringify_datetimes {
                 None,
                 true,
                 Default::default(),
+                Default::default(),
             )
             .await
             .unwrap();
@@ -301,6 +304,7 @@ mod test_stringify_datetimes {
                 None,
                 true,
                 Default::default(),
+                Default::default(),
             ))
             .unwrap();
 
@@ -340,7 +344,15 @@ mod test_stringify_datetimes {
         );
 
         let (spec, _warnings) = runtime
-            .pre_transform_spec(&spec, "UTC", &None, None, true, Default::default())
+            .pre_transform_spec(
+                &spec,
+                "UTC",
+                &None,
+                None,
+                true,
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
This PR adds the ability to keep select signals and datasets in the result of pre_transform_spec. By default, signals and datasets are not included if they are not required by the pre-transformed spec. But sometimes, it's helpful to have them included anyway.

A motivating use case is the `bin` transform's output signal. Sometimes this signals is used only by the transform pipeline itself and so is not required in the pre_transformed spec.  Even when it's not required, it can be helpful for the calling system to have access to the bin edge specification.

See the new Rust and Python tests for usage examples