### PR TITLE
SqlDataset.dialect doesn't have to be a classmethod

### DIFF
--- a/python/vegafusion/vegafusion/dataset/duckdb.py
+++ b/python/vegafusion/vegafusion/dataset/duckdb.py
@@ -7,8 +7,7 @@ from typing import Any
 
 
 class DuckDbDataset(SqlDataset):
-    @classmethod
-    def dialect(cls) -> str:
+    def dialect(self) -> str:
         return "duckdb"
 
     def __init__(self, relation: DuckDBPyRelation, fallback: bool = True, verbose: bool = False):

--- a/python/vegafusion/vegafusion/dataset/sql.py
+++ b/python/vegafusion/vegafusion/dataset/sql.py
@@ -8,8 +8,7 @@ class SqlDataset(ABC):
     Python interface for VegaFusion Sql Dataset
     """
 
-    @classmethod
-    def dialect(cls) -> str:
+    def dialect(self) -> str:
         """
         Returns SQL dialect accepted by the connection
 


### PR DESCRIPTION
The `dialect` method of the abstract `SqlDataset` class can be a regular method, rather than a classmethod.

This increases flexibility and allows SqlDataset subclasses to dynamically determine their dialect.