### PR TITLE
Experiment with facet support

### DIFF
--- a/vegafusion-core/src/planning/extract_facet_data.rs
+++ b/vegafusion-core/src/planning/extract_facet_data.rs
@@ -1,0 +1,164 @@
+use crate::planning::plan::PlannerConfig;
+use crate::proto::gen::tasks::Variable;
+use crate::spec::chart::{ChartSpec, MutChartVisitor};
+use crate::spec::data::DataSpec;
+use crate::spec::mark::MarkSpec;
+use crate::spec::transform::facet::FacetTransformSpec;
+use crate::spec::transform::TransformSpec;
+use crate::task_graph::scope::TaskScope;
+use vegafusion_common::error::Result;
+use crate::spec::transform::aggregate::AggregateOpSpec;
+use crate::spec::transform::joinaggregate::JoinAggregateTransformSpec;
+use crate::spec::values::Field;
+
+pub fn extract_facet_data(
+    server_spec: &mut ChartSpec,
+    client_spec: &mut ChartSpec,
+    full_task_scope: &mut TaskScope,
+    config: &PlannerConfig,
+) -> Result<()> {
+    let mut visitor = ExtractFacetDataVisitor::try_new(server_spec, full_task_scope, config)?;
+    client_spec.walk_mut(&mut visitor)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ExtractFacetDataVisitor<'a> {
+    pub server_spec: &'a mut ChartSpec,
+    pub server_scope: TaskScope,
+    pub full_task_scope: &'a mut TaskScope,
+    pub config: &'a PlannerConfig,
+}
+
+impl<'a> ExtractFacetDataVisitor<'a> {
+    pub fn try_new(
+        server_spec: &'a mut ChartSpec,
+        full_task_scope: &'a mut TaskScope,
+        config: &'a PlannerConfig,
+    ) -> Result<Self> {
+        let server_scope = server_spec.to_task_scope()?;
+        Ok(Self {
+            server_spec,
+            full_task_scope,
+            server_scope,
+            config,
+        })
+    }
+}
+
+impl<'a> MutChartVisitor for ExtractFacetDataVisitor<'a> {
+    fn visit_group_mark(&mut self, mark: &mut MarkSpec, scope: &[u32]) -> Result<()> {
+        let Some(from) = &mut mark.from else { return Ok(()) };
+        let Some(facet) = &mut from.facet else { return Ok(()) };
+        let facet_groupby = facet.groupby.clone();
+        if facet_groupby.is_empty() || facet_groupby.len() > 2 {
+            // Our facet transform only supports one or two groupby fields
+            return Ok(());
+        }
+
+        for mark in &mark.marks {
+            if let Some(from) = &mark.from {
+                if let Some(mark_from_data) = &from.data {
+                    if mark_from_data == &facet.name {
+                        // facet dataset is used directly by a mark, so we can't pre-transform it
+                        return Ok(())
+                    }
+                }
+            }
+        }
+
+        if facet.aggregate.is_some() {
+            // Aggregate not supported yet
+            return Ok(())
+        }
+
+        // Find child dataset with facet as source
+        // let facet_child_dataset = None;
+        let mut facet_child_datasets = Vec::new();
+        for fcds in &mut mark.data {
+            let Some(source) = &fcds.source else { continue };
+            if source == &facet.name {
+                facet_child_datasets.push(fcds);
+            }
+        }
+        if facet_child_datasets.len() != 1 {
+            // Only extract if facet dataset is used as the input to a single dataset
+            return Ok(())
+        }
+        let facet_child_dataset = facet_child_datasets.pop().unwrap();
+
+        let mut facet_child_transforms = facet_child_dataset.transform.clone();
+
+        if facet_child_transforms.is_empty() {
+            // No facet transforms, nothing to do
+            return Ok(());
+        }
+
+        // Check that facet input data is available on the server
+        let Ok(input_dataset) = self.server_scope.resolve_scope(
+            &Variable::new_data(&facet.data), scope
+        ) else { return Ok(())};
+
+        // Check that all transforms are supported
+        for tx in &facet_child_transforms {
+            if !tx.supported() {
+                return Ok(());
+            }
+            for v in tx.input_vars()? {
+                if self.server_scope.resolve_scope(&v.var, scope).is_err() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Now:
+        //  - All facet transforms are supported
+        //  - All facet transform inputs are available on the server
+        //  - The facet input dataset is available on the server
+        // So we can perform extraction
+        let facet_data_name = format!("_facet_{}_{}", facet.data, facet.name);
+
+        // Add dataset that performs faceting
+        let group_data = if input_dataset.scope.is_empty() {
+            &mut self.server_spec.data
+        } else {
+            let Ok(data_group) = self.server_spec.get_nested_group_mut(
+                input_dataset.scope.as_slice()
+            ) else { return Ok(() )};
+            &mut data_group.data
+        };
+
+        group_data.push(DataSpec {
+            name: facet_data_name.clone(),
+            source: Some(facet.data.clone()),
+            transform: vec![TransformSpec::Facet(FacetTransformSpec {
+                groupby: facet_groupby,
+                transform: facet_child_dataset.transform.clone(),
+                extra: Default::default(),
+            })],
+            url: None,
+            format: None,
+            values: None,
+            on: None,
+            extra: Default::default(),
+        });
+
+        // Add new dataset to full task scope
+        self.full_task_scope.add_variable(
+            &Variable::new_data(&facet_data_name),
+            input_dataset.scope.as_slice(),
+        )?;
+
+        // Update facet to point to the new dataset
+        facet.data = facet_data_name;
+
+        // Clear facet aggregate
+        facet.aggregate = None;
+
+        // Clear facet child dataset's transforms
+        // (since we moved them to the facet dataset on the server)
+        facet_child_dataset.transform.clear();
+
+        Ok(())
+    }
+}

--- a/vegafusion-core/src/planning/mod.rs
+++ b/vegafusion-core/src/planning/mod.rs
@@ -1,5 +1,6 @@
 pub mod dependency_graph;
 pub mod extract;
+pub mod extract_facet_data;
 pub mod optimize_server;
 pub mod plan;
 pub mod projection_pushdown;

--- a/vegafusion-core/src/proto/prost_gen/transforms.rs
+++ b/vegafusion-core/src/proto/prost_gen/transforms.rs
@@ -252,13 +252,22 @@ pub struct Sequence {
     #[prost(string, optional, tag = "4")]
     pub r#as: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Facet
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Facet {
+    #[prost(string, repeated, tag = "1")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "2")]
+    pub transform: ::prost::alloc::vec::Vec<Transform>,
+}
 /// Top-level transform
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
     #[prost(
         oneof = "transform::TransformKind",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
     )]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
@@ -299,6 +308,8 @@ pub mod transform {
         Fold(super::Fold),
         #[prost(message, tag = "16")]
         Sequence(super::Sequence),
+        #[prost(message, tag = "17")]
+        Facet(super::Facet),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/vegafusion-core/src/proto/tonic_gen/transforms.rs
+++ b/vegafusion-core/src/proto/tonic_gen/transforms.rs
@@ -252,13 +252,22 @@ pub struct Sequence {
     #[prost(string, optional, tag = "4")]
     pub r#as: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Facet
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Facet {
+    #[prost(string, repeated, tag = "1")]
+    pub groupby: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "2")]
+    pub transform: ::prost::alloc::vec::Vec<Transform>,
+}
 /// Top-level transform
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transform {
     #[prost(
         oneof = "transform::TransformKind",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
     )]
     pub transform_kind: ::core::option::Option<transform::TransformKind>,
 }
