### PR TITLE
Handle domain data reference with list of fields

### DIFF
--- a/vegafusion-core/src/planning/projection_pushdown.rs
+++ b/vegafusion-core/src/planning/projection_pushdown.rs
@@ -8,8 +8,8 @@ use crate::spec::chart::{ChartSpec, ChartVisitor, MutChartVisitor};
 use crate::spec::data::DataSpec;
 use crate::spec::mark::{MarkEncodeSpec, MarkEncodingField, MarkEncodingSpec, MarkSpec};
 use crate::spec::scale::{
-    ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSort, ScaleDataReferenceSpec,
-    ScaleDomainSpec, ScaleRangeSpec, ScaleSpec,
+    ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSort, ScaleDomainSpec,
+    ScaleFieldReferenceSpec, ScaleRangeSpec, ScaleSpec,
 };
 use crate::spec::signal::{SignalOnEventSpec, SignalSpec};
 use crate::spec::transform::project::ProjectTransformSpec;
@@ -305,7 +305,7 @@ impl GetDatasetsColumnUsage for MarkSpec {
     }
 }
 
-impl GetDatasetsColumnUsage for ScaleDataReferenceSpec {
+impl GetDatasetsColumnUsage for ScaleFieldReferenceSpec {
     fn datasets_column_usage(
         &self,
         _datum_var: &Option<ScopedVariable>,
@@ -357,7 +357,10 @@ impl GetDatasetsColumnUsage for ScaleDomainSpec {
                 scale_data_refs.push(field_ref.clone());
                 sort = field_ref.sort.clone();
             }
-            ScaleDomainSpec::FieldsReference(fields_refs) => {
+            ScaleDomainSpec::FieldsReference(fields_ref) => {
+                scale_data_refs.extend(fields_ref.to_field_references());
+            }
+            ScaleDomainSpec::FieldsReferences(fields_refs) => {
                 for v in &fields_refs.fields {
                     match v {
                         ScaleDataReferenceOrSignalSpec::Reference(scale_data_ref) => {

--- a/vegafusion-core/src/planning/split_domain_data.rs
+++ b/vegafusion-core/src/planning/split_domain_data.rs
@@ -3,7 +3,7 @@ use crate::spec::chart::{ChartSpec, MutChartVisitor};
 use crate::spec::data::DataSpec;
 use crate::spec::scale::{
     ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSort, ScaleDataReferenceSortParameters,
-    ScaleDataReferenceSpec, ScaleDataReferencesSpec, ScaleDomainSpec, ScaleSpec, ScaleTypeSpec,
+    ScaleDomainSpec, ScaleFieldReferenceSpec, ScaleFieldsReferencesSpec, ScaleSpec, ScaleTypeSpec,
 };
 use crate::spec::transform::aggregate::AggregateOpSpec;
 use crate::task_graph::graph::ScopedVariable;
@@ -59,7 +59,7 @@ impl<'a> MutChartVisitor for SplitScaleDomainVisitor<'a> {
                 ScaleDomainSpec::FieldReference(field_ref) => {
                     self.split_field_reference_domain(scale, scope, &field_ref)?;
                 }
-                ScaleDomainSpec::FieldsReference(fields_ref) => {
+                ScaleDomainSpec::FieldsReferences(fields_ref) => {
                     self.split_fields_reference_domain(scale, scope, &fields_ref)?;
                 }
                 _ => {}
@@ -74,7 +74,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
         &mut self,
         scale: &mut ScaleSpec,
         scope: &[u32],
-        fields_ref: &ScaleDataReferencesSpec,
+        fields_ref: &ScaleFieldsReferencesSpec,
     ) -> Result<()> {
         let discrete_scale = scale.type_.clone().unwrap_or_default().is_discrete();
         let (new_datasets, new_dataset_scope, new_domain) = if discrete_scale {
@@ -135,7 +135,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                 sort => sort.clone(),
             };
 
-            let new_domain = ScaleDomainSpec::FieldsReference(ScaleDataReferencesSpec {
+            let new_domain = ScaleDomainSpec::FieldsReferences(ScaleFieldsReferencesSpec {
                 fields: new_fields
                     .into_iter()
                     .map(|f| ScaleDataReferenceOrSignalSpec::Reference(f))
@@ -165,7 +165,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
         &mut self,
         scale: &mut ScaleSpec,
         scope: &[u32],
-        field_ref: &ScaleDataReferenceSpec,
+        field_ref: &ScaleFieldReferenceSpec,
     ) -> Result<()> {
         let discrete_scale = scale.type_.clone().unwrap_or_default().is_discrete();
         let data_name = field_ref.data.clone();
@@ -217,7 +217,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                 sort => sort.clone(),
             };
 
-            let new_domain = ScaleDomainSpec::FieldReference(ScaleDataReferenceSpec {
+            let new_domain = ScaleDomainSpec::FieldReference(ScaleFieldReferenceSpec {
                 data: new_data_name,
                 field: field_name.clone(),
                 sort,

--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -246,7 +246,10 @@ impl ChartVisitor for CollectLocalTimeScaledFieldsVisitor {
                     ScaleDomainSpec::FieldReference(field_ref) => {
                         vec![field_ref.clone()]
                     }
-                    ScaleDomainSpec::FieldsReference(fields_ref) => fields_ref
+                    ScaleDomainSpec::FieldsReference(fields_ref) => {
+                        fields_ref.to_field_references()
+                    }
+                    ScaleDomainSpec::FieldsReferences(fields_ref) => fields_ref
                         .fields
                         .iter()
                         .filter_map(|f| {

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -67,17 +67,16 @@ impl ScaleTypeSpec {
 #[serde(untagged)]
 pub enum ScaleDomainSpec {
     Array(Vec<ScaleArrayElementSpec>),
-    FieldReference(ScaleDataReferenceSpec),
-    FieldsVecStrings(ScaleVecStringsSpec),
-    FieldsStrings(ScaleStringsSpec),
-    FieldsReference(ScaleDataReferencesSpec),
+    FieldReference(ScaleFieldReferenceSpec),
+    FieldsReference(ScaleFieldsReferenceSpec),
+    FieldsReferences(ScaleFieldsReferencesSpec),
     FieldsSignals(ScaleSignalsSpec),
     Signal(SignalExpressionSpec),
     Value(Value),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ScaleDataReferencesSpec {
+pub struct ScaleFieldsReferencesSpec {
     pub fields: Vec<ScaleDataReferenceOrSignalSpec>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,12 +89,12 @@ pub struct ScaleDataReferencesSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ScaleDataReferenceOrSignalSpec {
-    Reference(ScaleDataReferenceSpec),
+    Reference(ScaleFieldReferenceSpec),
     Signal(SignalExpressionSpec),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ScaleDataReferenceSpec {
+pub struct ScaleFieldReferenceSpec {
     pub data: String,
     pub field: String,
 
@@ -110,19 +109,29 @@ pub struct ScaleDataReferenceSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ScaleVecStringsSpec {
-    pub fields: Vec<Vec<String>>,
+pub struct ScaleFieldsReferenceSpec {
+    pub data: String,
+    pub fields: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<ScaleDataReferenceSort>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ScaleStringsSpec {
-    pub fields: Vec<String>,
-
-    #[serde(flatten)]
-    pub extra: HashMap<String, Value>,
+impl ScaleFieldsReferenceSpec {
+    pub fn to_field_references(&self) -> Vec<ScaleFieldReferenceSpec> {
+        self.fields
+            .iter()
+            .map(|f| ScaleFieldReferenceSpec {
+                data: self.data.clone(),
+                field: f.clone(),
+                sort: self.sort.clone(),
+                extra: Default::default(),
+            })
+            .collect::<Vec<_>>()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -177,7 +186,7 @@ pub enum ScaleBinsSpec {
 #[serde(untagged)]
 pub enum ScaleRangeSpec {
     Array(Vec<ScaleArrayElementSpec>),
-    Reference(ScaleDataReferenceSpec),
+    Reference(ScaleFieldReferenceSpec),
     Signal(SignalExpressionSpec),
     Value(Value),
 }

--- a/vegafusion-core/src/spec/scale.rs
+++ b/vegafusion-core/src/spec/scale.rs
@@ -68,6 +68,7 @@ impl ScaleTypeSpec {
 pub enum ScaleDomainSpec {
     Array(Vec<ScaleArrayElementSpec>),
     FieldReference(ScaleFieldReferenceSpec),
+    FieldsVecStrings(ScaleVecStringsSpec),
     FieldsReference(ScaleFieldsReferenceSpec),
     FieldsReferences(ScaleFieldsReferencesSpec),
     FieldsSignals(ScaleSignalsSpec),
@@ -81,6 +82,14 @@ pub struct ScaleFieldsReferencesSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<ScaleDataReferenceSort>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScaleVecStringsSpec {
+    pub fields: Vec<Vec<String>>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -110,7 +119,9 @@ pub struct ScaleFieldReferenceSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScaleFieldsReferenceSpec {
-    pub data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+
     pub fields: Vec<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -122,15 +133,19 @@ pub struct ScaleFieldsReferenceSpec {
 
 impl ScaleFieldsReferenceSpec {
     pub fn to_field_references(&self) -> Vec<ScaleFieldReferenceSpec> {
-        self.fields
-            .iter()
-            .map(|f| ScaleFieldReferenceSpec {
-                data: self.data.clone(),
-                field: f.clone(),
-                sort: self.sort.clone(),
-                extra: Default::default(),
-            })
-            .collect::<Vec<_>>()
+        if let Some(data) = &self.data.clone() {
+            self.fields
+                .iter()
+                .map(|f| ScaleFieldReferenceSpec {
+                    data: data.clone(),
+                    field: f.clone(),
+                    sort: self.sort.clone(),
+                    extra: Default::default(),
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        }
     }
 }
 

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -9,8 +9,8 @@ use crate::spec::chart::{ChartSpec, ChartVisitor};
 use crate::spec::data::{DataFormatParseSpec, DataSpec};
 use crate::spec::mark::{MarkFacetSpec, MarkSpec};
 use crate::spec::scale::{
-    ScaleArrayElementSpec, ScaleBinsSpec, ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSpec,
-    ScaleDomainSpec, ScaleRangeSpec, ScaleSpec,
+    ScaleArrayElementSpec, ScaleBinsSpec, ScaleDataReferenceOrSignalSpec, ScaleDomainSpec,
+    ScaleFieldReferenceSpec, ScaleRangeSpec, ScaleSpec,
 };
 use crate::spec::signal::{SignalOnEventSpec, SignalSpec};
 use crate::spec::values::{SignalExpressionSpec, StringOrSignalSpec};
@@ -550,7 +550,7 @@ impl<'a> ChartVisitor for InputVarsChartVisitor<'a> {
     }
 
     fn visit_scale(&mut self, scale: &ScaleSpec, scope: &[u32]) -> Result<()> {
-        let mut references: Vec<ScaleDataReferenceSpec> = Vec::new();
+        let mut references: Vec<ScaleFieldReferenceSpec> = Vec::new();
         let mut signals: Vec<SignalExpressionSpec> = Vec::new();
 
         // domain
@@ -559,7 +559,10 @@ impl<'a> ChartVisitor for InputVarsChartVisitor<'a> {
                 ScaleDomainSpec::FieldReference(reference) => {
                     references.push(reference.clone());
                 }
-                ScaleDomainSpec::FieldsReference(field_references) => {
+                ScaleDomainSpec::FieldsReference(fields_reference) => {
+                    references.extend(fields_reference.to_field_references());
+                }
+                ScaleDomainSpec::FieldsReferences(field_references) => {
                     for v in field_references.fields.clone() {
                         match v {
                             ScaleDataReferenceOrSignalSpec::Reference(field_ref) => {

--- a/vegafusion-runtime/tests/specs/custom/gh_391.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/gh_391.comm_plan.json
@@ -1,0 +1,30 @@
+{
+  "server_to_client": [
+    {
+      "name": "column_domain",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_2_color_domain_location",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_source",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_source_y_domain_category",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/gh_391.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/gh_391.vg.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "data": [
+    {
+      "name": "data_source",
+      "values": [
+        {"location": "US", "category": "low", "value": 1},
+        {"location": "US", "category": "high", "value": 2},
+        {"location": "US", "category": "high", "value": 3},
+        {"location": "UK", "category": "low", "value": 2},
+        {"location": "UK", "category": "high", "value": 3},
+        {"location": "UK", "category": "high", "value": 4}
+      ]
+    },
+    {
+      "name": "column_domain",
+      "source": "data_source",
+      "transform": [{"type": "aggregate", "groupby": ["location"]}]
+    },
+    {
+      "name": "data_2",
+      "source": "data_source",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["category", "location"],
+          "ops": ["sum"],
+          "fields": ["value"],
+          "as": ["sum_value"]
+        },
+        {
+          "type": "stack",
+          "groupby": ["category", "location"],
+          "field": "sum_value",
+          "sort": {"field": ["location"], "order": ["ascending"]},
+          "as": ["sum_value_start", "sum_value_end"],
+          "offset": "zero"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"sum_value\"]) && isFinite(+datum[\"sum_value\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "child_width", "value": 300},
+    {"name": "y_step", "value": 20},
+    {
+      "name": "child_height",
+      "update": "bandspace(domain('y').length, 0.1, 0.05) * y_step"
+    }
+  ],
+  "layout": {
+    "padding": 20,
+    "offset": {"columnTitle": 10},
+    "columns": {"signal": "length(data('column_domain'))"},
+    "bounds": "full",
+    "align": "all"
+  },
+  "marks": [
+    {
+      "name": "column-title",
+      "type": "group",
+      "role": "column-title",
+      "title": {"text": "location", "style": "guide-title", "offset": 10}
+    },
+    {
+      "name": "row_header",
+      "type": "group",
+      "role": "row-header",
+      "encode": {"update": {"height": {"signal": "child_height"}}},
+      "axes": [
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": false,
+          "title": "category",
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "column_header",
+      "type": "group",
+      "role": "column-header",
+      "from": {"data": "column_domain"},
+      "sort": {"field": "datum[\"location\"]", "order": "ascending"},
+      "title": {
+        "text": {
+          "signal": "isValid(parent[\"location\"]) ? parent[\"location\"] : \"\"+parent[\"location\"]"
+        },
+        "style": "guide-label",
+        "frame": "group",
+        "offset": 10
+      },
+      "encode": {"update": {"width": {"signal": "child_width"}}}
+    },
+    {
+      "name": "column_footer",
+      "type": "group",
+      "role": "column-footer",
+      "from": {"data": "column_domain"},
+      "sort": {"field": "datum[\"location\"]", "order": "ascending"},
+      "encode": {"update": {"width": {"signal": "child_width"}}},
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "Sum of value",
+          "labelFlush": true,
+          "labelOverlap": true,
+          "tickCount": {"signal": "ceil(child_width/40)"},
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "cell",
+      "type": "group",
+      "style": "cell",
+      "from": {
+        "facet": {
+          "name": "facet",
+          "data": "data_source",
+          "groupby": ["location"]
+        }
+      },
+      "sort": {"field": ["datum[\"location\"]"], "order": ["ascending"]},
+      "data": [
+        {
+          "source": "facet",
+          "name": "data_0",
+          "transform": [
+            {
+              "type": "aggregate",
+              "groupby": ["category", "location"],
+              "ops": ["sum"],
+              "fields": ["value"],
+              "as": ["sum_value"]
+            },
+            {
+              "type": "stack",
+              "groupby": ["category"],
+              "field": "sum_value",
+              "sort": {"field": ["location"], "order": ["ascending"]},
+              "as": ["sum_value_start", "sum_value_end"],
+              "offset": "zero"
+            },
+            {
+              "type": "filter",
+              "expr": "isValid(datum[\"sum_value\"]) && isFinite(+datum[\"sum_value\"])"
+            }
+          ]
+        }
+      ],
+      "encode": {
+        "update": {
+          "width": {"signal": "child_width"},
+          "height": {"signal": "child_height"}
+        }
+      },
+      "marks": [
+        {
+          "name": "child_marks",
+          "type": "rect",
+          "style": ["bar"],
+          "from": {"data": "data_0"},
+          "encode": {
+            "update": {
+              "fill": {"scale": "color", "field": "location"},
+              "ariaRoleDescription": {"value": "bar"},
+              "description": {
+                "signal": "\"Sum of value: \" + (format(datum[\"sum_value\"], \"\")) + \"; category: \" + (isValid(datum[\"category\"]) ? datum[\"category\"] : \"\"+datum[\"category\"]) + \"; location: \" + (isValid(datum[\"location\"]) ? datum[\"location\"] : \"\"+datum[\"location\"])"
+              },
+              "x": {"scale": "x", "field": "sum_value_end"},
+              "x2": {"scale": "x", "field": "sum_value_start"},
+              "y": {"scale": "y", "field": "category"},
+              "height": {"signal": "max(0.25, bandwidth('y'))"}
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "gridScale": "y",
+          "grid": true,
+          "tickCount": {"signal": "ceil(child_width/40)"},
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": {
+        "data": "data_2",
+        "fields": ["sum_value_start", "sum_value_end"]
+      },
+      "range": [0, {"signal": "child_width"}],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "y",
+      "type": "band",
+      "domain": {
+        "data": "data_source",
+        "field": "category",
+        "sort": {"op": "sum", "field": "value", "order": "descending"}
+      },
+      "range": {"step": {"signal": "y_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "data_2", "field": "location", "sort": true},
+      "range": "category"
+    }
+  ],
+  "legends": [{"fill": "color", "symbolType": "square", "title": "location"}]
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -140,7 +140,8 @@ mod test_custom_specs {
         case("custom/geojson_inline", 0.001, true),
         case("custom/gh_361", 0.001, true),
         case("custom/gh_379", 0.001, true),
-        case("custom/gh_383", 0.001, true)
+        case("custom/gh_383", 0.001, true),
+        case("custom/gh_391", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");


### PR DESCRIPTION
Closes #391 

Handles scale domain data references of the form:

```json
      "domain": {
        "data": "data_2",
        "fields": ["sum_value_start", "sum_value_end"]
      }
```