### PR TITLE
Convert arrow types to those compatible with Vega when data_encoding_format is set

### DIFF
--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -287,7 +287,10 @@ class VegaFusionRuntime:
                         group = get_mark_group_for_scope(new_spec, scope)
                         for data in group.get("data", []):
                             if data.get("name", None) == name:
-                                data["values"] = tbl
+                                if data_encoding_format == "arrow-ipc-url":
+                                    data["url"] = tbl
+                                else:
+                                    data["values"] = tbl
 
             finally:
                 # Clean up temporary tables

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -369,6 +369,9 @@ impl PyVegaFusionRuntime {
                             PyBytes::new(py, table.to_ipc_bytes()?.as_slice()).to_object(py)
                         }
                         "arrow-ipc-base64" => table.to_ipc_base64()?.into_py(py),
+                        "arrow-ipc-url" => format!(
+                            "data:application/vnd.apache.arrow.file;base64,{}", table.to_ipc_base64()?
+                        ).into_py(py),
                         _ => {
                             return Err(PyValueError::new_err(format!(
                                 "Invalid extracted_format: {}",

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -360,6 +360,7 @@ impl PyVegaFusionRuntime {
             let datasets = datasets
                 .into_iter()
                 .map(|(name, scope, table)| {
+                    let table = table.to_js_types()?;
                     let name = name.into_py(py);
                     let scope = scope.into_py(py);
                     let table = match extracted_format.as_str() {


### PR DESCRIPTION
The apache-arrow JavaScript library will extract Int64 values as bigint, which aren't compatible with Vega. This PR casts all numeric types to Float64 when data_encoding_format is set. 

Even with the type conversion from integer to float, there are some issues with using Arrow tables directly in the Vega JavaScript library. See https://github.com/vega/vl-convert/pull/119.  So I'm not sure I want to move forward with this PR right now.