@@ -299,6 +308,8 @@ pub mod transform {
         Fold(super::Fold),
         #[prost(message, tag = "16")]
         Sequence(super::Sequence),
+        #[prost(message, tag = "17")]
+        Facet(super::Facet),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/vegafusion-core/src/proto/transforms.proto
+++ b/vegafusion-core/src/proto/transforms.proto
@@ -252,6 +252,12 @@ message Sequence {
   optional string as = 4;
 }
 
+// Facet
+message Facet {
+  repeated string groupby = 1;
+  repeated Transform transform = 2;
+}
+
 // Top-level transform
 message Transform {
   oneof transform_kind {
@@ -271,6 +277,7 @@ message Transform {
     Identifier identifier = 14;
     Fold fold = 15;
     Sequence sequence = 16;
+    Facet facet = 17;
   }
 }
 

--- a/vegafusion-core/src/spec/mark.rs
+++ b/vegafusion-core/src/spec/mark.rs
@@ -5,10 +5,11 @@ use crate::spec::data::DataSpec;
 use crate::spec::scale::ScaleSpec;
 use crate::spec::signal::SignalSpec;
 use crate::spec::title::TitleSpec;
-use crate::spec::values::StringOrStringList;
+use crate::spec::values::{StringOrStringList, Field};
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 use std::collections::HashMap;
+use crate::spec::transform::aggregate::AggregateOpSpec;
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MarkSpec {
@@ -217,6 +218,12 @@ pub struct MarkFacetSpec {
     pub data: String,
     pub name: String,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groupby: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate: Option<MarkFacetAggregate>,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -242,6 +249,24 @@ pub struct MarkEncodingFieldObject {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MarkSort {
     pub field: StringOrStringList,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MarkFacetAggregate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<Option<Field>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ops: Option<Vec<AggregateOpSpec>>,
+
+    #[serde(rename = "as", skip_serializing_if = "Option::is_none")]
+    pub as_: Option<Vec<Option<String>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross: Option<bool>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,

--- a/vegafusion-core/src/spec/transform/facet.rs
+++ b/vegafusion-core/src/spec/transform/facet.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use serde_json::Value;
+use crate::spec::transform::{TransformSpec, TransformSpecTrait};
+use serde::{Serialize, Deserialize};
+use crate::task_graph::task::InputVariable;
+use vegafusion_common::error::Result;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FacetTransformSpec {
+    pub groupby: Vec<String>,
+    pub transform: Vec<TransformSpec>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+
+impl TransformSpecTrait for FacetTransformSpec {
+    fn supported(&self) -> bool {
+        self.transform.iter().all(|tx| tx.supported())
+    }
+
+    fn output_signals(&self) -> Vec<String> {
+        self.transform.iter().flat_map(|tx| tx.output_signals()).collect()
+    }
+
+    fn input_vars(&self) -> Result<Vec<InputVariable>> {
+        let t = self.transform.iter().map(|tx| tx.input_vars()).collect::<Result<Vec<Vec<_>>>>()?;
+        Ok(t.into_iter().flatten().collect())
+    }
+
+    fn local_datetime_columns_produced(&self, input_local_datetime_columns: &[String]) -> Vec<String> {
+        let mut input_local_datetime_columns = Vec::from(input_local_datetime_columns);
+        for tx in &self.transform {
+            input_local_datetime_columns = tx.local_datetime_columns_produced(
+                input_local_datetime_columns.as_slice()
+            )
+        }
+        input_local_datetime_columns
+    }
+}

--- a/vegafusion-core/src/spec/transform/facet.rs
+++ b/vegafusion-core/src/spec/transform/facet.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-use serde_json::Value;
 use crate::spec::transform::{TransformSpec, TransformSpecTrait};
-use serde::{Serialize, Deserialize};
 use crate::task_graph::task::InputVariable;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 use vegafusion_common::error::Result;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -14,27 +14,35 @@ pub struct FacetTransformSpec {
     pub extra: HashMap<String, Value>,
 }
 
-
 impl TransformSpecTrait for FacetTransformSpec {
     fn supported(&self) -> bool {
         self.transform.iter().all(|tx| tx.supported())
     }
 
     fn output_signals(&self) -> Vec<String> {
-        self.transform.iter().flat_map(|tx| tx.output_signals()).collect()
+        self.transform
+            .iter()
+            .flat_map(|tx| tx.output_signals())
+            .collect()
     }
 
     fn input_vars(&self) -> Result<Vec<InputVariable>> {
-        let t = self.transform.iter().map(|tx| tx.input_vars()).collect::<Result<Vec<Vec<_>>>>()?;
+        let t = self
+            .transform
+            .iter()
+            .map(|tx| tx.input_vars())
+            .collect::<Result<Vec<Vec<_>>>>()?;
         Ok(t.into_iter().flatten().collect())
     }
 
-    fn local_datetime_columns_produced(&self, input_local_datetime_columns: &[String]) -> Vec<String> {
+    fn local_datetime_columns_produced(
+        &self,
+        input_local_datetime_columns: &[String],
+    ) -> Vec<String> {
         let mut input_local_datetime_columns = Vec::from(input_local_datetime_columns);
         for tx in &self.transform {
-            input_local_datetime_columns = tx.local_datetime_columns_produced(
-                input_local_datetime_columns.as_slice()
-            )
+            input_local_datetime_columns =
+                tx.local_datetime_columns_produced(input_local_datetime_columns.as_slice())
         }
         input_local_datetime_columns
     }

--- a/vegafusion-core/src/spec/transform/mod.rs
+++ b/vegafusion-core/src/spec/transform/mod.rs
@@ -2,6 +2,7 @@ pub mod aggregate;
 pub mod bin;
 pub mod collect;
 pub mod extent;
+pub mod facet;
 pub mod filter;
 pub mod fold;
 pub mod formula;
@@ -16,7 +17,6 @@ pub mod stack;
 pub mod timeunit;
 pub mod unsupported;
 pub mod window;
-pub mod facet;
 
 use crate::spec::transform::{extent::ExtentTransformSpec, filter::FilterTransformSpec};
 
@@ -26,6 +26,7 @@ use crate::planning::plan::PlannerConfig;
 use crate::spec::transform::aggregate::AggregateTransformSpec;
 use crate::spec::transform::bin::BinTransformSpec;
 use crate::spec::transform::collect::CollectTransformSpec;
+use crate::spec::transform::facet::FacetTransformSpec;
 use crate::spec::transform::fold::FoldTransformSpec;
 use crate::spec::transform::formula::FormulaTransformSpec;
 use crate::spec::transform::identifier::IdentifierTransformSpec;
@@ -44,7 +45,6 @@ use crate::task_graph::scope::TaskScope;
 use crate::task_graph::task::InputVariable;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
-use crate::spec::transform::facet::FacetTransformSpec;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]

--- a/vegafusion-core/src/spec/transform/mod.rs
+++ b/vegafusion-core/src/spec/transform/mod.rs
@@ -16,6 +16,7 @@ pub mod stack;
 pub mod timeunit;
 pub mod unsupported;
 pub mod window;
+pub mod facet;
 
 use crate::spec::transform::{extent::ExtentTransformSpec, filter::FilterTransformSpec};
 
@@ -43,6 +44,7 @@ use crate::task_graph::scope::TaskScope;
 use crate::task_graph::task::InputVariable;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
+use crate::spec::transform::facet::FacetTransformSpec;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -63,6 +65,7 @@ pub enum TransformSpec {
     Identifier(IdentifierTransformSpec),
     Fold(FoldTransformSpec),
     Sequence(SequenceTransformSpec),
+    Facet(FacetTransformSpec),
 
     // Unsupported
     CountPattern(CountpatternTransformSpec),
@@ -119,6 +122,7 @@ impl Deref for TransformSpec {
             TransformSpec::Impute(t) => t,
             TransformSpec::Pivot(t) => t,
             TransformSpec::Sequence(t) => t,
+            TransformSpec::Facet(t) => t,
 
             // Supported for dependency determination, not implementation
             TransformSpec::Lookup(t) => t,

--- a/vegafusion-core/src/transform/facet.rs
+++ b/vegafusion-core/src/transform/facet.rs
@@ -1,0 +1,31 @@
+use crate::proto::gen::transforms::Facet;
+use crate::spec::transform::facet::FacetTransformSpec;
+use vegafusion_common::error::Result;
+use crate::proto::gen::tasks::Variable;
+use crate::proto::gen::transforms::{Transform as ProtoTransform, transform::TransformKind};
+use crate::task_graph::task::InputVariable;
+use crate::transform::TransformDependencies;
+
+
+impl Facet {
+    pub fn try_new(tx: &FacetTransformSpec) -> Result<Facet> {
+        Ok(Facet {
+            groupby: tx.groupby.clone(),
+            transform: tx.transform.iter().map(|tx| {
+                let transform_kind = TransformKind::try_from(tx)?;
+                Ok(ProtoTransform { transform_kind: Some(transform_kind) })
+            }).collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+
+impl TransformDependencies for Facet {
+    fn input_vars(&self) -> Vec<InputVariable> {
+        self.transform.iter().flat_map(|tx| tx.input_vars()).collect()
+    }
+
+    fn output_vars(&self) -> Vec<Variable> {
+        self.transform.iter().flat_map(|tx| tx.output_vars()).collect()
+    }
+}

--- a/vegafusion-core/src/transform/facet.rs
+++ b/vegafusion-core/src/transform/facet.rs
@@ -1,31 +1,41 @@
-use crate::proto::gen::transforms::Facet;
-use crate::spec::transform::facet::FacetTransformSpec;
-use vegafusion_common::error::Result;
 use crate::proto::gen::tasks::Variable;
-use crate::proto::gen::transforms::{Transform as ProtoTransform, transform::TransformKind};
+use crate::proto::gen::transforms::Facet;
+use crate::proto::gen::transforms::{transform::TransformKind, Transform as ProtoTransform};
+use crate::spec::transform::facet::FacetTransformSpec;
 use crate::task_graph::task::InputVariable;
 use crate::transform::TransformDependencies;
-
+use vegafusion_common::error::Result;
 
 impl Facet {
     pub fn try_new(tx: &FacetTransformSpec) -> Result<Facet> {
         Ok(Facet {
             groupby: tx.groupby.clone(),
-            transform: tx.transform.iter().map(|tx| {
-                let transform_kind = TransformKind::try_from(tx)?;
-                Ok(ProtoTransform { transform_kind: Some(transform_kind) })
-            }).collect::<Result<Vec<_>>>()?,
+            transform: tx
+                .transform
+                .iter()
+                .map(|tx| {
+                    let transform_kind = TransformKind::try_from(tx)?;
+                    Ok(ProtoTransform {
+                        transform_kind: Some(transform_kind),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
         })
     }
 }
 
-
 impl TransformDependencies for Facet {
     fn input_vars(&self) -> Vec<InputVariable> {
-        self.transform.iter().flat_map(|tx| tx.input_vars()).collect()
+        self.transform
+            .iter()
+            .flat_map(|tx| tx.input_vars())
+            .collect()
     }
 
     fn output_vars(&self) -> Vec<Variable> {
-        self.transform.iter().flat_map(|tx| tx.output_vars()).collect()
+        self.transform
+            .iter()
+            .flat_map(|tx| tx.output_vars())
+            .collect()
     }
 }

--- a/vegafusion-core/src/transform/mod.rs
+++ b/vegafusion-core/src/transform/mod.rs
@@ -1,10 +1,7 @@
 use crate::error::VegaFusionError;
 use crate::proto::gen::tasks::Variable;
 use crate::proto::gen::transforms::transform::TransformKind;
-use crate::proto::gen::transforms::{
-    Aggregate, Bin, Collect, Extent, Filter, Fold, Formula, Identifier, Impute, Pivot, Project,
-    Sequence, Stack, TimeUnit,
-};
+use crate::proto::gen::transforms::{Aggregate, Bin, Collect, Extent, Facet, Filter, Fold, Formula, Identifier, Impute, Pivot, Project, Sequence, Stack, TimeUnit};
 use crate::proto::gen::transforms::{JoinAggregate, Transform, Window};
 use crate::spec::transform::TransformSpec;
 use crate::task_graph::task::InputVariable;
@@ -27,6 +24,7 @@ pub mod sequence;
 pub mod stack;
 pub mod timeunit;
 pub mod window;
+pub mod facet;
 
 impl TryFrom<&TransformSpec> for TransformKind {
     type Error = VegaFusionError;
@@ -51,6 +49,7 @@ impl TryFrom<&TransformSpec> for TransformKind {
             TransformSpec::Identifier(tx_spec) => Self::Identifier(Identifier::try_new(tx_spec)?),
             TransformSpec::Fold(tx_spec) => Self::Fold(Fold::try_new(tx_spec)?),
             TransformSpec::Sequence(tx_spec) => Self::Sequence(Sequence::try_new(tx_spec)?),
+            TransformSpec::Facet(tx_spec) => Self::Facet(Facet::try_new(tx_spec)?),
             _ => {
                 return Err(VegaFusionError::parse(format!(
                     "Unsupported transform: {value:?}"
@@ -89,6 +88,7 @@ impl TransformKind {
             TransformKind::Identifier(tx) => tx,
             TransformKind::Fold(tx) => tx,
             TransformKind::Sequence(tx) => tx,
+            TransformKind::Facet(tx) => tx,
         }
     }
 }

--- a/vegafusion-core/src/transform/mod.rs
+++ b/vegafusion-core/src/transform/mod.rs
@@ -1,7 +1,10 @@
 use crate::error::VegaFusionError;
 use crate::proto::gen::tasks::Variable;
 use crate::proto::gen::transforms::transform::TransformKind;
-use crate::proto::gen::transforms::{Aggregate, Bin, Collect, Extent, Facet, Filter, Fold, Formula, Identifier, Impute, Pivot, Project, Sequence, Stack, TimeUnit};
+use crate::proto::gen::transforms::{
+    Aggregate, Bin, Collect, Extent, Facet, Filter, Fold, Formula, Identifier, Impute, Pivot,
+    Project, Sequence, Stack, TimeUnit,
+};
 use crate::proto::gen::transforms::{JoinAggregate, Transform, Window};
 use crate::spec::transform::TransformSpec;
 use crate::task_graph::task::InputVariable;
@@ -11,6 +14,7 @@ pub mod aggregate;
 pub mod bin;
 pub mod collect;
 pub mod extent;
+pub mod facet;
 pub mod filter;
 pub mod fold;
 pub mod formula;
@@ -24,7 +28,6 @@ pub mod sequence;
 pub mod stack;
 pub mod timeunit;
 pub mod window;
-pub mod facet;
 
 impl TryFrom<&TransformSpec> for TransformKind {
     type Error = VegaFusionError;

--- a/vegafusion-runtime/src/transform/facet.rs
+++ b/vegafusion-runtime/src/transform/facet.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+use crate::transform::TransformTrait;
+use vegafusion_core::{
+    proto::gen::transforms::Facet,
+    task_graph::task_value::TaskValue
+};
+use vegafusion_common::error::Result;
+use vegafusion_dataframe::dataframe::DataFrame;
+use crate::expression::compiler::config::CompilationConfig;
+use async_trait::async_trait;
+
+
+#[async_trait]
+impl TransformTrait for Facet {
+    async fn eval(&self, _dataframe: Arc<dyn DataFrame>, _config: &CompilationConfig) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
+        todo!()
+    }
+}

--- a/vegafusion-runtime/src/transform/facet.rs
+++ b/vegafusion-runtime/src/transform/facet.rs
@@ -1,18 +1,99 @@
-use std::sync::Arc;
-use crate::transform::TransformTrait;
-use vegafusion_core::{
-    proto::gen::transforms::Facet,
-    task_graph::task_value::TaskValue
-};
-use vegafusion_common::error::Result;
-use vegafusion_dataframe::dataframe::DataFrame;
 use crate::expression::compiler::config::CompilationConfig;
+use crate::transform::TransformTrait;
 use async_trait::async_trait;
-
+use datafusion_common::ScalarValue;
+use datafusion_expr::{ExprSchemable, lit, max};
+use std::sync::Arc;
+use vegafusion_common::arrow::record_batch::RecordBatch;
+use vegafusion_common::column::{flat_col, unescaped_col};
+use vegafusion_common::data::scalar::ScalarValueHelpers;
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::error::{Result, VegaFusionError};
+use vegafusion_common::escape::unescape_field;
+use vegafusion_core::arrow::datatypes::Schema;
+use vegafusion_core::{proto::gen::transforms::Facet, task_graph::task_value::TaskValue};
+use vegafusion_dataframe::dataframe::DataFrame;
 
 #[async_trait]
 impl TransformTrait for Facet {
-    async fn eval(&self, _dataframe: Arc<dyn DataFrame>, _config: &CompilationConfig) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
-        todo!()
+    async fn eval(
+        &self,
+        dataframe: Arc<dyn DataFrame>,
+        config: &CompilationConfig,
+    ) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
+        let (df, output_values) = match self.groupby.len() {
+            1 => {
+                let group_field = unescape_field(&self.groupby[0]);
+                let group_col = unescaped_col(&self.groupby[0]);
+
+                let table = dataframe
+                    .aggregate(vec![group_col.clone()], vec![])
+                    .await?
+                    .collect()
+                    .await?;
+                let batch = table.to_record_batch()?;
+                let col_array = batch.column(0);
+                let col_values = (0..col_array.len())
+                    .map(|i| Ok(ScalarValue::try_from_array(col_array, i)?))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let mut final_schema = Schema::empty();
+                let mut batches: Vec<RecordBatch> = Vec::new();
+                let mut output_values: Vec<TaskValue> = Vec::new();
+                for col_value in col_values {
+                    let filter = if col_value.is_null() {
+                        group_col.clone().is_null()
+                    } else {
+                        group_col.clone().eq(lit(col_value.clone()))
+                    };
+
+                    let mut filtered_df = dataframe.filter(filter).await?;
+
+                    // Apply transform pipeline
+                    for tx in &self.transform {
+                        let (tx_df, tx_out_vals) = tx.eval(filtered_df, config).await?;
+                        output_values.extend(tx_out_vals);
+                        filtered_df = tx_df;
+                    }
+
+                    // Add group value column back
+                    let mut selections = filtered_df
+                        .schema()
+                        .fields
+                        .iter()
+                        .filter_map(|f| {
+                            if f.name() == &group_field {
+                                None
+                            } else {
+                                Some(flat_col(f.name()))
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    selections.insert(0, lit(col_value).alias(&group_field));
+                    filtered_df = filtered_df.select(selections).await?;
+
+                    // Grab schema
+                    final_schema = filtered_df.schema();
+
+                    // evaluate to batches
+                    let final_table = filtered_df.collect().await?;
+                    batches.extend(final_table.batches);
+                }
+
+                let combined = VegaFusionTable::try_new(Arc::new(final_schema), batches)?;
+                let df = dataframe.connection().scan_arrow(combined).await?;
+                (df, output_values)
+            }
+            2 => {
+                todo!("Facetting by two columns not yet implemented")
+            }
+            i => {
+                return Err(VegaFusionError::internal(format!(
+                    "Unexpected groupby length for facet transform: {i}"
+                )))
+            }
+        };
+
+        Ok((df, output_values))
     }
 }

--- a/vegafusion-runtime/src/transform/facet.rs
+++ b/vegafusion-runtime/src/transform/facet.rs
@@ -2,15 +2,15 @@ use crate::expression::compiler::config::CompilationConfig;
 use crate::transform::TransformTrait;
 use async_trait::async_trait;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{ExprSchemable, lit, max};
+use datafusion_expr::lit;
 use std::sync::Arc;
 use vegafusion_common::arrow::record_batch::RecordBatch;
 use vegafusion_common::column::{flat_col, unescaped_col};
-use vegafusion_common::data::scalar::ScalarValueHelpers;
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_common::error::{Result, VegaFusionError};
 use vegafusion_common::escape::unescape_field;
 use vegafusion_core::arrow::datatypes::Schema;
+use vegafusion_core::proto::gen::transforms::Transform;
 use vegafusion_core::{proto::gen::transforms::Facet, task_graph::task_value::TaskValue};
 use vegafusion_dataframe::dataframe::DataFrame;
 
@@ -23,69 +23,23 @@ impl TransformTrait for Facet {
     ) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
         let (df, output_values) = match self.groupby.len() {
             1 => {
-                let group_field = unescape_field(&self.groupby[0]);
-                let group_col = unescaped_col(&self.groupby[0]);
-
-                let table = dataframe
-                    .aggregate(vec![group_col.clone()], vec![])
-                    .await?
-                    .collect()
-                    .await?;
-                let batch = table.to_record_batch()?;
-                let col_array = batch.column(0);
-                let col_values = (0..col_array.len())
-                    .map(|i| Ok(ScalarValue::try_from_array(col_array, i)?))
-                    .collect::<Result<Vec<_>>>()?;
-
-                let mut final_schema = Schema::empty();
-                let mut batches: Vec<RecordBatch> = Vec::new();
-                let mut output_values: Vec<TaskValue> = Vec::new();
-                for col_value in col_values {
-                    let filter = if col_value.is_null() {
-                        group_col.clone().is_null()
-                    } else {
-                        group_col.clone().eq(lit(col_value.clone()))
-                    };
-
-                    let mut filtered_df = dataframe.filter(filter).await?;
-
-                    // Apply transform pipeline
-                    for tx in &self.transform {
-                        let (tx_df, tx_out_vals) = tx.eval(filtered_df, config).await?;
-                        output_values.extend(tx_out_vals);
-                        filtered_df = tx_df;
-                    }
-
-                    // Add group value column back
-                    let mut selections = filtered_df
-                        .schema()
-                        .fields
-                        .iter()
-                        .filter_map(|f| {
-                            if f.name() == &group_field {
-                                None
-                            } else {
-                                Some(flat_col(f.name()))
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    selections.insert(0, lit(col_value).alias(&group_field));
-                    filtered_df = filtered_df.select(selections).await?;
-
-                    // Grab schema
-                    final_schema = filtered_df.schema();
-
-                    // evaluate to batches
-                    let final_table = filtered_df.collect().await?;
-                    batches.extend(final_table.batches);
-                }
-
-                let combined = VegaFusionTable::try_new(Arc::new(final_schema), batches)?;
-                let df = dataframe.connection().scan_arrow(combined).await?;
-                (df, output_values)
+                facet_one_column(
+                    dataframe,
+                    config,
+                    &self.groupby[0],
+                    self.transform.as_slice(),
+                )
+                .await?
             }
             2 => {
-                todo!("Facetting by two columns not yet implemented")
+                facet_two_columns(
+                    dataframe,
+                    config,
+                    &self.groupby[0],
+                    &self.groupby[1],
+                    self.transform.as_slice(),
+                )
+                .await?
             }
             i => {
                 return Err(VegaFusionError::internal(format!(
@@ -96,4 +50,163 @@ impl TransformTrait for Facet {
 
         Ok((df, output_values))
     }
+}
+
+async fn facet_one_column(
+    dataframe: Arc<dyn DataFrame>,
+    config: &CompilationConfig,
+    group_field: &String,
+    transforms: &[Transform],
+) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
+    // Unescape field
+    let unescaped_group_field = unescape_field(&group_field);
+    let group_col = unescaped_col(&group_field);
+
+    // Collect unique values of group column
+    let table = dataframe
+        .aggregate(vec![group_col.clone()], vec![])
+        .await?
+        .collect()
+        .await?;
+    let batch = table.to_record_batch()?;
+    let col_array = batch.column(0);
+    let col_values = (0..col_array.len())
+        .map(|i| Ok(ScalarValue::try_from_array(col_array, i)?))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Collect output schema and batches
+    let mut final_schema = Schema::empty();
+    let mut batches: Vec<RecordBatch> = Vec::new();
+    let mut output_values: Vec<TaskValue> = Vec::new();
+    for col_value in col_values {
+        let filter = if col_value.is_null() {
+            group_col.clone().is_null()
+        } else {
+            group_col.clone().eq(lit(col_value.clone()))
+        };
+
+        let mut filtered_df = dataframe.filter(filter).await?;
+
+        // Apply transform pipeline
+        for tx in transforms {
+            let (tx_df, tx_out_vals) = tx.eval(filtered_df, config).await?;
+            output_values.extend(tx_out_vals);
+            filtered_df = tx_df;
+        }
+
+        // Add group value column back
+        let mut selections = filtered_df
+            .schema()
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if f.name() == &unescaped_group_field {
+                    None
+                } else {
+                    Some(flat_col(f.name()))
+                }
+            })
+            .collect::<Vec<_>>();
+        selections.insert(0, lit(col_value).alias(&unescaped_group_field));
+        filtered_df = filtered_df.select(selections).await?;
+
+        // Grab schema
+        final_schema = filtered_df.schema();
+
+        // evaluate to batches
+        let final_table = filtered_df.collect().await?;
+        batches.extend(final_table.batches);
+    }
+
+    let combined = VegaFusionTable::try_new(Arc::new(final_schema), batches)?;
+    let df = dataframe.connection().scan_arrow(combined).await?;
+    Ok((df, output_values))
+}
+
+async fn facet_two_columns(
+    dataframe: Arc<dyn DataFrame>,
+    config: &CompilationConfig,
+    group_field0: &String,
+    group_field1: &String,
+    transforms: &[Transform],
+) -> Result<(Arc<dyn DataFrame>, Vec<TaskValue>)> {
+    // Unescape fields
+    let unescaped_group_field0 = unescape_field(&group_field0);
+    let group_col0 = unescaped_col(&group_field0);
+
+    let unescaped_group_field1 = unescape_field(&group_field1);
+    let group_col1 = unescaped_col(&group_field1);
+
+    // Collect unique values of group column
+    let table = dataframe
+        .aggregate(vec![group_col0.clone(), group_col1.clone()], vec![])
+        .await?
+        .collect()
+        .await?;
+    let batch = table.to_record_batch()?;
+    let col_array0 = batch.column(0);
+    let col_array1 = batch.column(1);
+
+    let col_values = (0..col_array0.len())
+        .map(|i| {
+            let scalar0 = ScalarValue::try_from_array(col_array0, i)?;
+            let scalar1 = ScalarValue::try_from_array(col_array1, i)?;
+            Ok((scalar0, scalar1))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Collect output schema and batches
+    let mut final_schema = Schema::empty();
+    let mut batches: Vec<RecordBatch> = Vec::new();
+    let mut output_values: Vec<TaskValue> = Vec::new();
+    for (col0_value, col1_value) in col_values {
+        let filter0 = if col0_value.is_null() {
+            group_col0.clone().is_null()
+        } else {
+            group_col0.clone().eq(lit(col0_value.clone()))
+        };
+        let filter1 = if col1_value.is_null() {
+            group_col1.clone().is_null()
+        } else {
+            group_col1.clone().eq(lit(col1_value.clone()))
+        };
+
+        let mut filtered_df = dataframe.filter(filter0.and(filter1)).await?;
+
+        // Apply transform pipeline
+        for tx in transforms {
+            let (tx_df, tx_out_vals) = tx.eval(filtered_df, config).await?;
+            output_values.extend(tx_out_vals);
+            filtered_df = tx_df;
+        }
+
+        // Add group value column back
+        let mut selections = filtered_df
+            .schema()
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if f.name() == &unescaped_group_field0 || f.name() == &unescaped_group_field1 {
+                    None
+                } else {
+                    Some(flat_col(f.name()))
+                }
+            })
+            .collect::<Vec<_>>();
+        selections.insert(0, lit(col1_value).alias(&unescaped_group_field1));
+        selections.insert(0, lit(col0_value).alias(&unescaped_group_field0));
+        filtered_df = filtered_df.select(selections).await?;
+
+        // Grab schema
+        final_schema = filtered_df.schema();
+
+        // evaluate to batches
+        let final_table = filtered_df.collect().await?;
+        batches.extend(final_table.batches);
+    }
+
+    // Build combined DataFrame
+    let combined = VegaFusionTable::try_new(Arc::new(final_schema), batches)?;
+    let df = dataframe.connection().scan_arrow(combined).await?;
+    Ok((df, output_values))
 }

--- a/vegafusion-runtime/src/transform/mod.rs
+++ b/vegafusion-runtime/src/transform/mod.rs
@@ -16,6 +16,7 @@ pub mod stack;
 pub mod timeunit;
 pub mod utils;
 pub mod window;
+pub mod facet;
 
 use crate::expression::compiler::config::CompilationConfig;
 
@@ -55,6 +56,7 @@ pub fn to_transform_trait(tx: &TransformKind) -> &dyn TransformTrait {
         TransformKind::Identifier(tx) => tx,
         TransformKind::Fold(tx) => tx,
         TransformKind::Sequence(tx) => tx,
+        TransformKind::Facet(tx) => tx,
     }
 }
 

--- a/vegafusion-runtime/src/transform/mod.rs
+++ b/vegafusion-runtime/src/transform/mod.rs
@@ -2,6 +2,7 @@ pub mod aggregate;
 pub mod bin;
 pub mod collect;
 pub mod extent;
+pub mod facet;
 pub mod filter;
 pub mod fold;
 pub mod formula;
@@ -16,7 +17,6 @@ pub mod stack;
 pub mod timeunit;
 pub mod utils;
 pub mod window;
-pub mod facet;
 
 use crate::expression::compiler::config::CompilationConfig;
 

--- a/vegafusion-runtime/tests/specs/custom/extract_facet_transforms.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/extract_facet_transforms.comm_plan.json
@@ -1,0 +1,40 @@
+{
+  "server_to_client": [
+    {
+      "name": "_facet_source_0_facet",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2_x_domain_MPAA_Rating_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_color_domain_MPAA_Rating",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_x_domain_MPAA_Rating_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "row_domain",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/extract_facet_transforms.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/extract_facet_transforms.vg.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "data": [
+    {
+      "name": "source_0",
+      "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/movies.json",
+      "format": {"type": "json"}
+    },
+    {
+      "name": "row_domain",
+      "source": "source_0",
+      "transform": [{"type": "aggregate", "groupby": ["Creative_Type"]}]
+    },
+    {
+      "name": "data_1",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["MPAA_Rating", "Creative_Type"],
+          "ops": ["stdev", "mean", "mean"],
+          "fields": ["Worldwide_Gross", "Worldwide_Gross", "Worldwide_Gross"],
+          "as": [
+            "extent_Worldwide_Gross",
+            "center_Worldwide_Gross",
+            "mean_Worldwide_Gross"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum[\"center_Worldwide_Gross\"] + datum[\"extent_Worldwide_Gross\"]",
+          "as": "upper_Worldwide_Gross"
+        },
+        {
+          "type": "formula",
+          "expr": "datum[\"center_Worldwide_Gross\"] - datum[\"extent_Worldwide_Gross\"]",
+          "as": "lower_Worldwide_Gross"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"lower_Worldwide_Gross\"]) && isFinite(+datum[\"lower_Worldwide_Gross\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"mean_Worldwide_Gross\"]) && isFinite(+datum[\"mean_Worldwide_Gross\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "child_width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    },
+    {"name": "child_height", "value": 300}
+  ],
+  "layout": {
+    "padding": 20,
+    "offset": {"rowTitle": 10},
+    "columns": 1,
+    "bounds": "full",
+    "align": "all"
+  },
+  "marks": [
+    {
+      "name": "row-title",
+      "type": "group",
+      "role": "row-title",
+      "title": {
+        "text": "Creative_Type",
+        "orient": "left",
+        "style": "guide-title",
+        "offset": 10
+      }
+    },
+    {
+      "name": "row_header",
+      "type": "group",
+      "role": "row-header",
+      "from": {"data": "row_domain"},
+      "sort": {"field": "datum[\"Creative_Type\"]", "order": "ascending"},
+      "title": {
+        "text": {
+          "signal": "isValid(parent[\"Creative_Type\"]) ? parent[\"Creative_Type\"] : \"\"+parent[\"Creative_Type\"]"
+        },
+        "orient": "left",
+        "style": "guide-label",
+        "frame": "group",
+        "offset": 10
+      },
+      "encode": {"update": {"height": {"signal": "child_height"}}},
+      "axes": [
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": false,
+          "title": "Worldwide_Gross",
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(child_height/40)"},
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "column_footer",
+      "type": "group",
+      "role": "column-footer",
+      "encode": {"update": {"width": {"signal": "child_width"}}},
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "MPAA_Rating",
+          "labelAlign": "right",
+          "labelAngle": 270,
+          "labelBaseline": "middle",
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "cell",
+      "type": "group",
+      "style": "cell",
+      "from": {
+        "facet": {
+          "name": "facet",
+          "data": "source_0",
+          "groupby": ["Creative_Type"]
+        }
+      },
+      "sort": {"field": ["datum[\"Creative_Type\"]"], "order": ["ascending"]},
+      "data": [
+        {
+          "source": "facet",
+          "name": "data_0",
+          "transform": [
+            {
+              "type": "aggregate",
+              "groupby": ["MPAA_Rating"],
+              "ops": ["stdev", "mean", "mean"],
+              "fields": [
+                "Worldwide_Gross",
+                "Worldwide_Gross",
+                "Worldwide_Gross"
+              ],
+              "as": [
+                "extent_Worldwide_Gross",
+                "center_Worldwide_Gross",
+                "mean_Worldwide_Gross"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "data_1",
+          "source": "data_0",
+          "transform": [
+            {
+              "type": "formula",
+              "expr": "datum[\"center_Worldwide_Gross\"] + datum[\"extent_Worldwide_Gross\"]",
+              "as": "upper_Worldwide_Gross"
+            },
+            {
+              "type": "formula",
+              "expr": "datum[\"center_Worldwide_Gross\"] - datum[\"extent_Worldwide_Gross\"]",
+              "as": "lower_Worldwide_Gross"
+            },
+            {
+              "type": "filter",
+              "expr": "isValid(datum[\"lower_Worldwide_Gross\"]) && isFinite(+datum[\"lower_Worldwide_Gross\"])"
+            }
+          ]
+        },
+        {
+          "name": "data_2",
+          "source": "data_0",
+          "transform": [
+            {
+              "type": "filter",
+              "expr": "isValid(datum[\"mean_Worldwide_Gross\"]) && isFinite(+datum[\"mean_Worldwide_Gross\"])"
+            }
+          ]
+        }
+      ],
+      "encode": {
+        "update": {
+          "width": {"signal": "child_width"},
+          "height": {"signal": "child_height"}
+        }
+      },
+      "marks": [
+        {
+          "name": "child_layer_0_marks",
+          "type": "rect",
+          "style": ["bar"],
+          "from": {"data": "data_2"},
+          "encode": {
+            "update": {
+              "fill": {"scale": "color", "field": "MPAA_Rating"},
+              "ariaRoleDescription": {"value": "bar"},
+              "description": {
+                "signal": "\"MPAA_Rating: \" + (isValid(datum[\"MPAA_Rating\"]) ? datum[\"MPAA_Rating\"] : \"\"+datum[\"MPAA_Rating\"]) + \"; Mean of Worldwide_Gross: \" + (format(datum[\"mean_Worldwide_Gross\"], \"\"))"
+              },
+              "x": {"scale": "x", "field": "MPAA_Rating"},
+              "width": {"signal": "max(0.25, bandwidth('x'))"},
+              "y": {"scale": "y", "field": "mean_Worldwide_Gross"},
+              "y2": {"scale": "y", "value": 0}
+            }
+          }
+        },
+        {
+          "name": "child_layer_1_marks",
+          "type": "rule",
+          "style": ["rule", "errorbar-rule"],
+          "from": {"data": "data_1"},
+          "encode": {
+            "update": {
+              "ariaRoleDescription": {"value": "errorbar"},
+              "stroke": {"value": "black"},
+              "tooltip": {
+                "signal": "{\"Mean of Worldwide_Gross\": format(datum[\"center_Worldwide_Gross\"], \"\"), \"Mean + stdev of Worldwide_Gross\": format(datum[\"upper_Worldwide_Gross\"], \"\"), \"Mean - stdev of Worldwide_Gross\": format(datum[\"lower_Worldwide_Gross\"], \"\"), \"MPAA_Rating\": isValid(datum[\"MPAA_Rating\"]) ? datum[\"MPAA_Rating\"] : \"\"+datum[\"MPAA_Rating\"]}"
+              },
+              "description": {
+                "signal": "\"MPAA_Rating: \" + (isValid(datum[\"MPAA_Rating\"]) ? datum[\"MPAA_Rating\"] : \"\"+datum[\"MPAA_Rating\"]) + \"; Worldwide_Gross: \" + (format(datum[\"lower_Worldwide_Gross\"], \"\")) + \"; upper_Worldwide_Gross: \" + (format(datum[\"upper_Worldwide_Gross\"], \"\")) + \"; Mean of Worldwide_Gross: \" + (format(datum[\"center_Worldwide_Gross\"], \"\")) + \"; Mean + stdev of Worldwide_Gross: \" + (format(datum[\"upper_Worldwide_Gross\"], \"\")) + \"; Mean - stdev of Worldwide_Gross: \" + (format(datum[\"lower_Worldwide_Gross\"], \"\"))"
+              },
+              "x": {"scale": "x", "field": "MPAA_Rating", "band": 0.5},
+              "y": {"scale": "y", "field": "lower_Worldwide_Gross"},
+              "y2": {"scale": "y", "field": "upper_Worldwide_Gross"}
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "y",
+          "orient": "left",
+          "gridScale": "x",
+          "grid": true,
+          "tickCount": {"signal": "ceil(child_height/40)"},
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {
+        "fields": [
+          {"data": "data_3", "field": "MPAA_Rating"},
+          {"data": "data_2", "field": "MPAA_Rating"}
+        ],
+        "sort": true
+      },
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {"data": "data_3", "field": "mean_Worldwide_Gross"},
+          {"data": "data_2", "field": "lower_Worldwide_Gross"},
+          {"data": "data_2", "field": "upper_Worldwide_Gross"}
+        ]
+      },
+      "range": [{"signal": "child_height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "data_3", "field": "MPAA_Rating", "sort": true},
+      "range": "category"
+    }
+  ],
+  "legends": [{"fill": "color", "symbolType": "square", "title": "MPAA_Rating"}]
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -138,7 +138,8 @@ mod test_custom_specs {
         case("custom/periods_in_formula_output", 0.001, true),
         case("custom/bin_transform_rounding", 0.001, true),
         case("custom/geojson_inline", 0.001, true),
-        case("custom/gh_361", 0.001, true)
+        case("custom/gh_361", 0.001, true),
+        case("custom/extract_facet_transforms", 0.001, true),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");

--- a/vegafusion-runtime/tests/test_transform_facet.rs
+++ b/vegafusion-runtime/tests/test_transform_facet.rs
@@ -13,7 +13,7 @@ use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_runtime::expression::compiler::config::CompilationConfig;
 
 #[test]
-fn test_facet_simple() {
+fn test_facet_1() {
     let dataset = vega_json_dataset("penguins");
 
     let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!([
@@ -36,5 +36,60 @@ fn test_facet_simple() {
     let (result_data, result_signals) =
         eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &Default::default());
 
-    println!("{}", result_data.pretty_format(None).unwrap())
+    assert_eq!(
+        result_data.pretty_format(None).unwrap(),
+        "\
++--------+------------------+
+| Sex    | count_beak_depth |
++--------+------------------+
+| MALE   | 168              |
+| FEMALE | 165              |
+|        | 10               |
+| .      | 1                |
++--------+------------------+"
+    )
+}
+
+#[test]
+fn test_facet_2() {
+    let dataset = vega_json_dataset("penguins");
+
+    let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!([
+        {
+            "type": "facet",
+            "groupby": ["Sex", "Island"],
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": [],
+                    "fields": ["Island"],
+                    "op": ["count"],
+                    "as": ["count_beak_depth"]
+                }
+            ]
+        },
+    ]))
+    .unwrap();
+
+    let (result_data, result_signals) =
+        eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &Default::default());
+
+    assert_eq!(
+        result_data.pretty_format(None).unwrap(),
+        "\
++--------+-----------+------------------+
+| Sex    | Island    | count_beak_depth |
++--------+-----------+------------------+
+| MALE   | Torgersen | 23               |
+| FEMALE | Torgersen | 24               |
+|        | Torgersen | 5                |
+| FEMALE | Biscoe    | 80               |
+| MALE   | Biscoe    | 83               |
+| FEMALE | Dream     | 61               |
+| MALE   | Dream     | 62               |
+|        | Dream     | 1                |
+|        | Biscoe    | 4                |
+| .      | Biscoe    | 1                |
++--------+-----------+------------------+"
+    )
 }

--- a/vegafusion-runtime/tests/test_transform_facet.rs
+++ b/vegafusion-runtime/tests/test_transform_facet.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate lazy_static;
+
+mod util;
+
+use crate::util::check::eval_vegafusion_transforms;
+use datafusion_common::ScalarValue;
+use serde_json::json;
+use util::check::check_transform_evaluation;
+use util::datasets::vega_json_dataset;
+use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
+use vegafusion_core::spec::transform::TransformSpec;
+use vegafusion_runtime::expression::compiler::config::CompilationConfig;
+
+#[test]
+fn test_facet_simple() {
+    let dataset = vega_json_dataset("penguins");
+
+    let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!([
+        {
+            "type": "facet",
+            "groupby": ["Sex"],
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": [],
+                    "fields": ["Island"],
+                    "op": ["count"],
+                    "as": ["count_beak_depth"]
+                }
+            ]
+        },
+    ]))
+    .unwrap();
+
+    let (result_data, result_signals) =
+        eval_vegafusion_transforms(&dataset, transform_specs.as_slice(), &Default::default());
+
+    println!("{}", result_data.pretty_format(None).unwrap())
+}


### PR DESCRIPTION
This branch is a not-yet-successful attempt to support transforming datasets inside facets.

What I attempted was to add a new VegaFusion only transform named `facet`. The `facet` transform accepts grouping fields and a list of transforms to apply for each group.  The idea was to lift transforms inside facets into standalone datasets using the `facet` transform. I got it working for the specific case of #370, but it's very fragile and broke several other facet specs in the test suite.

Some challenges I ran into:
 - The faceted dataset may be used multiple times within the facet as both the source of datasets and as the input to marks. This approach only kind of works when the facet dataset is used only as the source for a single child dataset.
 - So far, I'm not even attempting to handle the `facet.aggregate` calculation for sorting facets. Supporting the aggregate calculation is not as simple as adding an aggregate transform to the pipeline. The output of this aggregate calculation does not affect the facet dataset itself. It's used as the `datum` value of the group mark, which can be used in the "sort" configuration.
