### PR TITLE
Remove panics from planning logic

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -311,7 +311,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars==0.19.3 duckdb vl-convert-python scikit-image pandas==2.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest
@@ -342,7 +342,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars==0.19.3 duckdb altair vl-convert-python scikit-image pandas==2.0
           
           # Downgrade pyarrow to 10.0.1
           python -m pip install pyarrow==10.0.1
@@ -380,7 +380,7 @@ jobs:
 
           python -m pip install $vegafusion
           python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+          python -m pip install pytest vega-datasets polars==0.19.3 duckdb vl-convert-python scikit-image
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/vegafusion-core/src/planning/split_domain_data.rs
+++ b/vegafusion-core/src/planning/split_domain_data.rs
@@ -248,8 +248,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                         }
                     ]
                 }
-            ))
-            .unwrap();
+            ))?;
 
             // Create new domain specification that uses the new dataset
             let new_domain: ScaleDomainSpec = serde_json::from_value(serde_json::json!([
@@ -267,8 +266,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                             escape_field(&new_data_name)
                         )
                 }
-            ]))
-            .unwrap();
+            ]))?;
 
             (new_data, new_domain)
         } else {
@@ -324,8 +322,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                         }
                     ]
                }
-            ))
-            .unwrap()
+            ))?
         } else {
             // Will sort by the grouped field values
             serde_json::from_value(serde_json::json!(
@@ -346,8 +343,7 @@ impl<'a> SplitScaleDomainVisitor<'a> {
                         }
                     ]
                }
-            ))
-            .unwrap()
+            ))?
         })
     }
 }

--- a/vegafusion-core/src/planning/stitch.rs
+++ b/vegafusion-core/src/planning/stitch.rs
@@ -21,30 +21,14 @@ pub fn stitch_specs(
     keep_variables: &[ScopedVariable],
 ) -> Result<CommPlan> {
     // Get client spec variable types
-    let client_defs: HashSet<_> = client_spec.definition_vars().unwrap().into_iter().collect();
-    let client_inputs: HashSet<_> = client_spec
-        .input_vars(task_scope)
-        .unwrap()
-        .into_iter()
-        .collect();
-    let client_updates: HashSet<_> = client_spec
-        .update_vars(task_scope)
-        .unwrap()
-        .into_iter()
-        .collect();
+    let client_defs: HashSet<_> = client_spec.definition_vars()?.into_iter().collect();
+    let client_inputs: HashSet<_> = client_spec.input_vars(task_scope)?.into_iter().collect();
+    let client_updates: HashSet<_> = client_spec.update_vars(task_scope)?.into_iter().collect();
 
     // Get server spec variable types
-    let server_defs: HashSet<_> = server_spec.definition_vars().unwrap().into_iter().collect();
-    let server_inputs: HashSet<_> = server_spec
-        .input_vars(task_scope)
-        .unwrap()
-        .into_iter()
-        .collect();
-    let server_updates: HashSet<_> = server_spec
-        .update_vars(task_scope)
-        .unwrap()
-        .into_iter()
-        .collect();
+    let server_defs: HashSet<_> = server_spec.definition_vars()?.into_iter().collect();
+    let server_inputs: HashSet<_> = server_spec.input_vars(task_scope)?.into_iter().collect();
+    let server_updates: HashSet<_> = server_spec.update_vars(task_scope)?.into_iter().collect();
 
     // Determine communication requirements
     let mut server_to_client: HashSet<_> = client_inputs


### PR DESCRIPTION
I came across a case where the VegaFusion planner paniced when passed a spec that contained unparsable Vega expression strings.  This removes that panic, and a couple of others in the vicinity.