### PR TITLE
Allow scale.domain.fields to contain signals

### DIFF
--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -5,7 +5,9 @@ use crate::spec::axis::{AxisFormatTypeSpec, AxisSpec};
 use crate::spec::chart::{ChartSpec, ChartVisitor, MutChartVisitor};
 use crate::spec::data::DataSpec;
 use crate::spec::mark::{MarkEncodingField, MarkSpec};
-use crate::spec::scale::{ScaleDomainSpec, ScaleSpec, ScaleTypeSpec};
+use crate::spec::scale::{
+    ScaleDataReferenceOrSignalSpec, ScaleDomainSpec, ScaleSpec, ScaleTypeSpec,
+};
 use crate::spec::transform::formula::FormulaTransformSpec;
 use crate::spec::transform::TransformSpec;
 use crate::task_graph::graph::ScopedVariable;
@@ -244,7 +246,17 @@ impl ChartVisitor for CollectLocalTimeScaledFieldsVisitor {
                     ScaleDomainSpec::FieldReference(field_ref) => {
                         vec![field_ref.clone()]
                     }
-                    ScaleDomainSpec::FieldsReference(fields_ref) => fields_ref.fields.clone(),
+                    ScaleDomainSpec::FieldsReference(fields_ref) => fields_ref
+                        .fields
+                        .iter()
+                        .filter_map(|f| {
+                            if let ScaleDataReferenceOrSignalSpec::Reference(f) = f {
+                                Some(f.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
                     _ => Default::default(),
                 };
                 for field_ref in &field_refs {

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -78,13 +78,20 @@ pub enum ScaleDomainSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScaleDataReferencesSpec {
-    pub fields: Vec<ScaleDataReferenceSpec>,
+    pub fields: Vec<ScaleDataReferenceOrSignalSpec>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<ScaleDataReferenceSort>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ScaleDataReferenceOrSignalSpec {
+    Reference(ScaleDataReferenceSpec),
+    Signal(SignalExpressionSpec),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -68,9 +68,9 @@ impl ScaleTypeSpec {
 pub enum ScaleDomainSpec {
     Array(Vec<ScaleArrayElementSpec>),
     FieldReference(ScaleDataReferenceSpec),
-    FieldsReference(ScaleDataReferencesSpec),
     FieldsVecStrings(ScaleVecStringsSpec),
     FieldsStrings(ScaleStringsSpec),
+    FieldsReference(ScaleDataReferencesSpec),
     FieldsSignals(ScaleSignalsSpec),
     Signal(SignalExpressionSpec),
     Value(Value),

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -9,8 +9,8 @@ use crate::spec::chart::{ChartSpec, ChartVisitor};
 use crate::spec::data::{DataFormatParseSpec, DataSpec};
 use crate::spec::mark::{MarkFacetSpec, MarkSpec};
 use crate::spec::scale::{
-    ScaleArrayElementSpec, ScaleBinsSpec, ScaleDataReferenceSpec, ScaleDomainSpec, ScaleRangeSpec,
-    ScaleSpec,
+    ScaleArrayElementSpec, ScaleBinsSpec, ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSpec,
+    ScaleDomainSpec, ScaleRangeSpec, ScaleSpec,
 };
 use crate::spec::signal::{SignalOnEventSpec, SignalSpec};
 use crate::spec::values::{SignalExpressionSpec, StringOrSignalSpec};
@@ -560,7 +560,16 @@ impl<'a> ChartVisitor for InputVarsChartVisitor<'a> {
                     references.push(reference.clone());
                 }
                 ScaleDomainSpec::FieldsReference(field_references) => {
-                    references.extend(field_references.fields.clone());
+                    for v in field_references.fields.clone() {
+                        match v {
+                            ScaleDataReferenceOrSignalSpec::Reference(field_ref) => {
+                                references.push(field_ref);
+                            }
+                            ScaleDataReferenceOrSignalSpec::Signal(signal) => {
+                                signals.push(signal);
+                            }
+                        }
+                    }
                 }
                 ScaleDomainSpec::FieldsSignals(fields_signals) => {
                     signals.extend(fields_signals.fields.clone());

--- a/vegafusion-runtime/tests/specs/custom/gh_383.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/gh_383.comm_plan.json
@@ -1,0 +1,35 @@
+{
+  "server_to_client": [
+    {
+      "name": "concat_0_bin_maxbins_20_mean_price_bins",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "concat_1_layer_0_bin_maxbins_20_mean_price_bins",
+      "namespace": "signal",
+      "scope": []
+    },
+    {
+      "name": "source_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_0_concat_0_y_domain___count",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_1",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_1_concat_1_y_domain___count",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/gh_383.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/gh_383.comm_plan.json
@@ -29,6 +29,11 @@
       "name": "source_1_concat_1_y_domain___count",
       "namespace": "data",
       "scope": []
+    },
+    {
+      "name": "source_2",
+      "namespace": "data",
+      "scope": []
     }
   ],
   "client_to_server": []

--- a/vegafusion-runtime/tests/specs/custom/gh_383.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/gh_383.vg.json
@@ -1,0 +1,457 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 300,
+  "data": [
+    {
+      "name": "source_0",
+      "values": [
+        {
+          "mean_price": 166,
+          "replicate": 0
+        },
+        {
+          "mean_price": 169,
+          "replicate": 1
+        }
+      ],
+      "format": {
+        "type": "json"
+      },
+      "transform": [
+        {
+          "type": "extent",
+          "field": "mean_price",
+          "signal": "concat_0_bin_maxbins_20_mean_price_extent"
+        },
+        {
+          "type": "bin",
+          "field": "mean_price",
+          "as": [
+            "bin_maxbins_20_mean_price",
+            "bin_maxbins_20_mean_price_end"
+          ],
+          "signal": "concat_0_bin_maxbins_20_mean_price_bins",
+          "extent": {
+            "signal": "concat_0_bin_maxbins_20_mean_price_extent"
+          },
+          "maxbins": 20
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_maxbins_20_mean_price",
+            "bin_maxbins_20_mean_price_end"
+          ],
+          "ops": [
+            "count"
+          ],
+          "fields": [
+            null
+          ],
+          "as": [
+            "__count"
+          ]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"bin_maxbins_20_mean_price\"]) && isFinite(+datum[\"bin_maxbins_20_mean_price\"])"
+        }
+      ]
+    },
+    {
+      "name": "source_1",
+      "values": [
+        {
+          "mean_price": 166,
+          "replicate": 0
+        },
+        {
+          "mean_price": 169,
+          "replicate": 1
+        }
+      ],
+      "format": {
+        "type": "json"
+      },
+      "transform": [
+        {
+          "type": "extent",
+          "field": "mean_price",
+          "signal": "concat_1_layer_0_bin_maxbins_20_mean_price_extent"
+        },
+        {
+          "type": "bin",
+          "field": "mean_price",
+          "as": [
+            "bin_maxbins_20_mean_price",
+            "bin_maxbins_20_mean_price_end"
+          ],
+          "signal": "concat_1_layer_0_bin_maxbins_20_mean_price_bins",
+          "extent": {
+            "signal": "concat_1_layer_0_bin_maxbins_20_mean_price_extent"
+          },
+          "maxbins": 20
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_maxbins_20_mean_price",
+            "bin_maxbins_20_mean_price_end"
+          ],
+          "ops": [
+            "count"
+          ],
+          "fields": [
+            null
+          ],
+          "as": [
+            "__count"
+          ]
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"bin_maxbins_20_mean_price\"]) && isFinite(+datum[\"bin_maxbins_20_mean_price\"])"
+        }
+      ]
+    },
+    {
+      "name": "source_2",
+      "values": [
+        {
+          "mean_price": 166,
+          "replicate": 0
+        },
+        {
+          "mean_price": 169,
+          "replicate": 1
+        }
+      ],
+      "format": {
+        "type": "json"
+      },
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"mean_price\"]) && isFinite(+datum[\"mean_price\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {
+      "name": "childHeight",
+      "value": 300
+    }
+  ],
+  "layout": {
+    "padding": 20,
+    "columns": 1,
+    "bounds": "full",
+    "align": "each"
+  },
+  "marks": [
+    {
+      "type": "group",
+      "name": "concat_0_group",
+      "style": "cell",
+      "encode": {
+        "update": {
+          "width": {
+            "signal": "width"
+          },
+          "height": {
+            "signal": "childHeight"
+          }
+        }
+      },
+      "marks": [
+        {
+          "name": "concat_0_marks",
+          "type": "rect",
+          "style": [
+            "bar"
+          ],
+          "from": {
+            "data": "source_0"
+          },
+          "encode": {
+            "update": {
+              "fill": {
+                "value": "#4c78a8"
+              },
+              "ariaRoleDescription": {
+                "value": "bar"
+              },
+              "description": {
+                "signal": "\"mean_price (binned): \" + (!isValid(datum[\"bin_maxbins_20_mean_price\"]) || !isFinite(+datum[\"bin_maxbins_20_mean_price\"]) ? \"null\" : format(datum[\"bin_maxbins_20_mean_price\"], \"\") + \" \u2013 \" + format(datum[\"bin_maxbins_20_mean_price_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+              },
+              "x2": {
+                "scale": "x",
+                "field": "bin_maxbins_20_mean_price",
+                "offset": {
+                  "signal": "0.5 + (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])) < 0.25 ? -0.5 * (0.25 - (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])))) : 0.5)"
+                }
+              },
+              "x": {
+                "scale": "x",
+                "field": "bin_maxbins_20_mean_price_end",
+                "offset": {
+                  "signal": "0.5 + (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])) < 0.25 ? 0.5 * (0.25 - (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])))) : -0.5)"
+                }
+              },
+              "y": {
+                "scale": "concat_0_y",
+                "field": "__count"
+              },
+              "y2": {
+                "scale": "concat_0_y",
+                "value": 0
+              }
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "concat_0_y",
+          "orient": "left",
+          "gridScale": "x",
+          "grid": true,
+          "tickCount": {
+            "signal": "ceil(childHeight/40)"
+          },
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "mean_price (binned)",
+          "labelFlush": true,
+          "labelOverlap": true,
+          "tickCount": {
+            "signal": "ceil(width/10)"
+          },
+          "zindex": 0
+        },
+        {
+          "scale": "concat_0_y",
+          "orient": "left",
+          "grid": false,
+          "title": "Count of Records",
+          "labelOverlap": true,
+          "tickCount": {
+            "signal": "ceil(childHeight/40)"
+          },
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "type": "group",
+      "name": "concat_1_group",
+      "style": "cell",
+      "encode": {
+        "update": {
+          "width": {
+            "signal": "width"
+          },
+          "height": {
+            "signal": "childHeight"
+          }
+        }
+      },
+      "marks": [
+        {
+          "name": "concat_1_layer_0_marks",
+          "type": "rect",
+          "style": [
+            "bar"
+          ],
+          "from": {
+            "data": "source_1"
+          },
+          "encode": {
+            "update": {
+              "fill": {
+                "value": "#4c78a8"
+              },
+              "ariaRoleDescription": {
+                "value": "bar"
+              },
+              "description": {
+                "signal": "\"mean_price (binned): \" + (!isValid(datum[\"bin_maxbins_20_mean_price\"]) || !isFinite(+datum[\"bin_maxbins_20_mean_price\"]) ? \"null\" : format(datum[\"bin_maxbins_20_mean_price\"], \"\") + \" \u2013 \" + format(datum[\"bin_maxbins_20_mean_price_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+              },
+              "x2": {
+                "scale": "x",
+                "field": "bin_maxbins_20_mean_price",
+                "offset": {
+                  "signal": "0.5 + (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])) < 0.25 ? -0.5 * (0.25 - (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])))) : 0.5)"
+                }
+              },
+              "x": {
+                "scale": "x",
+                "field": "bin_maxbins_20_mean_price_end",
+                "offset": {
+                  "signal": "0.5 + (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])) < 0.25 ? 0.5 * (0.25 - (abs(scale(\"x\", datum[\"bin_maxbins_20_mean_price_end\"]) - scale(\"x\", datum[\"bin_maxbins_20_mean_price\"])))) : -0.5)"
+                }
+              },
+              "y": {
+                "scale": "concat_1_y",
+                "field": "__count"
+              },
+              "y2": {
+                "scale": "concat_1_y",
+                "value": 0
+              }
+            }
+          }
+        },
+        {
+          "name": "concat_1_layer_1_marks",
+          "type": "rule",
+          "style": [
+            "rule"
+          ],
+          "from": {
+            "data": "source_2"
+          },
+          "encode": {
+            "update": {
+              "stroke": {
+                "value": "black"
+              },
+              "description": {
+                "signal": "\"mean_price: \" + (format(datum[\"mean_price\"], \"\"))"
+              },
+              "x": {
+                "scale": "x",
+                "field": "mean_price"
+              },
+              "y": {
+                "value": 0
+              },
+              "y2": {
+                "field": {
+                  "group": "height"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "concat_1_y",
+          "orient": "left",
+          "gridScale": "x",
+          "grid": true,
+          "tickCount": {
+            "signal": "ceil(childHeight/40)"
+          },
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "mean_price (binned), mean_price",
+          "labelFlush": true,
+          "labelOverlap": true,
+          "tickCount": {
+            "signal": "ceil(width/10)"
+          },
+          "zindex": 0
+        },
+        {
+          "scale": "concat_1_y",
+          "orient": "left",
+          "grid": false,
+          "title": "Count of Records",
+          "labelOverlap": true,
+          "tickCount": {
+            "signal": "ceil(childHeight/40)"
+          },
+          "zindex": 0
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {
+        "fields": [
+          {
+            "signal": "[concat_0_bin_maxbins_20_mean_price_bins.start, concat_0_bin_maxbins_20_mean_price_bins.stop]"
+          },
+          {
+            "signal": "[concat_1_layer_0_bin_maxbins_20_mean_price_bins.start, concat_1_layer_0_bin_maxbins_20_mean_price_bins.stop]"
+          },
+          {
+            "data": "source_2",
+            "field": "mean_price"
+          }
+        ]
+      },
+      "range": [
+        0,
+        {
+          "signal": "width"
+        }
+      ],
+      "bins": {
+        "signal": "concat_0_bin_maxbins_20_mean_price_bins"
+      },
+      "nice": true,
+      "zero": false
+    },
+    {
+      "name": "concat_0_y",
+      "type": "linear",
+      "domain": {
+        "data": "source_0",
+        "field": "__count"
+      },
+      "range": [
+        {
+          "signal": "childHeight"
+        },
+        0
+      ],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "concat_1_y",
+      "type": "linear",
+      "domain": {
+        "data": "source_1",
+        "field": "__count"
+      },
+      "range": [
+        {
+          "signal": "childHeight"
+        },
+        0
+      ],
+      "nice": true,
+      "zero": true
+    }
+  ]
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -138,7 +138,8 @@ mod test_custom_specs {
         case("custom/periods_in_formula_output", 0.001, true),
         case("custom/bin_transform_rounding", 0.001, true),
         case("custom/geojson_inline", 0.001, true),
-        case("custom/gh_361", 0.001, true)
+        case("custom/gh_361", 0.001, true),
+        case("custom/gh_383", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");


### PR DESCRIPTION
Fixes https://github.com/hex-inc/vegafusion/issues/382 by allowing `scale.domain.fields` array to contain a mix of data references and signals.

e.g.
```json
        [
          {
            "signal": "[concat_0_bin_maxbins_20_mean_price_bins.start, concat_0_bin_maxbins_20_mean_price_bins.stop]"
          },
          {
            "signal": "[concat_1_layer_0_bin_maxbins_20_mean_price_bins.start, concat_1_layer_0_bin_maxbins_20_mean_price_bins.stop]"
          },
          {
            "data": "source_2",
            "field": "mean_price"
          }
        ]
```

I didn't know Vega-Lite would do this, and apparently Vega supports it.

Closes https://github.com/hex-inc/vegafusion/issues/382