### PR TITLE
Fix crash in bin transform with empty input table

### DIFF
--- a/vegafusion-runtime/src/transform/bin.rs
+++ b/vegafusion-runtime/src/transform/bin.rs
@@ -157,7 +157,7 @@ pub fn calculate_bin_params(
     let extent_expr = compile(tx.extent.as_ref().unwrap(), config, Some(schema))?;
     let extent_scalar = extent_expr.eval_to_scalar()?;
 
-    let extent = extent_scalar.to_f64x2()?;
+    let extent = extent_scalar.to_f64x2().unwrap_or([0.0, 0.0]);
 
     let [min_, max_] = extent;
     if min_ > max_ {


### PR DESCRIPTION
When a transform pipeline that involves `extent` and `bin` was fed an empty table as input, the following error would occur.

```
Internal error: Cannot convert NULL to f64
```

The issue is that `extent` returns `[NULL, NULL]` in this case (which is valid) and `bin` would attempt to cast these elements to f64 values (which is not valid).  Now we default to `[0.0, 0.0]` in this case (any valid values would work since the result will be an empty table).