### PR TITLE
Free Python GIL on blocking operations to allow multi-threading runtime usage without deadlocks

### DIFF
--- a/python/vegafusion/vegafusion/dataset/dataframe.py
+++ b/python/vegafusion/vegafusion/dataset/dataframe.py
@@ -37,6 +37,15 @@ class DataFrameDataset(ABC):
         """
         return True
 
+    def main_thread(self) -> bool:
+        """
+        True if the dataset must be evaluated run on the main thread.
+        This blocks multithreaded parallelization, but is sometimes required
+
+        :return: bool
+        """
+        return True
+
     def sort(
         self, exprs: List[LogicalExprNode], limit: Optional[int]
     ) -> "DataFrameDataset":

--- a/python/vegafusion/vegafusion/dataset/sql.py
+++ b/python/vegafusion/vegafusion/dataset/sql.py
@@ -60,6 +60,15 @@ class SqlDataset(ABC):
         """
         return True
 
+    def main_thread(self) -> bool:
+        """
+        True if the dataset must be evaluated run on the main thread.
+        This blocks multithreaded parallelization, but is sometimes required
+
+        :return: bool
+        """
+        return True
+
     def __dataframe__(
         self, nan_as_null: bool = False, allow_copy: bool = True, **kwargs
     ) -> "SqlDatasetDataFrame":


### PR DESCRIPTION
Previously we forced the use of a single-threaded tokio runtime whenever a Python Datasource was in use. This was done to work around deadlocks, but has the unfortunate side affect of disabling multi-threaded parallelization of queries in these situations. This PR applies the technique discussed in See https://github.com/PyO3/pyo3/discussions/2182 to use the PyO3 `allow_threads` construct to release the Python GIL before performing blocking operations that may themselves need to acquire the GIL in separate threads.

In turns out that the DuckDbDatasource still requires running on the main thread in order to access the kernel's top-level DataFrames, so I made the main thread behavior configurable on a per-datasource level, where the default is to maintain the prior behavior of running on the main thread.

I started thinking about this again as a result of the discussion in https://github.com/hex-inc/vegafusion/issues/386. With these changes, it should be possible to write a `__dataframe__` protocol-based VegaFusion Datasource that implements a custom DataFusion datasource without requiring everything to run on the main thread.
