### PR TITLE
Fix edge cases: Use TRY_CAST for type conversions, convert cols to datetime before stringification

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -311,7 +311,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image pandas==2.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -342,7 +342,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image pandas==2.0
           
           # Downgrade pyarrow to 10.0.1
           python -m pip install pyarrow==10.0.1
@@ -380,7 +380,7 @@ jobs:
 
           python -m pip install $vegafusion
           python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -311,7 +311,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest
@@ -342,7 +342,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
           
           # Downgrade pyarrow to 10.0.1
           python -m pip install pyarrow==10.0.1

--- a/vegafusion-common/src/datatypes.rs
+++ b/vegafusion-common/src/datatypes.rs
@@ -1,7 +1,7 @@
 use crate::error::{Result, ResultWithContext};
 use arrow::datatypes::DataType;
 use datafusion_common::DFSchema;
-use datafusion_expr::{coalesce, expr, lit, BuiltinScalarFunction, Cast, Expr, ExprSchemable};
+use datafusion_expr::{coalesce, expr, lit, BuiltinScalarFunction, Expr, ExprSchemable, TryCast};
 
 pub fn is_numeric_datatype(dtype: &DataType) -> bool {
     matches!(
@@ -67,7 +67,7 @@ pub fn to_boolean(value: Expr, schema: &DFSchema) -> Result<Expr> {
         //  - empty string to false
         //  - NaN to false
         coalesce(vec![
-            Expr::Cast(Cast {
+            Expr::TryCast(TryCast {
                 expr: Box::new(value),
                 data_type: DataType::Boolean,
             }),
@@ -91,7 +91,7 @@ pub fn to_numeric(value: Expr, schema: &DFSchema) -> Result<Expr> {
         })
     } else {
         // Cast non-numeric types (like UTF-8) to Float64
-        Expr::Cast(Cast {
+        Expr::TryCast(TryCast {
             expr: Box::new(value),
             data_type: DataType::Float64,
         })
@@ -106,7 +106,7 @@ pub fn to_string(value: Expr, schema: &DFSchema) -> Result<Expr> {
     let utf8_value = if dtype == DataType::Utf8 || dtype == DataType::LargeUtf8 {
         value
     } else {
-        Expr::Cast(Cast {
+        Expr::TryCast(TryCast {
             expr: Box::new(value),
             data_type: DataType::Utf8,
         })
@@ -129,7 +129,7 @@ pub fn cast_to(value: Expr, cast_dtype: &DataType, schema: &DFSchema) -> Result<
         Ok(value)
     } else {
         // Cast non-numeric types (like UTF-8) to Float64
-        Ok(Expr::Cast(Cast {
+        Ok(Expr::TryCast(TryCast {
             expr: Box::new(value),
             data_type: cast_dtype.clone(),
         }))

--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -370,7 +370,8 @@ impl<'a> MutChartVisitor for StringifyLocalDatetimeFieldsVisitor<'a> {
         );
 
         for field in sorted(fields) {
-            let expr_str = format!("timeFormat(datum['{field}'], '%Y-%m-%dT%H:%M:%S.%L')");
+            let expr_str =
+                format!("timeFormat(toDate(datum['{field}'], 'local'), '%Y-%m-%dT%H:%M:%S.%L')");
 
             let transforms = &mut data.transform;
             let transform = FormulaTransformSpec {

--- a/vegafusion-runtime/src/expression/compiler/mod.rs
+++ b/vegafusion-runtime/src/expression/compiler/mod.rs
@@ -64,7 +64,7 @@ mod test_compile {
 
     use crate::task_graph::timezone::RuntimeTzConfig;
     use datafusion_common::{DFSchema, ScalarValue};
-    use datafusion_expr::expr::{BinaryExpr, Case, Cast, TryCast};
+    use datafusion_expr::expr::{BinaryExpr, Case, TryCast};
     use datafusion_expr::{concat, expr, lit, BuiltinScalarFunction, Expr, Operator};
     use std::collections::HashMap;
     use std::convert::TryFrom;

--- a/vegafusion-runtime/src/expression/compiler/mod.rs
+++ b/vegafusion-runtime/src/expression/compiler/mod.rs
@@ -64,7 +64,7 @@ mod test_compile {
 
     use crate::task_graph::timezone::RuntimeTzConfig;
     use datafusion_common::{DFSchema, ScalarValue};
-    use datafusion_expr::expr::{BinaryExpr, Case, Cast};
+    use datafusion_expr::expr::{BinaryExpr, Case, Cast, TryCast};
     use datafusion_expr::{concat, expr, lit, BuiltinScalarFunction, Expr, Operator};
     use std::collections::HashMap;
     use std::convert::TryFrom;
@@ -150,7 +150,7 @@ mod test_compile {
         println!("expr: {result_expr:?}");
 
         // plus prefix on a string should result in a numeric cast
-        let expected_expr = Expr::Cast(Cast {
+        let expected_expr = Expr::TryCast(TryCast {
             expr: Box::new(lit("72")),
             data_type: DataType::Float64,
         });
@@ -174,7 +174,7 @@ mod test_compile {
         let expected_expr = !Expr::ScalarFunction(expr::ScalarFunction {
             fun: BuiltinScalarFunction::Coalesce,
             args: vec![
-                Expr::Cast(Cast {
+                Expr::TryCast(TryCast {
                     expr: Box::new(lit(32.0)),
                     data_type: DataType::Boolean,
                 }),
@@ -204,7 +204,7 @@ mod test_compile {
                 Box::new(Expr::ScalarFunction(expr::ScalarFunction {
                     fun: BuiltinScalarFunction::Coalesce,
                     args: vec![
-                        Expr::Cast(Cast {
+                        Expr::TryCast(TryCast {
                             expr: Box::new(lit(32.0)),
                             data_type: DataType::Boolean,
                         }),
@@ -259,7 +259,7 @@ mod test_compile {
                 Box::new(Expr::ScalarFunction(expr::ScalarFunction {
                     fun: BuiltinScalarFunction::Coalesce,
                     args: vec![
-                        Expr::Cast(Cast {
+                        Expr::TryCast(TryCast {
                             expr: Box::new(lit(5.0)),
                             data_type: DataType::Boolean,
                         }),
@@ -291,7 +291,7 @@ mod test_compile {
         let t1 = Expr::BinaryExpr(BinaryExpr {
             left: Box::new(lit(1.0)),
             op: Operator::Plus,
-            right: Box::new(Expr::Cast(Cast {
+            right: Box::new(Expr::TryCast(TryCast {
                 expr: Box::new(lit("2")),
                 data_type: DataType::Float64,
             })),
@@ -299,7 +299,7 @@ mod test_compile {
 
         // true * 10
         let t2 = Expr::BinaryExpr(BinaryExpr {
-            left: Box::new(Expr::Cast(Cast {
+            left: Box::new(Expr::TryCast(TryCast {
                 expr: Box::new(lit(true)),
                 data_type: DataType::Float64,
             })),
@@ -347,7 +347,7 @@ mod test_compile {
         let result_expr = compile(&expr, &Default::default(), None).unwrap();
 
         let expected_expr = Expr::BinaryExpr(BinaryExpr {
-            left: Box::new(Expr::Cast(Cast {
+            left: Box::new(Expr::TryCast(TryCast {
                 expr: Box::new(lit("2.0")),
                 data_type: DataType::Float64,
             })),
@@ -617,7 +617,7 @@ mod test_compile {
                 Box::new(Expr::ScalarFunction(expr::ScalarFunction {
                     fun: BuiltinScalarFunction::Coalesce,
                     args: vec![
-                        Expr::Cast(Cast {
+                        Expr::TryCast(TryCast {
                             expr: Box::new(lit(32.0)),
                             data_type: DataType::Boolean,
                         }),

--- a/vegafusion-sql/src/dialect/mod.rs
+++ b/vegafusion-sql/src/dialect/mod.rs
@@ -132,6 +132,22 @@ pub enum UnorderedRowNumberMode {
 }
 
 #[derive(Clone, Debug)]
+pub enum TryCastMode {
+    /// TRY_CAST is supported
+    Supported,
+
+    /// Regular CAST is the best we can do
+    JustUseCast,
+
+    /// Use SAFE_CAST
+    SafeCast,
+
+    /// TRY_CAST is supported when the first argument is a string type
+    /// Otherwise fall back to regular CAST
+    SupportedOnStringsOtherwiseJustCast,
+}
+
+#[derive(Clone, Debug)]
 pub struct Dialect {
     /// sqlparser dialect to use to parse queries
     parse_dialect: ParseDialect,
@@ -198,6 +214,9 @@ pub struct Dialect {
     /// Whether dialect supports null values in cast expressions
     pub cast_propagates_null: bool,
 
+    /// How TRY_CAST is implemented
+    pub try_cast_mode: TryCastMode,
+
     /// Whether dialect supports -inf, nan, and inf float values.
     /// If false, non-finite values are converted to NULL
     pub supports_non_finite_floats: bool,
@@ -234,6 +253,7 @@ impl Default for Dialect {
             cast_datatypes: Default::default(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::Supported,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -367,6 +387,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::Supported,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -499,6 +520,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::SafeCast,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -604,6 +626,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: false,
+            try_cast_mode: TryCastMode::JustUseCast,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -756,6 +779,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::Supported,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::OrderByConstant,
@@ -926,6 +950,7 @@ impl Dialect {
             .into_iter()
             .collect(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::Supported,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -1077,6 +1102,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::Supported,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -1183,6 +1209,7 @@ impl Dialect {
             .into_iter()
             .collect(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::JustUseCast,
             supports_non_finite_floats: false,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -1335,6 +1362,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::JustUseCast,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -1477,6 +1505,7 @@ impl Dialect {
             .into_iter()
             .collect(),
             cast_propagates_null: false,
+            try_cast_mode: TryCastMode::JustUseCast,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: false,
             unordered_row_number_mode: UnorderedRowNumberMode::Supported,
@@ -1624,6 +1653,7 @@ impl Dialect {
             .collect(),
             cast_transformers: Default::default(),
             cast_propagates_null: true,
+            try_cast_mode: TryCastMode::SupportedOnStringsOtherwiseJustCast,
             supports_non_finite_floats: true,
             supports_mixed_case_identical_columns: true,
             unordered_row_number_mode: UnorderedRowNumberMode::AlternateScalarFunction(

--- a/vegafusion-sql/tests/expected/select.toml
+++ b/vegafusion-sql/tests/expected/select.toml
@@ -169,6 +169,45 @@ result = '''
 +---+----+----+-----+-----+-----+-----+-----+-----+-----+
 '''
 
+[try_cast_numeric]
+athena = """
+WITH values0 AS (SELECT * FROM (VALUES ('0'), ('1')) AS "_values" ("a")), values1 AS (SELECT "a", TRY_CAST("a" AS TINYINT) AS "i8", TRY_CAST("a" AS SMALLINT) AS "u8", TRY_CAST("a" AS SMALLINT) AS "i16", TRY_CAST("a" AS INT) AS "u16", TRY_CAST("a" AS INT) AS "i32", TRY_CAST("a" AS BIGINT) AS "u32", TRY_CAST("a" AS BIGINT) AS "i64", TRY_CAST("a" AS DOUBLE) AS "f32", TRY_CAST("a" AS DOUBLE) AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+bigquery = """
+WITH values0 AS (SELECT '0' AS `a` UNION ALL SELECT '1' AS `a`), values1 AS (SELECT `a`, SAFE_CAST(`a` AS INT) AS `i8`, SAFE_CAST(`a` AS INT) AS `u8`, SAFE_CAST(`a` AS INT) AS `i16`, SAFE_CAST(`a` AS INT) AS `u16`, SAFE_CAST(`a` AS INT) AS `i32`, SAFE_CAST(`a` AS INT) AS `u32`, SAFE_CAST(`a` AS INT) AS `i64`, SAFE_CAST(`a` AS float64) AS `f32`, SAFE_CAST(`a` AS float64) AS `f64` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+clickhouse = """
+WITH values0 AS (SELECT '0' AS "a" UNION ALL SELECT '1' AS "a"), values1 AS (SELECT "a", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS TINYINT) ELSE NULL END AS "i8", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS SMALLINT) ELSE NULL END AS "u8", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS SMALLINT) ELSE NULL END AS "i16", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS INT) ELSE NULL END AS "u16", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS INT) ELSE NULL END AS "i32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS BIGINT) ELSE NULL END AS "u32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS BIGINT) ELSE NULL END AS "i64", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS FLOAT) ELSE NULL END AS "f32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS DOUBLE) ELSE NULL END AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+databricks = """
+WITH values0 AS (SELECT * FROM (VALUES ('0'), ('1')) AS `_values` (`a`)), values1 AS (SELECT `a`, TRY_CAST(`a` AS TINYINT) AS `i8`, TRY_CAST(`a` AS SMALLINT) AS `u8`, TRY_CAST(`a` AS SMALLINT) AS `i16`, TRY_CAST(`a` AS INT) AS `u16`, TRY_CAST(`a` AS INT) AS `i32`, TRY_CAST(`a` AS BIGINT) AS `u32`, TRY_CAST(`a` AS BIGINT) AS `i64`, TRY_CAST(`a` AS FLOAT) AS `f32`, TRY_CAST(`a` AS DOUBLE) AS `f64` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+datafusion = """
+WITH values0 AS (SELECT * FROM (VALUES ('0'), ('1')) AS "_values" ("a")), values1 AS (SELECT "a", TRY_CAST("a" AS TINYINT) AS "i8", TRY_CAST("a" AS SMALLINT) AS "u8", TRY_CAST("a" AS SMALLINT) AS "i16", TRY_CAST("a" AS INT) AS "u16", TRY_CAST("a" AS INT) AS "i32", TRY_CAST("a" AS BIGINT) AS "u32", TRY_CAST("a" AS BIGINT) AS "i64", TRY_CAST("a" AS FLOAT) AS "f32", TRY_CAST("a" AS DOUBLE) AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+duckdb = """
+WITH values0 AS (SELECT * FROM (VALUES ('0'), ('1')) AS "_values" ("a")), values1 AS (SELECT "a", TRY_CAST("a" AS TINYINT) AS "i8", TRY_CAST("a" AS SMALLINT) AS "u8", TRY_CAST("a" AS SMALLINT) AS "i16", TRY_CAST("a" AS INT) AS "u16", TRY_CAST("a" AS INT) AS "i32", TRY_CAST("a" AS BIGINT) AS "u32", TRY_CAST("a" AS BIGINT) AS "i64", TRY_CAST("a" AS FLOAT) AS "f32", TRY_CAST("a" AS DOUBLE) AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+mysql = """
+WITH values0 AS (SELECT * FROM (VALUES ROW('0'), ROW('1')) AS `_values` (`a`)), values1 AS (SELECT `a`, CAST(`a` AS SIGNED) AS `i8`, CAST(`a` AS UNSIGNED) AS `u8`, CAST(`a` AS SIGNED) AS `i16`, CAST(`a` AS UNSIGNED) AS `u16`, CAST(`a` AS SIGNED) AS `i32`, CAST(`a` AS UNSIGNED) AS `u32`, CAST(`a` AS SIGNED) AS `i64`, CAST(`a` AS FLOAT) AS `f32`, CAST(`a` AS DOUBLE) AS `f64` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC
+"""
+postgres = """
+WITH values0 AS (SELECT * FROM (VALUES ('0'), ('1')) AS "_values" ("a")), values1 AS (SELECT "a", CAST("a" AS SMALLINT) AS "i8", CAST("a" AS SMALLINT) AS "u8", CAST("a" AS SMALLINT) AS "i16", CAST("a" AS INTEGER) AS "u16", CAST("a" AS INTEGER) AS "i32", CAST("a" AS BIGINT) AS "u32", CAST("a" AS BIGINT) AS "i64", CAST("a" AS REAL) AS "f32", CAST("a" AS DOUBLE PRECISION) AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+redshift = """
+WITH values0 AS (SELECT '0' AS "a" UNION ALL SELECT '1' AS "a"), values1 AS (SELECT "a", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS SMALLINT) ELSE NULL END AS "i8", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS SMALLINT) ELSE NULL END AS "u8", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS SMALLINT) ELSE NULL END AS "i16", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS INTEGER) ELSE NULL END AS "u16", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS INTEGER) ELSE NULL END AS "i32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS BIGINT) ELSE NULL END AS "u32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS BIGINT) ELSE NULL END AS "i64", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS REAL) ELSE NULL END AS "f32", CASE WHEN "a" IS NOT NULL THEN CAST("a" AS DOUBLE PRECISION) ELSE NULL END AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+snowflake = """
+WITH values0 AS (SELECT "COLUMN1" AS "a" FROM (VALUES ('0'), ('1'))), values1 AS (SELECT "a", TRY_CAST("a" AS TINYINT) AS "i8", TRY_CAST("a" AS SMALLINT) AS "u8", TRY_CAST("a" AS SMALLINT) AS "i16", TRY_CAST("a" AS INTEGER) AS "u16", TRY_CAST("a" AS INTEGER) AS "i32", TRY_CAST("a" AS BIGINT) AS "u32", TRY_CAST("a" AS BIGINT) AS "i64", TRY_CAST("a" AS FLOAT) AS "f32", TRY_CAST("a" AS DOUBLE) AS "f64" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+result = '''
++---+----+----+-----+-----+-----+-----+-----+-----+-----+
+| a | i8 | u8 | i16 | u16 | i32 | u32 | i64 | f32 | f64 |
++---+----+----+-----+-----+-----+-----+-----+-----+-----+
+| 0 | 0  | 0  | 0   | 0   | 0   | 0   | 0   | 0.0 | 0.0 |
+| 1 | 1  | 1  | 1   | 1   | 1   | 1   | 1   | 1.0 | 1.0 |
++---+----+----+-----+-----+-----+-----+-----+-----+-----+
+'''
 
 [cast_string]
 athena = """
@@ -200,6 +239,47 @@ WITH values0 AS (SELECT 0 AS "a", true AS "c", 'A' AS "d", NULL AS "b" UNION ALL
 """
 snowflake = """
 WITH values0 AS (SELECT "COLUMN1" AS "a", "COLUMN2" AS "c", "COLUMN3" AS "d", "COLUMN4" AS "b" FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25))), values1 AS (SELECT CAST("a" AS VARCHAR) AS "a", CAST("b" AS VARCHAR) AS "b", CAST("c" AS VARCHAR) AS "c", CAST("d" AS VARCHAR) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+result = '''
++---+------+-------+-----+
+| a | b    | c     | d   |
++---+------+-------+-----+
+|   | 2.25 |       | CCC |
+| 0 |      | true  | A   |
+| 1 | 1.5  | false | BB  |
++---+------+-------+-----+
+'''
+
+[try_cast_string]
+athena = """
+WITH values0 AS (SELECT * FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25)) AS "_values" ("a", "c", "d", "b")), values1 AS (SELECT TRY_CAST("a" AS VARCHAR) AS "a", TRY_CAST("b" AS VARCHAR) AS "b", TRY_CAST("c" AS VARCHAR) AS "c", TRY_CAST("d" AS VARCHAR) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+bigquery = """
+WITH values0 AS (SELECT 0 AS `a`, true AS `c`, 'A' AS `d`, NULL AS `b` UNION ALL SELECT 1 AS `a`, false AS `c`, 'BB' AS `d`, 1.5 AS `b` UNION ALL SELECT NULL AS `a`, NULL AS `c`, 'CCC' AS `d`, 2.25 AS `b`), values1 AS (SELECT SAFE_CAST(`a` AS STRING) AS `a`, SAFE_CAST(`b` AS STRING) AS `b`, SAFE_CAST(`c` AS STRING) AS `c`, SAFE_CAST(`d` AS STRING) AS `d` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+clickhouse = """
+WITH values0 AS (SELECT 0 AS "a", true AS "c", 'A' AS "d", NULL AS "b" UNION ALL SELECT 1 AS "a", false AS "c", 'BB' AS "d", 1.5 AS "b" UNION ALL SELECT NULL AS "a", NULL AS "c", 'CCC' AS "d", 2.25 AS "b"), values1 AS (SELECT CASE WHEN "a" IS NOT NULL THEN CAST("a" AS VARCHAR) ELSE NULL END AS "a", CASE WHEN "b" IS NOT NULL THEN CAST("b" AS VARCHAR) ELSE NULL END AS "b", CASE WHEN "c" IS NOT NULL THEN CAST("c" AS VARCHAR) ELSE NULL END AS "c", CASE WHEN "d" IS NOT NULL THEN CAST("d" AS VARCHAR) ELSE NULL END AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+databricks = """
+WITH values0 AS (SELECT * FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25)) AS `_values` (`a`, `c`, `d`, `b`)), values1 AS (SELECT TRY_CAST(`a` AS STRING) AS `a`, TRY_CAST(`b` AS STRING) AS `b`, TRY_CAST(`c` AS STRING) AS `c`, TRY_CAST(`d` AS STRING) AS `d` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC NULLS FIRST
+"""
+datafusion = """
+WITH values0 AS (SELECT * FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25)) AS "_values" ("a", "c", "d", "b")), values1 AS (SELECT TRY_CAST("a" AS STRING) AS "a", TRY_CAST("b" AS STRING) AS "b", CASE WHEN ("c" = true) THEN 'true' WHEN ("c" = false) THEN 'false' ELSE NULL END AS "c", TRY_CAST("d" AS STRING) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+duckdb = """
+WITH values0 AS (SELECT * FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25)) AS "_values" ("a", "c", "d", "b")), values1 AS (SELECT TRY_CAST("a" AS VARCHAR) AS "a", TRY_CAST("b" AS VARCHAR) AS "b", TRY_CAST("c" AS VARCHAR) AS "c", TRY_CAST("d" AS VARCHAR) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+mysql = """
+WITH values0 AS (SELECT * FROM (VALUES ROW(0, true, 'A', NULL), ROW(1, false, 'BB', 1.5), ROW(NULL, NULL, 'CCC', 2.25)) AS `_values` (`a`, `c`, `d`, `b`)), values1 AS (SELECT CAST(`a` AS CHAR) AS `a`, CAST(`b` AS CHAR) AS `b`, CASE WHEN (`c` = true) THEN 'true' WHEN (`c` = false) THEN 'false' ELSE NULL END AS `c`, CAST(`d` AS CHAR) AS `d` FROM values0) SELECT * FROM values1 ORDER BY `a` ASC
+"""
+postgres = """
+WITH values0 AS (SELECT * FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25)) AS "_values" ("a", "c", "d", "b")), values1 AS (SELECT CAST("a" AS TEXT) AS "a", CAST("b" AS TEXT) AS "b", CAST("c" AS TEXT) AS "c", CAST("d" AS TEXT) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+redshift = """
+WITH values0 AS (SELECT 0 AS "a", true AS "c", 'A' AS "d", NULL AS "b" UNION ALL SELECT 1 AS "a", false AS "c", 'BB' AS "d", 1.5 AS "b" UNION ALL SELECT NULL AS "a", NULL AS "c", 'CCC' AS "d", 2.25 AS "b"), values1 AS (SELECT CASE WHEN "a" IS NOT NULL THEN CAST("a" AS TEXT) ELSE NULL END AS "a", CASE WHEN "b" IS NOT NULL THEN CAST("b" AS TEXT) ELSE NULL END AS "b", CASE WHEN "c" IS NOT NULL THEN CASE WHEN ("c" = true) THEN 'true' WHEN ("c" = false) THEN 'false' ELSE NULL END ELSE NULL END AS "c", CASE WHEN "d" IS NOT NULL THEN CAST("d" AS TEXT) ELSE NULL END AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
+"""
+snowflake = """
+WITH values0 AS (SELECT "COLUMN1" AS "a", "COLUMN2" AS "c", "COLUMN3" AS "d", "COLUMN4" AS "b" FROM (VALUES (0, true, 'A', NULL), (1, false, 'BB', 1.5), (NULL, NULL, 'CCC', 2.25))), values1 AS (SELECT CAST("a" AS VARCHAR) AS "a", CAST("b" AS VARCHAR) AS "b", CAST("c" AS VARCHAR) AS "c", TRY_CAST("d" AS VARCHAR) AS "d" FROM values0) SELECT * FROM values1 ORDER BY "a" ASC NULLS FIRST
 """
 result = '''
 +---+------+-------+-----+

--- a/vegafusion-sql/tests/test_select.rs
+++ b/vegafusion-sql/tests/test_select.rs
@@ -266,7 +266,7 @@ mod test_cast_numeric {
 mod test_try_cast_numeric {
     use crate::*;
     use arrow::datatypes::DataType;
-    use datafusion_expr::{cast, expr, try_cast, Expr};
+    use datafusion_expr::{expr, try_cast, Expr};
     use vegafusion_common::column::flat_col;
 
     #[apply(dialect_names)]
@@ -377,7 +377,7 @@ mod test_cast_string {
 mod test_try_cast_string {
     use crate::*;
     use arrow::datatypes::DataType;
-    use datafusion_expr::{cast, expr, try_cast, Expr};
+    use datafusion_expr::{expr, try_cast, Expr};
     use vegafusion_common::column::flat_col;
 
     #[apply(dialect_names)]


### PR DESCRIPTION
This PR adds support for the TRY_CAST construct across SQL dialects and switches to using TRY_CAST for type conversions. This avoids crashes for things like Vega's `toNumeric("abc")`, instead returning a NULL, which is much closer to Vega's behavior (it returns a NaN).

Also adds an explicit `toDate` to the local datetime stringification logic to handle edge cases where a string column is used in a local datetime context without conversion.