### PR TITLE
Add dialect specialization for the row_number window function without ordering

### DIFF
--- a/vegafusion-sql/src/dialect/mod.rs
+++ b/vegafusion-sql/src/dialect/mod.rs
@@ -116,6 +116,18 @@ pub enum ValuesMode {
 }
 
 #[derive(Clone, Debug)]
+pub enum UnorderedRowNumberMode {
+    /// `SELECT ROW_NUMBER() OVER ()` is supported
+    Supported,
+
+    /// `SELECT ${alternate}()` is supported as an alternative
+    AlternateScalarFunction(String),
+
+    /// `SELECT ROW_NUMBER() OVER (ORDER BY 1)` is supported
+    OrderByConstant,
+}
+
+#[derive(Clone, Debug)]
 pub struct Dialect {
     /// sqlparser dialect to use to parse queries
     parse_dialect: ParseDialect,
@@ -188,6 +200,9 @@ pub struct Dialect {
 
     /// Whether dialect supports multiple columns in the same table that differ only by case
     pub supports_mixed_case_identical_columns: bool,
+
+    /// How `ROW_NUMBER() OVER ()` should be handled
+    pub unordered_row_number_mode: UnorderedRowNumberMode,
 }
 
 impl Default for Dialect {
@@ -217,6 +232,7 @@ impl Default for Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 }
@@ -344,6 +360,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -470,6 +487,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -569,6 +587,7 @@ impl Dialect {
             cast_propagates_null: false,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -711,6 +730,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::OrderByConstant,
         }
     }
 
@@ -862,6 +882,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -1011,6 +1032,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -1111,6 +1133,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -1261,6 +1284,7 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -1397,6 +1421,7 @@ impl Dialect {
             cast_propagates_null: false,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
+            unordered_row_number_mode: UnorderedRowNumberMode::Supported,
         }
     }
 
@@ -1538,6 +1563,9 @@ impl Dialect {
             cast_propagates_null: true,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
+            unordered_row_number_mode: UnorderedRowNumberMode::AlternateScalarFunction(
+                "seq8".to_string(),
+            ),
         }
     }
 }

--- a/vegafusion-sql/tests/expected/select_window.toml
+++ b/vegafusion-sql/tests/expected/select_window.toml
@@ -334,3 +334,46 @@ result = '''
 | 9 | 10 | A  | 2    | 1.0                | 8     |        | 2     |
 +---+----+----+------+--------------------+-------+--------+-------+
 '''
+
+[row_number_no_order]
+athena = """
+WITH values0 AS (SELECT * FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A')) AS "_values" ("a", "b", "c")), values1 AS (SELECT "a", "b", "c", row_number() OVER () AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+bigquery = """
+WITH values0 AS (SELECT 1 AS `a`, 2 AS `b`, 'A' AS `c` UNION ALL SELECT 3 AS `a`, 4 AS `b`, 'BB' AS `c` UNION ALL SELECT 5 AS `a`, 6 AS `b`, 'A' AS `c` UNION ALL SELECT 7 AS `a`, 8 AS `b`, 'BB' AS `c` UNION ALL SELECT 9 AS `a`, 10 AS `b`, 'A' AS `c`), values1 AS (SELECT `a`, `b`, `c`, row_number() OVER () AS `row_num` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+clickhouse = """
+WITH values0 AS (SELECT 1 AS "a", 2 AS "b", 'A' AS "c" UNION ALL SELECT 3 AS "a", 4 AS "b", 'BB' AS "c" UNION ALL SELECT 5 AS "a", 6 AS "b", 'A' AS "c" UNION ALL SELECT 7 AS "a", 8 AS "b", 'BB' AS "c" UNION ALL SELECT 9 AS "a", 10 AS "b", 'A' AS "c"), values1 AS (SELECT "a", "b", "c", row_number() OVER () AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+databricks = """
+WITH values0 AS (SELECT * FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A')) AS `_values` (`a`, `b`, `c`)), values1 AS (SELECT `a`, `b`, `c`, row_number() OVER (ORDER BY 1 DESC NULLS LAST) AS `row_num` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+datafusion = """
+WITH values0 AS (SELECT * FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A')) AS "_values" ("a", "b", "c")), values1 AS (SELECT "a", "b", "c", row_number() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+duckdb = """
+WITH values0 AS (SELECT * FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A')) AS "_values" ("a", "b", "c")), values1 AS (SELECT "a", "b", "c", row_number() OVER () AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+mysql = """
+WITH values0 AS (SELECT * FROM (VALUES ROW(1, 2, 'A'), ROW(3, 4, 'BB'), ROW(5, 6, 'A'), ROW(7, 8, 'BB'), ROW(9, 10, 'A')) AS `_values` (`a`, `b`, `c`)), values1 AS (SELECT `a`, `b`, `c`, row_number() OVER () AS `row_num` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC
+"""
+postgres = """
+WITH values0 AS (SELECT * FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A')) AS "_values" ("a", "b", "c")), values1 AS (SELECT "a", "b", "c", row_number() OVER () AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+redshift = """
+WITH values0 AS (SELECT 1 AS "a", 2 AS "b", 'A' AS "c" UNION ALL SELECT 3 AS "a", 4 AS "b", 'BB' AS "c" UNION ALL SELECT 5 AS "a", 6 AS "b", 'A' AS "c" UNION ALL SELECT 7 AS "a", 8 AS "b", 'BB' AS "c" UNION ALL SELECT 9 AS "a", 10 AS "b", 'A' AS "c"), values1 AS (SELECT "a", "b", "c", row_number() OVER () AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+snowflake = """
+WITH values0 AS (SELECT "COLUMN1" AS "a", "COLUMN2" AS "b", "COLUMN3" AS "c" FROM (VALUES (1, 2, 'A'), (3, 4, 'BB'), (5, 6, 'A'), (7, 8, 'BB'), (9, 10, 'A'))), values1 AS (SELECT "a", "b", "c", seq8() AS "row_num" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+result = '''
++---+----+----+---------+
+| a | b  | c  | row_num |
++---+----+----+---------+
+| 1 | 2  | A  | 1       |
+| 3 | 4  | BB | 2       |
+| 5 | 6  | A  | 3       |
+| 7 | 8  | BB | 4       |
+| 9 | 10 | A  | 5       |
++---+----+----+---------+
+'''


### PR DESCRIPTION
Many SQL dialects (including DataFusion and DuckDB) allow the use of the `ROW_NUMBER` window function without an explicit `ORDER BY` clause: 

```sql
SELECT ROW_NUMBER() OVER () FROM tbl
```

But some (including Snowflake and Databricks) do not. For Snowflake, we can substitute the [`seq8` function](https://docs.snowflake.com/en/sql-reference/functions/seq1):

```sql
SELECT seq8() FROM tbl
```

I haven't found an equivalent for Databricks, so in this case we can add a constant ordering value

```sql
SELECT ROW_NUMBER() OVER (ORDER BY 1) FROM tbl
```

cc @FreddieLindsey 
