### PR TITLE
Add linux-arm64 builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,6 @@
+# Pin third-part actions
+For improved security, third-party GitHub actions are pinned using [pin-github-action](https://github.com/mheap/pin-github-action). To add pins:
+
+```
+GH_ADMIN_TOKEN={token} pin-github-action .github/workflows/build.yml
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,163 @@
+name: build
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  build-vegafusion-server:
+    strategy:
+      matrix:
+        options: [
+          [ ubuntu-latest,  linux-64 ],
+          [ windows-2022,  win-64 ],
+          [ macos-11,   osx-64 ],
+          [ macos-11,   osx-arm64 ],
+        ]
+    runs-on: ${{ matrix.options[0] }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc on Window
+        run: |
+          choco install --yes protoc
+        if: ${{ runner.os == 'Windows' }}
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download Apple Silicon toolchain
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build vegafusion-server (Windows)
+        uses: actions-rs/cargo@v1
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          command: build
+          args: -p vegafusion-server --release
+      - name: Build vegafusion-server (Mac/Linux)
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src
+      - name: Build vegafusion-server (Apple Silicon)
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
+        with:
+          command: build
+          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
+      - name: zip executable (Windows)
+        uses: papeloto/action-zip@v1
+        if: runner.os == 'Windows'
+        with:
+          files: target/release/vegafusion-server.exe
+          dest: vegafusion-server-${{ matrix.options[1] }}.zip
+      - name: zip executable (Mac or Linux)
+        uses: papeloto/action-zip@v1
+        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-${{ matrix.options[1] }}.zip
+      - name: zip executable (Apple silicon)
+        uses: papeloto/action-zip@v1
+        if: ${{ matrix.options[1] == 'osx-arm64'}}
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
+          dest: vegafusion-server-${{ matrix.options[1] }}.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+
+  build-vegafusion-python-embed:
+    runs-on: ${{ matrix.options[0] }}
+    strategy:
+      matrix:
+        options:
+          - [ ubuntu-latest, linux-64 ]
+          - [ windows-latest, win-64 ]
+          - [ macos-11, osx-64 ]
+          - [ macos-11, osx-arm64 ]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc on Window
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          choco install --yes protoc
+      - name: Install protoc on mac
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew install protobuf
+      - uses: actions/setup-python@v4
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          architecture: 'x64'
+          python-version: '3.10'
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download Apple Silicon toolchain
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build wheels (Windows)
+        if: ${{ runner.os == 'Windows'}}
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Build wheels (Linux)
+        if: ${{ runner.os == 'Linux'}}
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+      - name: Build wheels (Mac)
+        if: ${{ matrix.options[1] == 'osx-64' }}
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Build Apple Silicon wheels
+        if: ${{ matrix.options[1] == 'osx-arm64' }}
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
+      - name: Remove unwanted universal
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          rm -rf target/wheels/*universal2*.whl
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*cp37*.whl
+            target/wheels/*cp38*.whl
+            target/wheels/*cp39*.whl
+            target/wheels/*cp310*.whl
+            target/wheels/*cp311*.whl
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,23 +3,11 @@ on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-  build-vegafusion-server:
-    strategy:
-      matrix:
-        options: [
-          [ ubuntu-latest,  linux-64 ],
-          [ windows-2022,  win-64 ],
-          [ macos-11,   osx-64 ],
-          [ macos-11,   osx-arm64 ],
-        ]
-    runs-on: ${{ matrix.options[0] }}
+  build-vegafusion-server-linux-64:
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install protoc on Window
-        run: |
-          choco install --yes protoc
-        if: ${{ runner.os == 'Windows' }}
       - name: Install latest stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -29,46 +17,16 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: True
-      - name: Download Apple Silicon toolchain
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build vegafusion-server (Windows)
-        uses: actions-rs/cargo@v1
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          command: build
-          args: -p vegafusion-server --release
       - name: Build vegafusion-server (Mac/Linux)
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
         with:
           command: build
           args: -p vegafusion-server --release --features=protobuf-src
-      - name: Build vegafusion-server (Apple Silicon)
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        with:
-          command: build
-          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
-      - name: zip executable (Windows)
+      - name: zip executable
         uses: papeloto/action-zip@v1
-        if: runner.os == 'Windows'
-        with:
-          files: target/release/vegafusion-server.exe
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
-      - name: zip executable (Mac or Linux)
-        uses: papeloto/action-zip@v1
-        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
         with:
           files: target/release/vegafusion-server
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
-      - name: zip executable (Apple silicon)
-        uses: papeloto/action-zip@v1
-        if: ${{ matrix.options[1] == 'osx-arm64'}}
-        with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
+          dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -76,32 +34,110 @@ jobs:
           path: |
             vegafusion-server-*
 
+  build-vegafusion-server-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Build vegafusion-server (Mac/Linux)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+          dest: vegafusion-server-linux-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
 
-  build-vegafusion-python-embed:
-    runs-on: ${{ matrix.options[0] }}
-    strategy:
-      matrix:
-        options:
-          - [ ubuntu-latest, linux-64 ]
-          - [ windows-latest, win-64 ]
-          - [ macos-11, osx-64 ]
-          - [ macos-11, osx-arm64 ]
+  build-vegafusion-server-win-64:
+    runs-on: windows-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Install protoc on Window
-        if: ${{ runner.os == 'Windows' }}
         run: |
           choco install --yes protoc
-      - name: Install protoc on mac
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew install protobuf
-      - uses: actions/setup-python@v4
-        if: ${{ runner.os == 'Windows' }}
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          architecture: 'x64'
-          python-version: '3.10'
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-server (Windows)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/release/vegafusion-server.exe
+          dest: vegafusion-server-win-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-osx-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
       - name: Install latest stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -112,52 +148,184 @@ jobs:
         with:
           cache-on-failure: True
       - name: Download Apple Silicon toolchain
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
         run: |
           rustup target add aarch64-apple-darwin
-      - name: Build wheels (Windows)
-        if: ${{ runner.os == 'Windows'}}
-        uses: messense/maturin-action@v1
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@v1
         with:
           command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
+      - name: zip executable (Apple silicon)
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
+          dest: vegafusion-server-osx-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-python-embed-linux-64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
       - name: Build wheels (Linux)
-        if: ${{ runner.os == 'Linux'}}
         uses: messense/maturin-action@v1
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-      - name: Build wheels (Mac)
-        if: ${{ matrix.options[1] == 'osx-64' }}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-      - name: Build Apple Silicon wheels
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
-      - name: Remove unwanted universal
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          rm -rf target/wheels/*universal2*.whl
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |
             target/wheels/*.tar.gz
-            target/wheels/*cp37*.whl
-            target/wheels/*cp38*.whl
-            target/wheels/*cp39*.whl
-            target/wheels/*cp310*.whl
-            target/wheels/*cp311*.whl
+            target/wheels/*.whl
 
+  build-vegafusion-python-embed-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Build arm64 wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+    build-vegafusion-python-embed-win-64:
+      runs-on: windows-latest
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2
+        - name: Install protoc
+          run: |
+            choco install --yes protoc
+        - name: Setup Python 3.10
+          uses: actions/setup-python@v4
+          with:
+            architecture: 'x64'
+            python-version: '3.10'
+        - name: Install latest stable Rust toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: stable
+            override: true
+        - name: Cache rust dependencies
+          uses: Swatinem/rust-cache@v1
+          with:
+            cache-on-failure: True
+        - name: Build wheels
+          uses: messense/maturin-action@v1
+          with:
+            command: build
+            manylinux: 2014
+            rust-toolchain: stable
+            args: --release -m vegafusion-python-embed/Cargo.toml --strip
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: vegafusion-python-embed-wheels
+            path: |
+              target/wheels/*.tar.gz
+              target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          brew install protobuf
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          brew install protobuf
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download Apple Silicon toolchain
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build Apple Silicon wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,36 +3,36 @@ on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-  build-vegafusion-server-linux-64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build vegafusion-server (Mac/Linux)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p vegafusion-server --release --features=protobuf-src
-      - name: zip executable
-        uses: papeloto/action-zip@v1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-linux-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
+#  build-vegafusion-server-linux-64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build vegafusion-server (Mac/Linux)
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release --features=protobuf-src
+#      - name: zip executable
+#        uses: papeloto/action-zip@v1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-linux-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
 
   build-vegafusion-server-linux-arm64:
     runs-on: ubuntu-latest
@@ -72,264 +72,264 @@ jobs:
           path: |
             vegafusion-server-*
 
-  build-vegafusion-server-win-64:
-    runs-on: windows-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc on Window
-        run: |
-          choco install --yes protoc
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build vegafusion-server (Windows)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p vegafusion-server --release
-      - name: zip executable
-        uses: papeloto/action-zip@v1
-        with:
-          files: target/release/vegafusion-server.exe
-          dest: vegafusion-server-win-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build vegafusion-server
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p vegafusion-server --release --features=protobuf-src
-      - name: zip executable
-        uses: papeloto/action-zip@v1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-osx-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Download Apple Silicon toolchain
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build vegafusion-server
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
-      - name: zip executable (Apple silicon)
-        uses: papeloto/action-zip@v1
-        with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
-          dest: vegafusion-server-osx-arm64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-python-embed-linux-64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build wheels (Linux)
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Build arm64 wheels
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-win-64:
-    runs-on: windows-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc
-        run: |
-          choco install --yes protoc
-      - name: Setup Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          architecture: 'x64'
-          python-version: '3.10'
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build wheels
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc
-        run: |
-          brew install protobuf
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build wheels
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc
-        run: |
-          brew install protobuf
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Download Apple Silicon toolchain
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build Apple Silicon wheels
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
+#  build-vegafusion-server-win-64:
+#    runs-on: windows-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install protoc on Window
+#        run: |
+#          choco install --yes protoc
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build vegafusion-server (Windows)
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release
+#      - name: zip executable
+#        uses: papeloto/action-zip@v1
+#        with:
+#          files: target/release/vegafusion-server.exe
+#          dest: vegafusion-server-win-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build vegafusion-server
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release --features=protobuf-src
+#      - name: zip executable
+#        uses: papeloto/action-zip@v1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-osx-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download Apple Silicon toolchain
+#        run: |
+#          rustup target add aarch64-apple-darwin
+#      - name: Build vegafusion-server
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
+#      - name: zip executable (Apple silicon)
+#        uses: papeloto/action-zip@v1
+#        with:
+#          files: target/aarch64-apple-darwin/release/vegafusion-server
+#          dest: vegafusion-server-osx-arm64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-python-embed-linux-64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build wheels (Linux)
+#        uses: messense/maturin-action@v1
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-linux-arm64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download arm64 toolchain
+#        run: |
+#          rustup target add aarch64-unknown-linux-gnu
+#      - name: Build arm64 wheels
+#        uses: messense/maturin-action@v1
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-win-64:
+#    runs-on: windows-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install protoc
+#        run: |
+#          choco install --yes protoc
+#      - name: Setup Python 3.10
+#        uses: actions/setup-python@v4
+#        with:
+#          architecture: 'x64'
+#          python-version: '3.10'
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build wheels
+#        uses: messense/maturin-action@v1
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install protoc
+#        run: |
+#          brew install protobuf
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build wheels
+#        uses: messense/maturin-action@v1
+#        with:
+#          command: build
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install protoc
+#        run: |
+#          brew install protobuf
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download Apple Silicon toolchain
+#        run: |
+#          rustup target add aarch64-apple-darwin
+#      - name: Build Apple Silicon wheels
+#        uses: messense/maturin-action@v1
+#        with:
+#          command: build
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install gcc-aarch64-linux-gnu
-      - name: Build vegafusion-server (Mac/Linux)
+      - name: Build vegafusion-server
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,34 @@
 name: build
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
 jobs:
   build-vegafusion-server-linux-64:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build vegafusion-server (Mac/Linux)
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: -p vegafusion-server --release --features=protobuf-src
       - name: zip executable
-        uses: papeloto/action-zip@v1
+        uses: papeloto/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # pin@v1
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-server
           path: |
@@ -38,14 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Download arm64 toolchain
@@ -56,19 +56,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-aarch64-linux-gnu
       - name: Build vegafusion-server
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         env:
           RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
         with:
           command: build
           args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
       - name: zip executable
-        uses: papeloto/action-zip@v1
+        uses: papeloto/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # pin@v1
         with:
           files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
           dest: vegafusion-server-linux-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-server
           path: |
@@ -78,31 +78,31 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install protoc on Window
         run: |
           choco install --yes protoc
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build vegafusion-server (Windows)
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: -p vegafusion-server --release
       - name: zip executable
-        uses: papeloto/action-zip@v1
+        uses: papeloto/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # pin@v1
         with:
           files: target/release/vegafusion-server.exe
           dest: vegafusion-server-win-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-server
           path: |
@@ -112,28 +112,28 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build vegafusion-server
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: -p vegafusion-server --release --features=protobuf-src
       - name: zip executable
-        uses: papeloto/action-zip@v1
+        uses: papeloto/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # pin@v1
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-osx-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-server
           path: |
@@ -143,31 +143,31 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Download Apple Silicon toolchain
         run: |
           rustup target add aarch64-apple-darwin
       - name: Build vegafusion-server
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
           args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
       - name: zip executable (Apple silicon)
-        uses: papeloto/action-zip@v1
+        uses: papeloto/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # pin@v1
         with:
           files: target/aarch64-apple-darwin/release/vegafusion-server
           dest: vegafusion-server-osx-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-server
           path: |
@@ -177,25 +177,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build wheels (Linux)
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |
@@ -206,28 +206,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Download arm64 toolchain
         run: |
           rustup target add aarch64-unknown-linux-gnu
       - name: Build arm64 wheels
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |
@@ -238,33 +238,33 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install protoc
         run: |
           choco install --yes protoc
       - name: Setup Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@v4
         with:
           architecture: 'x64'
           python-version: '3.10'
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build wheels
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |
@@ -275,27 +275,27 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install protoc
         run: |
           brew install protobuf
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build wheels
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
         with:
           command: build
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |
@@ -306,30 +306,30 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install protoc
         run: |
           brew install protobuf
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Download Apple Silicon toolchain
         run: |
           rustup target add aarch64-apple-darwin
       - name: Build Apple Silicon wheels
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
         with:
           command: build
           rust-toolchain: stable
           args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-python-embed-wheels
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Download arm64 toolchain
         run: |
           rustup target add aarch64-unknown-linux-gnu
+      - name: Download gcc for cross compilation
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-aarch64-linux-gnu
       - name: Build vegafusion-server (Mac/Linux)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
           sudo apt-get install gcc-aarch64-linux-gnu
       - name: Build vegafusion-server
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
         with:
           command: build
           args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,36 +3,36 @@ on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-#  build-vegafusion-server-linux-64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build vegafusion-server (Mac/Linux)
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release --features=protobuf-src
-#      - name: zip executable
-#        uses: papeloto/action-zip@v1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-linux-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
+  build-vegafusion-server-linux-64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-server (Mac/Linux)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-linux-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
 
   build-vegafusion-server-linux-arm64:
     runs-on: ubuntu-latest
@@ -74,264 +74,264 @@ jobs:
           path: |
             vegafusion-server-*
 
-#  build-vegafusion-server-win-64:
-#    runs-on: windows-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install protoc on Window
-#        run: |
-#          choco install --yes protoc
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build vegafusion-server (Windows)
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release
-#      - name: zip executable
-#        uses: papeloto/action-zip@v1
-#        with:
-#          files: target/release/vegafusion-server.exe
-#          dest: vegafusion-server-win-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build vegafusion-server
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release --features=protobuf-src
-#      - name: zip executable
-#        uses: papeloto/action-zip@v1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-osx-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download Apple Silicon toolchain
-#        run: |
-#          rustup target add aarch64-apple-darwin
-#      - name: Build vegafusion-server
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
-#      - name: zip executable (Apple silicon)
-#        uses: papeloto/action-zip@v1
-#        with:
-#          files: target/aarch64-apple-darwin/release/vegafusion-server
-#          dest: vegafusion-server-osx-arm64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-python-embed-linux-64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build wheels (Linux)
-#        uses: messense/maturin-action@v1
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-linux-arm64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download arm64 toolchain
-#        run: |
-#          rustup target add aarch64-unknown-linux-gnu
-#      - name: Build arm64 wheels
-#        uses: messense/maturin-action@v1
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-win-64:
-#    runs-on: windows-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install protoc
-#        run: |
-#          choco install --yes protoc
-#      - name: Setup Python 3.10
-#        uses: actions/setup-python@v4
-#        with:
-#          architecture: 'x64'
-#          python-version: '3.10'
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build wheels
-#        uses: messense/maturin-action@v1
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install protoc
-#        run: |
-#          brew install protobuf
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build wheels
-#        uses: messense/maturin-action@v1
-#        with:
-#          command: build
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install protoc
-#        run: |
-#          brew install protobuf
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download Apple Silicon toolchain
-#        run: |
-#          rustup target add aarch64-apple-darwin
-#      - name: Build Apple Silicon wheels
-#        uses: messense/maturin-action@v1
-#        with:
-#          command: build
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
+  build-vegafusion-server-win-64:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc on Window
+        run: |
+          choco install --yes protoc
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-server (Windows)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/release/vegafusion-server.exe
+          dest: vegafusion-server-win-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src
+      - name: zip executable
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-osx-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download Apple Silicon toolchain
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
+      - name: zip executable (Apple silicon)
+        uses: papeloto/action-zip@v1
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
+          dest: vegafusion-server-osx-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-python-embed-linux-64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels (Linux)
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Build arm64 wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-win-64:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          choco install --yes protoc
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          architecture: 'x64'
+          python-version: '3.10'
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          brew install protobuf
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          brew install protobuf
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Download Apple Silicon toolchain
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build Apple Silicon wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,42 +228,42 @@ jobs:
             target/wheels/*.tar.gz
             target/wheels/*.whl
 
-    build-vegafusion-python-embed-win-64:
-      runs-on: windows-latest
-      steps:
-        - name: Check out repository code
-          uses: actions/checkout@v2
-        - name: Install protoc
-          run: |
-            choco install --yes protoc
-        - name: Setup Python 3.10
-          uses: actions/setup-python@v4
-          with:
-            architecture: 'x64'
-            python-version: '3.10'
-        - name: Install latest stable Rust toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
-            override: true
-        - name: Cache rust dependencies
-          uses: Swatinem/rust-cache@v1
-          with:
-            cache-on-failure: True
-        - name: Build wheels
-          uses: messense/maturin-action@v1
-          with:
-            command: build
-            manylinux: 2014
-            rust-toolchain: stable
-            args: --release -m vegafusion-python-embed/Cargo.toml --strip
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v2
-          with:
-            name: vegafusion-python-embed-wheels
-            path: |
-              target/wheels/*.tar.gz
-              target/wheels/*.whl
+  build-vegafusion-python-embed-win-64:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: |
+          choco install --yes protoc
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          architecture: 'x64'
+          python-version: '3.10'
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
 
   build-vegafusion-python-embed-osx-64:
     runs-on: macos-11

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,7 +1,7 @@
 name: build_test
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
 jobs:
   rust-fmt-clippy:
     runs-on: ubuntu-latest
@@ -9,15 +9,15 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
           components: rustfmt, clippy
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Check cargo fmt compliance
@@ -32,13 +32,13 @@ jobs:
     strategy:
       matrix:
         os:
-         - ubuntu-latest
-         - windows-2022
-         - macos-11
+          - ubuntu-latest
+          - windows-2022
+          - macos-11
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install apt system dependencies needed to build nodecanvas
         run: |
           sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
@@ -48,12 +48,12 @@ jobs:
           choco install --yes protoc
         if: ${{ runner.os == 'Windows' }}
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # pin@v2
         with:
           node-version: '17.9.0'
       - name: Install test node dependencies
@@ -62,7 +62,7 @@ jobs:
           npm install
       - name: Run Rust Tests (Windows)
         if: ${{ runner.os == 'Windows' }}
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         env:
           CARGO_HOME: C:\cargo_home\
           CARGO_TARGET_DIR: C:\cargo_target_dir\
@@ -71,28 +71,27 @@ jobs:
           args: --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
       - name: Run Rust Tests (MacOs/Linux)
         if: ${{ runner.os != 'Windows' }}
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: test
           args: --release --all-features --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         if: always()
         with:
           name: vegafusion-rt-test-images
           path: |
             vegafusion-runtime/tests/output
 
-
   build-vegafusion-wasm:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # pin@v2
         with:
           node-version: '17.9.0'
       - name: Build package
@@ -101,7 +100,7 @@ jobs:
           npm run build:protobuf-src
           wasm-pack pack
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-wasm-packages
           path: vegafusion-wasm/pkg
@@ -113,8 +112,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
+      - uses: conda-incubator/setup-miniconda@3b0f2504dd76ef23b6d31f291f4913fb60ab5ff3 # pin@v2
         with:
           auto-update-conda: true
           activate-environment: vegafusion_dev
@@ -125,31 +124,30 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-wheel
           path: |
             python/vegafusion/dist/*.whl
             python/vegafusion/dist/*.tar.gz
 
-
   build-vegafusion-jupyter-package:
-    needs: [build-vegafusion-wheel, build-vegafusion-wasm]
+    needs: [ build-vegafusion-wheel, build-vegafusion-wasm ]
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
+      - uses: conda-incubator/setup-miniconda@3b0f2504dd76ef23b6d31f291f4913fb60ab5ff3 # pin@v2
         with:
           auto-update-conda: true
           activate-environment: vegafusion_dev
           miniforge-version: latest
           environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
       - name: Download vegafusion-wasm packages
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: vegafusion-wasm-packages
           path: vegafusion-wasm/pkg
@@ -159,7 +157,7 @@ jobs:
           npm install
           npm run build
       - name: Download vegafusion wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: vegafusion-wheel
           path: target/wheels/
@@ -175,16 +173,19 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: vegafusion-jupyter-packages
           path: |
             python/vegafusion-jupyter/dist/*.whl
             python/vegafusion-jupyter/dist/*.tar.gz
 
-
   test-vegafusion-python:
-    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
+    needs:
+      [
+        build-vegafusion-wheel,
+        build-vegafusion-jupyter-package
+      ]
     strategy:
       matrix:
         options: [
@@ -205,9 +206,9 @@ jobs:
         shell: ${{ matrix.options[2] }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Create conda test environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@3b0f2504dd76ef23b6d31f291f4913fb60ab5ff3 # pin@v2
         with:
           auto-update-conda: true
           activate-environment: vegafusion_dev
@@ -218,12 +219,12 @@ jobs:
           choco install --yes protoc
         if: ${{ runner.os == 'Windows' }}
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Build vegafusion-python-embed in development mode (Non-windows)
@@ -235,19 +236,19 @@ jobs:
           maturin develop --release -m vegafusion-python-embed/Cargo.toml
         if: ${{ runner.os == 'Windows' }}
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
+        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
         with:
           chrome-version: stable
       - name: Install ChromeDriver
         run: |
           pip install chromedriver-binary-auto
       - name: Download vegafusion wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: vegafusion-wheel
           path: target/wheels/
       - name: Download vegafusion-jupyter wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: vegafusion-jupyter-packages
           path: target/wheels/
@@ -272,7 +273,7 @@ jobs:
         run: pytest
         if: ${{ matrix.options[5] == 'vegafusion-jupyter' }}
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         if: always()
         with:
           name: vegafusion-jupyter-test-failures

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -83,162 +83,6 @@ jobs:
           path: |
             vegafusion-runtime/tests/output
 
-  build-vegafusion-server:
-    strategy:
-      matrix:
-        options: [
-            [ubuntu-latest,  linux-64],
-            [windows-2022,  win-64],
-            [macos-11,   osx-64],
-            [macos-11,   osx-arm64],
-        ]
-    runs-on: ${{ matrix.options[0] }}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc on Window
-        run: |
-          choco install --yes protoc
-        if: ${{ runner.os == 'Windows' }}
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Download Apple Silicon toolchain
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build vegafusion-server (Windows)
-        uses: actions-rs/cargo@v1
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          command: build
-          args: -p vegafusion-server --release
-      - name: Build vegafusion-server (Mac/Linux)
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
-        with:
-          command: build
-          args: -p vegafusion-server --release --features=protobuf-src
-      - name: Build vegafusion-server (Apple Silicon)
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        with:
-          command: build
-          args: -p vegafusion-server --release --target aarch64-apple-darwin --features=protobuf-src
-      - name: zip executable (Windows)
-        uses: papeloto/action-zip@v1
-        if: runner.os == 'Windows'
-        with:
-          files: target/release/vegafusion-server.exe
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
-      - name: zip executable (Mac or Linux)
-        uses: papeloto/action-zip@v1
-        if: ${{ matrix.options[1] != 'osx-arm64' && runner.os != 'Windows'}}
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
-      - name: zip executable (Apple silicon)
-        uses: papeloto/action-zip@v1
-        if: ${{ matrix.options[1] == 'osx-arm64'}}
-        with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
-          dest: vegafusion-server-${{ matrix.options[1] }}.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-python-embed:
-    runs-on: ${{ matrix.options[0] }}
-    strategy:
-      matrix:
-        options:
-         - [ubuntu-latest, linux-64]
-         - [windows-latest, win-64]
-         - [macos-11, osx-64]
-         - [macos-11, osx-arm64]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install protoc on Window
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          choco install --yes protoc
-      - name: Install protoc on mac
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew install protobuf
-      - uses: actions/setup-python@v4
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          architecture: 'x64'
-          python-version: '3.10'
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Download Apple Silicon toolchain
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build wheels (Windows)
-        if: ${{ runner.os == 'Windows'}}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-      - name: Build wheels (Linux)
-        if: ${{ runner.os == 'Linux'}}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-      - name: Build wheels (Mac)
-        if: ${{ matrix.options[1] == 'osx-64' }}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip
-      - name: Build Apple Silicon wheels
-        if: ${{ matrix.options[1] == 'osx-arm64' }}
-        uses: messense/maturin-action@v1
-        with:
-          command: build
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --strip --target aarch64-apple-darwin
-      - name: Remove unwanted universal
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          rm -rf target/wheels/*universal2*.whl
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*cp37*.whl
-            target/wheels/*cp38*.whl
-            target/wheels/*cp39*.whl
-            target/wheels/*cp310*.whl
-            target/wheels/*cp311*.whl
 
   build-vegafusion-wasm:
     runs-on: ubuntu-latest
@@ -288,6 +132,7 @@ jobs:
             python/vegafusion/dist/*.whl
             python/vegafusion/dist/*.tar.gz
 
+
   build-vegafusion-jupyter-package:
     needs: [build-vegafusion-wheel, build-vegafusion-wasm]
     runs-on: ubuntu-latest
@@ -336,6 +181,7 @@ jobs:
           path: |
             python/vegafusion-jupyter/dist/*.whl
             python/vegafusion-jupyter/dist/*.tar.gz
+
 
   test-vegafusion-python:
     needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,280 +1,280 @@
-#name: build_test
-#on:
-#  pull_request:
-#    types: [opened, synchronize]
-#jobs:
-#  rust-fmt-clippy:
-#    runs-on: ubuntu-latest
-#    env:
-#      RUSTFLAGS: "-D warnings"
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#          components: rustfmt, clippy
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Check cargo fmt compliance
-#        run: cargo fmt --all -- --check
-#      - name: Check no rustc warnings
-#        run: cargo check --tests --features=protobuf-src
-#      - name: Check for clippy warnings
-#        run: cargo clippy --features=protobuf-src -- -A clippy::borrow_deref_ref
-#
-#  test-rust:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        os:
-#         - ubuntu-latest
-#         - windows-2022
-#         - macos-11
-#
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install apt system dependencies needed to build nodecanvas
-#        run: |
-#          sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
-#        if: ${{ runner.os == 'Linux' }}
-#      - name: Install protoc on Window
-#        run: |
-#          choco install --yes protoc
-#        if: ${{ runner.os == 'Windows' }}
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Install node
-#        uses: actions/setup-node@v2
-#        with:
-#          node-version: '17.9.0'
-#      - name: Install test node dependencies
-#        working-directory: vegafusion-runtime/tests/util/vegajs_runtime
-#        run: |
-#          npm install
-#      - name: Run Rust Tests (Windows)
-#        if: ${{ runner.os == 'Windows' }}
-#        uses: actions-rs/cargo@v1
-#        env:
-#          CARGO_HOME: C:\cargo_home\
-#          CARGO_TARGET_DIR: C:\cargo_target_dir\
-#        with:
-#          command: test
-#          args: --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
-#      - name: Run Rust Tests (MacOs/Linux)
-#        if: ${{ runner.os != 'Windows' }}
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: test
-#          args: --release --all-features --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: vegafusion-rt-test-images
-#          path: |
-#            vegafusion-runtime/tests/output
-#
-#
-#  build-vegafusion-wasm:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install wasm-pack
-#        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-#      - name: Install node
-#        uses: actions/setup-node@v2
-#        with:
-#          node-version: '17.9.0'
-#      - name: Build package
-#        working-directory: vegafusion-wasm/
-#        run: |
-#          npm run build:protobuf-src
-#          wasm-pack pack
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-wasm-packages
-#          path: vegafusion-wasm/pkg
-#
-#  build-vegafusion-wheel:
-#    runs-on: ubuntu-latest
-#    defaults:
-#      run:
-#        shell: bash -l {0}
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - uses: conda-incubator/setup-miniconda@v2
-#        with:
-#          auto-update-conda: true
-#          activate-environment: vegafusion_dev
-#          miniforge-version: latest
-#          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
-#      - name: Build vegafusion
-#        working-directory: python/vegafusion
-#        run: |
-#          python setup.py sdist bdist_wheel
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-wheel
-#          path: |
-#            python/vegafusion/dist/*.whl
-#            python/vegafusion/dist/*.tar.gz
-#
-#
-#  build-vegafusion-jupyter-package:
-#    needs: [build-vegafusion-wheel, build-vegafusion-wasm]
-#    runs-on: ubuntu-latest
-#    defaults:
-#      run:
-#        shell: bash -l {0}
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - uses: conda-incubator/setup-miniconda@v2
-#        with:
-#          auto-update-conda: true
-#          activate-environment: vegafusion_dev
-#          miniforge-version: latest
-#          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
-#      - name: Download vegafusion-wasm packages
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: vegafusion-wasm-packages
-#          path: vegafusion-wasm/pkg
-#      - name: Build vegafusion-embed
-#        working-directory: javascript/vegafusion-embed/
-#        run: |
-#          npm install
-#          npm run build
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: vegafusion-wheel
-#          path: target/wheels/
-#      - name: Install vegafusion wheel
-#        run: |
-#          python -m pip install target/wheels/vegafusion-*.whl
-#      - name: Install vegafusion-wasm npm dependencies
-#        working-directory: vegafusion-wasm/
-#        run: |
-#          npm install
-#      - name: Build vegafusion-jupyter
-#        working-directory: python/vegafusion-jupyter
-#        run: |
-#          python setup.py sdist bdist_wheel
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: |
-#            python/vegafusion-jupyter/dist/*.whl
-#            python/vegafusion-jupyter/dist/*.tar.gz
-#
-#
-#  test-vegafusion-python:
-#    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
-#    strategy:
-#      matrix:
-#        options: [
-#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion-jupyter"],
-#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion"],
-#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion-jupyter"],
-#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion"],
-#
-## TODO: Should vegafusion-jupyter tests on Windows and Mac as well, but there a selenium+GitHub action issue
-##            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion"],
-##            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion"],
-##            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion-jupyter"],
-##            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion-jupyter"],
-#        ]
-#    runs-on: ${{ matrix.options[0] }}
-#    defaults:
-#      run:
-#        shell: ${{ matrix.options[2] }}
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Create conda test environment
-#        uses: conda-incubator/setup-miniconda@v2
-#        with:
-#          auto-update-conda: true
-#          activate-environment: vegafusion_dev
-#          miniforge-version: latest
-#          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[3] }}.lock
-#      - name: Install protoc on Window
-#        run: |
-#          choco install --yes protoc
-#        if: ${{ runner.os == 'Windows' }}
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build vegafusion-python-embed in development mode (Non-windows)
-#        run: |
-#          maturin develop --release --features=protobuf-src -m vegafusion-python-embed/Cargo.toml
-#        if: ${{ runner.os != 'Windows' }}
-#      - name: Build vegafusion-python-embed in development mode (Windows)
-#        run: |
-#          maturin develop --release -m vegafusion-python-embed/Cargo.toml
-#        if: ${{ runner.os == 'Windows' }}
-#      - name: Install Chrome
-#        uses: browser-actions/setup-chrome@latest
-#        with:
-#          chrome-version: stable
-#      - name: Install ChromeDriver
-#        run: |
-#          pip install chromedriver-binary-auto
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: vegafusion-wheel
-#          path: target/wheels/
-#      - name: Download vegafusion-jupyter wheel
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        run: |
-#          ls -la
-#          python -m pip install vegafusion-*.whl
-#          python -m pip install vegafusion_jupyter*.whl
-#          python -m pip install vl-convert-python==0.10.3
-#      - name: Update to latest Altair 5
-#        run: |
-#          pip install -U altair
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#        if: ${{ matrix.options[4] == 'vegafusion' }}
-#      - name: Test vegafusion-jupyter
-#        env:
-#          VEGAFUSION_TEST_HEADLESS: 1
-#        working-directory: python/vegafusion-jupyter/tests/
-#        run: pytest
-#        if: ${{ matrix.options[5] == 'vegafusion-jupyter' }}
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: vegafusion-jupyter-test-failures
-#          path: |
-#            python/vegafusion-jupyter/tests/failures/*
+name: build_test
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  rust-fmt-clippy:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Check cargo fmt compliance
+        run: cargo fmt --all -- --check
+      - name: Check no rustc warnings
+        run: cargo check --tests --features=protobuf-src
+      - name: Check for clippy warnings
+        run: cargo clippy --features=protobuf-src -- -A clippy::borrow_deref_ref
+
+  test-rust:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+         - ubuntu-latest
+         - windows-2022
+         - macos-11
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install apt system dependencies needed to build nodecanvas
+        run: |
+          sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+        if: ${{ runner.os == 'Linux' }}
+      - name: Install protoc on Window
+        run: |
+          choco install --yes protoc
+        if: ${{ runner.os == 'Windows' }}
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17.9.0'
+      - name: Install test node dependencies
+        working-directory: vegafusion-runtime/tests/util/vegajs_runtime
+        run: |
+          npm install
+      - name: Run Rust Tests (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_HOME: C:\cargo_home\
+          CARGO_TARGET_DIR: C:\cargo_target_dir\
+        with:
+          command: test
+          args: --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
+      - name: Run Rust Tests (MacOs/Linux)
+        if: ${{ runner.os != 'Windows' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --all-features --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: vegafusion-rt-test-images
+          path: |
+            vegafusion-runtime/tests/output
+
+
+  build-vegafusion-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17.9.0'
+      - name: Build package
+        working-directory: vegafusion-wasm/
+        run: |
+          npm run build:protobuf-src
+          wasm-pack pack
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-wasm-packages
+          path: vegafusion-wasm/pkg
+
+  build-vegafusion-wheel:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: vegafusion_dev
+          miniforge-version: latest
+          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
+      - name: Build vegafusion
+        working-directory: python/vegafusion
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-wheel
+          path: |
+            python/vegafusion/dist/*.whl
+            python/vegafusion/dist/*.tar.gz
+
+
+  build-vegafusion-jupyter-package:
+    needs: [build-vegafusion-wheel, build-vegafusion-wasm]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: vegafusion_dev
+          miniforge-version: latest
+          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
+      - name: Download vegafusion-wasm packages
+        uses: actions/download-artifact@v2
+        with:
+          name: vegafusion-wasm-packages
+          path: vegafusion-wasm/pkg
+      - name: Build vegafusion-embed
+        working-directory: javascript/vegafusion-embed/
+        run: |
+          npm install
+          npm run build
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@v2
+        with:
+          name: vegafusion-wheel
+          path: target/wheels/
+      - name: Install vegafusion wheel
+        run: |
+          python -m pip install target/wheels/vegafusion-*.whl
+      - name: Install vegafusion-wasm npm dependencies
+        working-directory: vegafusion-wasm/
+        run: |
+          npm install
+      - name: Build vegafusion-jupyter
+        working-directory: python/vegafusion-jupyter
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vegafusion-jupyter-packages
+          path: |
+            python/vegafusion-jupyter/dist/*.whl
+            python/vegafusion-jupyter/dist/*.tar.gz
+
+
+  test-vegafusion-python:
+    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
+    strategy:
+      matrix:
+        options: [
+            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion-jupyter"],
+            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion"],
+            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion-jupyter"],
+            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion"],
+
+# TODO: Should vegafusion-jupyter tests on Windows and Mac as well, but there a selenium+GitHub action issue
+#            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion"],
+#            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion"],
+#            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion-jupyter"],
+#            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion-jupyter"],
+        ]
+    runs-on: ${{ matrix.options[0] }}
+    defaults:
+      run:
+        shell: ${{ matrix.options[2] }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Create conda test environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: vegafusion_dev
+          miniforge-version: latest
+          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[3] }}.lock
+      - name: Install protoc on Window
+        run: |
+          choco install --yes protoc
+        if: ${{ runner.os == 'Windows' }}
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Build vegafusion-python-embed in development mode (Non-windows)
+        run: |
+          maturin develop --release --features=protobuf-src -m vegafusion-python-embed/Cargo.toml
+        if: ${{ runner.os != 'Windows' }}
+      - name: Build vegafusion-python-embed in development mode (Windows)
+        run: |
+          maturin develop --release -m vegafusion-python-embed/Cargo.toml
+        if: ${{ runner.os == 'Windows' }}
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
+      - name: Install ChromeDriver
+        run: |
+          pip install chromedriver-binary-auto
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@v2
+        with:
+          name: vegafusion-wheel
+          path: target/wheels/
+      - name: Download vegafusion-jupyter wheel
+        uses: actions/download-artifact@v2
+        with:
+          name: vegafusion-jupyter-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        run: |
+          ls -la
+          python -m pip install vegafusion-*.whl
+          python -m pip install vegafusion_jupyter*.whl
+          python -m pip install vl-convert-python==0.10.3
+      - name: Update to latest Altair 5
+        run: |
+          pip install -U altair
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+        if: ${{ matrix.options[4] == 'vegafusion' }}
+      - name: Test vegafusion-jupyter
+        env:
+          VEGAFUSION_TEST_HEADLESS: 1
+        working-directory: python/vegafusion-jupyter/tests/
+        run: pytest
+        if: ${{ matrix.options[5] == 'vegafusion-jupyter' }}
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: vegafusion-jupyter-test-failures
+          path: |
+            python/vegafusion-jupyter/tests/failures/*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,280 +1,280 @@
-name: build_test
-on:
-  pull_request:
-    types: [opened, synchronize]
-jobs:
-  rust-fmt-clippy:
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Check cargo fmt compliance
-        run: cargo fmt --all -- --check
-      - name: Check no rustc warnings
-        run: cargo check --tests --features=protobuf-src
-      - name: Check for clippy warnings
-        run: cargo clippy --features=protobuf-src -- -A clippy::borrow_deref_ref
-
-  test-rust:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-         - ubuntu-latest
-         - windows-2022
-         - macos-11
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install apt system dependencies needed to build nodecanvas
-        run: |
-          sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
-        if: ${{ runner.os == 'Linux' }}
-      - name: Install protoc on Window
-        run: |
-          choco install --yes protoc
-        if: ${{ runner.os == 'Windows' }}
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Install node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '17.9.0'
-      - name: Install test node dependencies
-        working-directory: vegafusion-runtime/tests/util/vegajs_runtime
-        run: |
-          npm install
-      - name: Run Rust Tests (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_HOME: C:\cargo_home\
-          CARGO_TARGET_DIR: C:\cargo_target_dir\
-        with:
-          command: test
-          args: --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
-      - name: Run Rust Tests (MacOs/Linux)
-        if: ${{ runner.os != 'Windows' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: vegafusion-rt-test-images
-          path: |
-            vegafusion-runtime/tests/output
-
-
-  build-vegafusion-wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Install node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '17.9.0'
-      - name: Build package
-        working-directory: vegafusion-wasm/
-        run: |
-          npm run build:protobuf-src
-          wasm-pack pack
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-wasm-packages
-          path: vegafusion-wasm/pkg
-
-  build-vegafusion-wheel:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          activate-environment: vegafusion_dev
-          miniforge-version: latest
-          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
-      - name: Build vegafusion
-        working-directory: python/vegafusion
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-wheel
-          path: |
-            python/vegafusion/dist/*.whl
-            python/vegafusion/dist/*.tar.gz
-
-
-  build-vegafusion-jupyter-package:
-    needs: [build-vegafusion-wheel, build-vegafusion-wasm]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          activate-environment: vegafusion_dev
-          miniforge-version: latest
-          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
-      - name: Download vegafusion-wasm packages
-        uses: actions/download-artifact@v2
-        with:
-          name: vegafusion-wasm-packages
-          path: vegafusion-wasm/pkg
-      - name: Build vegafusion-embed
-        working-directory: javascript/vegafusion-embed/
-        run: |
-          npm install
-          npm run build
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@v2
-        with:
-          name: vegafusion-wheel
-          path: target/wheels/
-      - name: Install vegafusion wheel
-        run: |
-          python -m pip install target/wheels/vegafusion-*.whl
-      - name: Install vegafusion-wasm npm dependencies
-        working-directory: vegafusion-wasm/
-        run: |
-          npm install
-      - name: Build vegafusion-jupyter
-        working-directory: python/vegafusion-jupyter
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vegafusion-jupyter-packages
-          path: |
-            python/vegafusion-jupyter/dist/*.whl
-            python/vegafusion-jupyter/dist/*.tar.gz
-
-
-  test-vegafusion-python:
-    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
-    strategy:
-      matrix:
-        options: [
-            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion-jupyter"],
-            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion"],
-            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion-jupyter"],
-            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion"],
-
-# TODO: Should vegafusion-jupyter tests on Windows and Mac as well, but there a selenium+GitHub action issue
-#            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion"],
-#            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion"],
-#            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion-jupyter"],
-#            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion-jupyter"],
-        ]
-    runs-on: ${{ matrix.options[0] }}
-    defaults:
-      run:
-        shell: ${{ matrix.options[2] }}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Create conda test environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          activate-environment: vegafusion_dev
-          miniforge-version: latest
-          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[3] }}.lock
-      - name: Install protoc on Window
-        run: |
-          choco install --yes protoc
-        if: ${{ runner.os == 'Windows' }}
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Build vegafusion-python-embed in development mode (Non-windows)
-        run: |
-          maturin develop --release --features=protobuf-src -m vegafusion-python-embed/Cargo.toml
-        if: ${{ runner.os != 'Windows' }}
-      - name: Build vegafusion-python-embed in development mode (Windows)
-        run: |
-          maturin develop --release -m vegafusion-python-embed/Cargo.toml
-        if: ${{ runner.os == 'Windows' }}
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
-      - name: Install ChromeDriver
-        run: |
-          pip install chromedriver-binary-auto
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@v2
-        with:
-          name: vegafusion-wheel
-          path: target/wheels/
-      - name: Download vegafusion-jupyter wheel
-        uses: actions/download-artifact@v2
-        with:
-          name: vegafusion-jupyter-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        run: |
-          ls -la
-          python -m pip install vegafusion-*.whl
-          python -m pip install vegafusion_jupyter*.whl
-          python -m pip install vl-convert-python==0.10.3
-      - name: Update to latest Altair 5
-        run: |
-          pip install -U altair
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-        if: ${{ matrix.options[4] == 'vegafusion' }}
-      - name: Test vegafusion-jupyter
-        env:
-          VEGAFUSION_TEST_HEADLESS: 1
-        working-directory: python/vegafusion-jupyter/tests/
-        run: pytest
-        if: ${{ matrix.options[5] == 'vegafusion-jupyter' }}
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: vegafusion-jupyter-test-failures
-          path: |
-            python/vegafusion-jupyter/tests/failures/*
+#name: build_test
+#on:
+#  pull_request:
+#    types: [opened, synchronize]
+#jobs:
+#  rust-fmt-clippy:
+#    runs-on: ubuntu-latest
+#    env:
+#      RUSTFLAGS: "-D warnings"
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#          components: rustfmt, clippy
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Check cargo fmt compliance
+#        run: cargo fmt --all -- --check
+#      - name: Check no rustc warnings
+#        run: cargo check --tests --features=protobuf-src
+#      - name: Check for clippy warnings
+#        run: cargo clippy --features=protobuf-src -- -A clippy::borrow_deref_ref
+#
+#  test-rust:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        os:
+#         - ubuntu-latest
+#         - windows-2022
+#         - macos-11
+#
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install apt system dependencies needed to build nodecanvas
+#        run: |
+#          sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+#        if: ${{ runner.os == 'Linux' }}
+#      - name: Install protoc on Window
+#        run: |
+#          choco install --yes protoc
+#        if: ${{ runner.os == 'Windows' }}
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Install node
+#        uses: actions/setup-node@v2
+#        with:
+#          node-version: '17.9.0'
+#      - name: Install test node dependencies
+#        working-directory: vegafusion-runtime/tests/util/vegajs_runtime
+#        run: |
+#          npm install
+#      - name: Run Rust Tests (Windows)
+#        if: ${{ runner.os == 'Windows' }}
+#        uses: actions-rs/cargo@v1
+#        env:
+#          CARGO_HOME: C:\cargo_home\
+#          CARGO_TARGET_DIR: C:\cargo_target_dir\
+#        with:
+#          command: test
+#          args: --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
+#      - name: Run Rust Tests (MacOs/Linux)
+#        if: ${{ runner.os != 'Windows' }}
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: test
+#          args: --release --all-features --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: vegafusion-rt-test-images
+#          path: |
+#            vegafusion-runtime/tests/output
+#
+#
+#  build-vegafusion-wasm:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install wasm-pack
+#        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+#      - name: Install node
+#        uses: actions/setup-node@v2
+#        with:
+#          node-version: '17.9.0'
+#      - name: Build package
+#        working-directory: vegafusion-wasm/
+#        run: |
+#          npm run build:protobuf-src
+#          wasm-pack pack
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-wasm-packages
+#          path: vegafusion-wasm/pkg
+#
+#  build-vegafusion-wheel:
+#    runs-on: ubuntu-latest
+#    defaults:
+#      run:
+#        shell: bash -l {0}
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          auto-update-conda: true
+#          activate-environment: vegafusion_dev
+#          miniforge-version: latest
+#          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
+#      - name: Build vegafusion
+#        working-directory: python/vegafusion
+#        run: |
+#          python setup.py sdist bdist_wheel
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-wheel
+#          path: |
+#            python/vegafusion/dist/*.whl
+#            python/vegafusion/dist/*.tar.gz
+#
+#
+#  build-vegafusion-jupyter-package:
+#    needs: [build-vegafusion-wheel, build-vegafusion-wasm]
+#    runs-on: ubuntu-latest
+#    defaults:
+#      run:
+#        shell: bash -l {0}
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          auto-update-conda: true
+#          activate-environment: vegafusion_dev
+#          miniforge-version: latest
+#          environment-file: python/vegafusion-jupyter/conda-linux-64-cp310.lock
+#      - name: Download vegafusion-wasm packages
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: vegafusion-wasm-packages
+#          path: vegafusion-wasm/pkg
+#      - name: Build vegafusion-embed
+#        working-directory: javascript/vegafusion-embed/
+#        run: |
+#          npm install
+#          npm run build
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: vegafusion-wheel
+#          path: target/wheels/
+#      - name: Install vegafusion wheel
+#        run: |
+#          python -m pip install target/wheels/vegafusion-*.whl
+#      - name: Install vegafusion-wasm npm dependencies
+#        working-directory: vegafusion-wasm/
+#        run: |
+#          npm install
+#      - name: Build vegafusion-jupyter
+#        working-directory: python/vegafusion-jupyter
+#        run: |
+#          python setup.py sdist bdist_wheel
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: |
+#            python/vegafusion-jupyter/dist/*.whl
+#            python/vegafusion-jupyter/dist/*.tar.gz
+#
+#
+#  test-vegafusion-python:
+#    needs: [ build-vegafusion-wheel, build-vegafusion-jupyter-package ]
+#    strategy:
+#      matrix:
+#        options: [
+#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion-jupyter"],
+#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp38,  "vegafusion"],
+#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion-jupyter"],
+#            [ubuntu-latest,  linux-64, "bash -l {0}",  cp310, "vegafusion"],
+#
+## TODO: Should vegafusion-jupyter tests on Windows and Mac as well, but there a selenium+GitHub action issue
+##            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion"],
+##            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion"],
+##            [windows-2022, win-64,   "pwsh",         cp38,  "vegafusion-jupyter"],
+##            [macos-11,   osx-64,   "bash -l {0}",  cp310, "vegafusion-jupyter"],
+#        ]
+#    runs-on: ${{ matrix.options[0] }}
+#    defaults:
+#      run:
+#        shell: ${{ matrix.options[2] }}
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Create conda test environment
+#        uses: conda-incubator/setup-miniconda@v2
+#        with:
+#          auto-update-conda: true
+#          activate-environment: vegafusion_dev
+#          miniforge-version: latest
+#          environment-file: python/vegafusion-jupyter/conda-${{ matrix.options[1] }}-${{ matrix.options[3] }}.lock
+#      - name: Install protoc on Window
+#        run: |
+#          choco install --yes protoc
+#        if: ${{ runner.os == 'Windows' }}
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build vegafusion-python-embed in development mode (Non-windows)
+#        run: |
+#          maturin develop --release --features=protobuf-src -m vegafusion-python-embed/Cargo.toml
+#        if: ${{ runner.os != 'Windows' }}
+#      - name: Build vegafusion-python-embed in development mode (Windows)
+#        run: |
+#          maturin develop --release -m vegafusion-python-embed/Cargo.toml
+#        if: ${{ runner.os == 'Windows' }}
+#      - name: Install Chrome
+#        uses: browser-actions/setup-chrome@latest
+#        with:
+#          chrome-version: stable
+#      - name: Install ChromeDriver
+#        run: |
+#          pip install chromedriver-binary-auto
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: vegafusion-wheel
+#          path: target/wheels/
+#      - name: Download vegafusion-jupyter wheel
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        run: |
+#          ls -la
+#          python -m pip install vegafusion-*.whl
+#          python -m pip install vegafusion_jupyter*.whl
+#          python -m pip install vl-convert-python==0.10.3
+#      - name: Update to latest Altair 5
+#        run: |
+#          pip install -U altair
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#        if: ${{ matrix.options[4] == 'vegafusion' }}
+#      - name: Test vegafusion-jupyter
+#        env:
+#          VEGAFUSION_TEST_HEADLESS: 1
+#        working-directory: python/vegafusion-jupyter/tests/
+#        run: pytest
+#        if: ${{ matrix.options[5] == 'vegafusion-jupyter' }}
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: vegafusion-jupyter-test-failures
+#          path: |
+#            python/vegafusion-jupyter/tests/failures/*

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,24 +1,24 @@
 name: java
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
 jobs:
   build-test-java-linux64:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -35,7 +35,7 @@ jobs:
           mkdir -p native/linux-64
           cp target/release/libvegafusion_jni.so native/linux-64
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: jni-native
           path: |
@@ -45,18 +45,18 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -73,7 +73,7 @@ jobs:
           mkdir -p native/osx-64
           cp target/release/libvegafusion_jni.dylib native/osx-64
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: jni-native
           path: |
@@ -83,18 +83,18 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -108,7 +108,7 @@ jobs:
           mkdir -p native/osx-arm64
           cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: jni-native
           path: |
@@ -118,18 +118,18 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           toolchain: stable
           override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
         with:
           cache-on-failure: True
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -151,7 +151,7 @@ jobs:
           mkdir -p native/win-64
           cp target/release/vegafusion_jni.dll native/win-64
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: jni-native
           path: |
@@ -166,14 +166,14 @@ jobs:
       - build-test-java-win64
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Download jni libs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: jni-native
           path: jni-native
@@ -184,7 +184,7 @@ jobs:
           cd java
           ./gradlew jar
       - name: Upload jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # pin@v2
         with:
           name: jar
           path: |
@@ -194,19 +194,19 @@ jobs:
     strategy:
       matrix:
         os:
-         - ubuntu-20.04
-         - macos-11
-         - windows-2022
+          - ubuntu-20.04
+          - macos-11
+          - windows-2022
     runs-on: ${{ matrix.os }}
     needs: [ build-jar ]
     steps:
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Download jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
           name: jar
           path: .

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,221 +1,221 @@
-#name: java
-#on:
-#  pull_request:
-#    types: [opened, synchronize]
-#jobs:
-#  build-test-java-linux64:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Build jni
-#        run: cargo build -p vegafusion-jni --release --features=protobuf-src
-#      - name: gradle test
-#        run: |
-#          cd java
-#          ./gradlew test -i
-#        env:
-#          VEGAFUSION_JNI_LIBRARY: /home/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.so
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/linux-64
-#          cp target/release/libvegafusion_jni.so native/linux-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-test-java-osx64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Build jni
-#        run: cargo build -p vegafusion-jni --release --features=protobuf-src
-#      - name: gradle test
-#        run: |
-#          cd java
-#          ./gradlew test -i
-#        env:
-#          VEGAFUSION_JNI_LIBRARY: /Users/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.dylib
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/osx-64
-#          cp target/release/libvegafusion_jni.dylib native/osx-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-test-java-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Download Apple Silicon toolchain
-#        run: |
-#          rustup target add aarch64-apple-darwin
-#      - name: Build jni
-#        run: cargo build -p vegafusion-jni --release --features=protobuf-src --target aarch64-apple-darwin
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/osx-arm64
-#          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-test-java-win64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Install protoc with choco
-#        run: choco install --yes protoc
-#      - name: Build jni
-#        run: cargo build -p vegafusion-jni --release
-#      - name: Show release files
-#        run: |
-#          Get-ChildItem -Path target/release -Recurse
-#      - name: gradle test
-#        run: |
-#          cd java
-#          ./gradlew test -i
-#        env:
-#          VEGAFUSION_JNI_LIBRARY: D:/a/vegafusion/vegafusion/target/release/vegafusion_jni.dll
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/win-64
-#          cp target/release/vegafusion_jni.dll native/win-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-jar:
-#    runs-on: ubuntu-20.04
-#    needs:
-#      - build-test-java-linux64
-#      - build-test-java-osx64
-#      - build-test-java-osx-arm64
-#      - build-test-java-win64
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@v2
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Download jni libs
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: jni-native
-#          path: jni-native
-#      - name: Build jar
-#        env:
-#          VEGAFUSION_JNI_LIBRARIES: /home/runner/work/vegafusion/vegafusion/jni-native
-#        run: |
-#          cd java
-#          ./gradlew jar
-#      - name: Upload jar
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: jar
-#          path: |
-#            java/lib/build/libs/vegafusion-*.jar
-#
-#  try-jar:
-#    strategy:
-#      matrix:
-#        os:
-#         - ubuntu-20.04
-#         - macos-11
-#         - windows-2022
-#    runs-on: ${{ matrix.os }}
-#    needs: [ build-jar ]
-#    steps:
-#      - name: Install Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Download jar
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: jar
-#          path: .
-#      - name: Run jar (non-Windows)
-#        if: ${{ runner.os != 'Windows' }}
-#        run: |
-#          java -jar vegafusion-*.jar
-#      - name: Run jar (Windows)
-#        if: ${{ runner.os == 'Windows' }}
-#        run: |
-#          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
-#          java -jar $jarFile
+name: java
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  build-test-java-linux64:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build jni
+        run: cargo build -p vegafusion-jni --release --features=protobuf-src
+      - name: gradle test
+        run: |
+          cd java
+          ./gradlew test -i
+        env:
+          VEGAFUSION_JNI_LIBRARY: /home/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.so
+      - name: Copy native lib
+        run: |
+          mkdir -p native/linux-64
+          cp target/release/libvegafusion_jni.so native/linux-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-test-java-osx64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build jni
+        run: cargo build -p vegafusion-jni --release --features=protobuf-src
+      - name: gradle test
+        run: |
+          cd java
+          ./gradlew test -i
+        env:
+          VEGAFUSION_JNI_LIBRARY: /Users/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.dylib
+      - name: Copy native lib
+        run: |
+          mkdir -p native/osx-64
+          cp target/release/libvegafusion_jni.dylib native/osx-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-test-java-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Download Apple Silicon toolchain
+        run: |
+          rustup target add aarch64-apple-darwin
+      - name: Build jni
+        run: cargo build -p vegafusion-jni --release --features=protobuf-src --target aarch64-apple-darwin
+      - name: Copy native lib
+        run: |
+          mkdir -p native/osx-arm64
+          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-test-java-win64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: True
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Install protoc with choco
+        run: choco install --yes protoc
+      - name: Build jni
+        run: cargo build -p vegafusion-jni --release
+      - name: Show release files
+        run: |
+          Get-ChildItem -Path target/release -Recurse
+      - name: gradle test
+        run: |
+          cd java
+          ./gradlew test -i
+        env:
+          VEGAFUSION_JNI_LIBRARY: D:/a/vegafusion/vegafusion/target/release/vegafusion_jni.dll
+      - name: Copy native lib
+        run: |
+          mkdir -p native/win-64
+          cp target/release/vegafusion_jni.dll native/win-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-jar:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-test-java-linux64
+      - build-test-java-osx64
+      - build-test-java-osx-arm64
+      - build-test-java-win64
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Download jni libs
+        uses: actions/download-artifact@v2
+        with:
+          name: jni-native
+          path: jni-native
+      - name: Build jar
+        env:
+          VEGAFUSION_JNI_LIBRARIES: /home/runner/work/vegafusion/vegafusion/jni-native
+        run: |
+          cd java
+          ./gradlew jar
+      - name: Upload jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: jar
+          path: |
+            java/lib/build/libs/vegafusion-*.jar
+
+  try-jar:
+    strategy:
+      matrix:
+        os:
+         - ubuntu-20.04
+         - macos-11
+         - windows-2022
+    runs-on: ${{ matrix.os }}
+    needs: [ build-jar ]
+    steps:
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Download jar
+        uses: actions/download-artifact@v2
+        with:
+          name: jar
+          path: .
+      - name: Run jar (non-Windows)
+        if: ${{ runner.os != 'Windows' }}
+        run: |
+          java -jar vegafusion-*.jar
+      - name: Run jar (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
+          java -jar $jarFile

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,221 +1,221 @@
-name: java
-on:
-  pull_request:
-    types: [opened, synchronize]
-jobs:
-  build-test-java-linux64:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Build jni
-        run: cargo build -p vegafusion-jni --release --features=protobuf-src
-      - name: gradle test
-        run: |
-          cd java
-          ./gradlew test -i
-        env:
-          VEGAFUSION_JNI_LIBRARY: /home/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.so
-      - name: Copy native lib
-        run: |
-          mkdir -p native/linux-64
-          cp target/release/libvegafusion_jni.so native/linux-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-test-java-osx64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Build jni
-        run: cargo build -p vegafusion-jni --release --features=protobuf-src
-      - name: gradle test
-        run: |
-          cd java
-          ./gradlew test -i
-        env:
-          VEGAFUSION_JNI_LIBRARY: /Users/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.dylib
-      - name: Copy native lib
-        run: |
-          mkdir -p native/osx-64
-          cp target/release/libvegafusion_jni.dylib native/osx-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-test-java-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download Apple Silicon toolchain
-        run: |
-          rustup target add aarch64-apple-darwin
-      - name: Build jni
-        run: cargo build -p vegafusion-jni --release --features=protobuf-src --target aarch64-apple-darwin
-      - name: Copy native lib
-        run: |
-          mkdir -p native/osx-arm64
-          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-test-java-win64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: True
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Install protoc with choco
-        run: choco install --yes protoc
-      - name: Build jni
-        run: cargo build -p vegafusion-jni --release
-      - name: Show release files
-        run: |
-          Get-ChildItem -Path target/release -Recurse
-      - name: gradle test
-        run: |
-          cd java
-          ./gradlew test -i
-        env:
-          VEGAFUSION_JNI_LIBRARY: D:/a/vegafusion/vegafusion/target/release/vegafusion_jni.dll
-      - name: Copy native lib
-        run: |
-          mkdir -p native/win-64
-          cp target/release/vegafusion_jni.dll native/win-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-jar:
-    runs-on: ubuntu-20.04
-    needs:
-      - build-test-java-linux64
-      - build-test-java-osx64
-      - build-test-java-osx-arm64
-      - build-test-java-win64
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download jni libs
-        uses: actions/download-artifact@v2
-        with:
-          name: jni-native
-          path: jni-native
-      - name: Build jar
-        env:
-          VEGAFUSION_JNI_LIBRARIES: /home/runner/work/vegafusion/vegafusion/jni-native
-        run: |
-          cd java
-          ./gradlew jar
-      - name: Upload jar
-        uses: actions/upload-artifact@v2
-        with:
-          name: jar
-          path: |
-            java/lib/build/libs/vegafusion-*.jar
-
-  try-jar:
-    strategy:
-      matrix:
-        os:
-         - ubuntu-20.04
-         - macos-11
-         - windows-2022
-    runs-on: ${{ matrix.os }}
-    needs: [ build-jar ]
-    steps:
-      - name: Install Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download jar
-        uses: actions/download-artifact@v2
-        with:
-          name: jar
-          path: .
-      - name: Run jar (non-Windows)
-        if: ${{ runner.os != 'Windows' }}
-        run: |
-          java -jar vegafusion-*.jar
-      - name: Run jar (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
-          java -jar $jarFile
+#name: java
+#on:
+#  pull_request:
+#    types: [opened, synchronize]
+#jobs:
+#  build-test-java-linux64:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Build jni
+#        run: cargo build -p vegafusion-jni --release --features=protobuf-src
+#      - name: gradle test
+#        run: |
+#          cd java
+#          ./gradlew test -i
+#        env:
+#          VEGAFUSION_JNI_LIBRARY: /home/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.so
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/linux-64
+#          cp target/release/libvegafusion_jni.so native/linux-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-test-java-osx64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Build jni
+#        run: cargo build -p vegafusion-jni --release --features=protobuf-src
+#      - name: gradle test
+#        run: |
+#          cd java
+#          ./gradlew test -i
+#        env:
+#          VEGAFUSION_JNI_LIBRARY: /Users/runner/work/vegafusion/vegafusion/target/release/libvegafusion_jni.dylib
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/osx-64
+#          cp target/release/libvegafusion_jni.dylib native/osx-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-test-java-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Download Apple Silicon toolchain
+#        run: |
+#          rustup target add aarch64-apple-darwin
+#      - name: Build jni
+#        run: cargo build -p vegafusion-jni --release --features=protobuf-src --target aarch64-apple-darwin
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/osx-arm64
+#          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-test-java-win64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Install protoc with choco
+#        run: choco install --yes protoc
+#      - name: Build jni
+#        run: cargo build -p vegafusion-jni --release
+#      - name: Show release files
+#        run: |
+#          Get-ChildItem -Path target/release -Recurse
+#      - name: gradle test
+#        run: |
+#          cd java
+#          ./gradlew test -i
+#        env:
+#          VEGAFUSION_JNI_LIBRARY: D:/a/vegafusion/vegafusion/target/release/vegafusion_jni.dll
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/win-64
+#          cp target/release/vegafusion_jni.dll native/win-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-jar:
+#    runs-on: ubuntu-20.04
+#    needs:
+#      - build-test-java-linux64
+#      - build-test-java-osx64
+#      - build-test-java-osx-arm64
+#      - build-test-java-win64
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v2
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Download jni libs
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: jni-native
+#          path: jni-native
+#      - name: Build jar
+#        env:
+#          VEGAFUSION_JNI_LIBRARIES: /home/runner/work/vegafusion/vegafusion/jni-native
+#        run: |
+#          cd java
+#          ./gradlew jar
+#      - name: Upload jar
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: jar
+#          path: |
+#            java/lib/build/libs/vegafusion-*.jar
+#
+#  try-jar:
+#    strategy:
+#      matrix:
+#        os:
+#         - ubuntu-20.04
+#         - macos-11
+#         - windows-2022
+#    runs-on: ${{ matrix.os }}
+#    needs: [ build-jar ]
+#    steps:
+#      - name: Install Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Download jar
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: jar
+#          path: .
+#      - name: Run jar (non-Windows)
+#        if: ${{ runner.os != 'Windows' }}
+#        run: |
+#          java -jar vegafusion-*.jar
+#      - name: Run jar (Windows)
+#        if: ${{ runner.os == 'Windows' }}
+#        run: |
+#          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
+#          java -jar $jarFile

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,21 +1,21 @@
-#name: Semgrep
-#on:
-#  pull_request: {}
-#  push:
-#    branches: ["master", "main"]
-#    paths:
-#      - .github/workflows/semgrep.yml
-#  schedule:
-#    - cron: '0 16 * * *'
-#jobs:
-#  semgrep:
-#    name: Code and Dependency Scan
-#    runs-on: ubuntu-latest
-#    container:
-#      image: returntocorp/semgrep
-#    if: (github.actor != 'dependabot[bot]')
-#    steps:
-#      - uses: actions/checkout@v3
-#      - run: semgrep ci
-#        env:
-#          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+name: Semgrep
+on:
+  pull_request: {}
+  push:
+    branches: ["master", "main"]
+    paths:
+      - .github/workflows/semgrep.yml
+  schedule:
+    - cron: '0 16 * * *'
+jobs:
+  semgrep:
+    name: Code and Dependency Scan
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,21 +1,21 @@
-name: Semgrep
-on:
-  pull_request: {}
-  push:
-    branches: ["master", "main"]
-    paths:
-      - .github/workflows/semgrep.yml
-  schedule:
-    - cron: '0 16 * * *'
-jobs:
-  semgrep:
-    name: Code and Dependency Scan
-    runs-on: ubuntu-latest
-    container:
-      image: returntocorp/semgrep
-    if: (github.actor != 'dependabot[bot]')
-    steps:
-      - uses: actions/checkout@v3
-      - run: semgrep ci
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+#name: Semgrep
+#on:
+#  pull_request: {}
+#  push:
+#    branches: ["master", "main"]
+#    paths:
+#      - .github/workflows/semgrep.yml
+#  schedule:
+#    - cron: '0 16 * * *'
+#jobs:
+#  semgrep:
+#    name: Code and Dependency Scan
+#    runs-on: ubuntu-latest
+#    container:
+#      image: returntocorp/semgrep
+#    if: (github.actor != 'dependabot[bot]')
+#    steps:
+#      - uses: actions/checkout@v3
+#      - run: semgrep ci
+#        env:
+#          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/vegafusion-core/src/task_graph/graph.rs
+++ b/vegafusion-core/src/task_graph/graph.rs
@@ -291,7 +291,7 @@ impl TaskGraph {
         node_index: usize,
         value: TaskValue,
     ) -> Result<Vec<NodeValueIndex>> {
-        let mut node = self
+        let node = self
             .nodes
             .get_mut(node_index)
             .ok_or_else(|| VegaFusionError::internal("Missing node"))?;


### PR DESCRIPTION
Add linux arm64 builds of `vegafusion-server` and the `vegafusion-python-embed` wheel. 

Refactor CI jobs to pull out build.yml, which contains artifact building for vegafusion-server and vegafusion-python-embed.

Finally, addresses semgrep warning by pinning the hash of the GitHub actions versions