### PR TITLE
Unpin vl-convert-python now that 0.13.1 is out

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -311,7 +311,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest
@@ -342,7 +342,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
           
           # Downgrade pyarrow to 10.0.1
           python -m pip install pyarrow==10.0.1
@@ -380,7 +380,7 @@ jobs:
 
           python -m pip install $vegafusion
           python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb altair==5.0.1 vl-convert-python==0.12.0 scikit-image
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest


### PR DESCRIPTION
We should be able to unpin `vl-convert-python` now that https://github.com/vega/vl-convert/issues/94 was fixed in  `vl-convert-python` 0.13.1.