### PR TITLE
Add fuse_datasets planner configuration for combining datasets during planning

### DIFF
--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -176,6 +176,52 @@ class VegaFusionRuntime:
 
         return imported_inline_datasets
 
+    def build_pre_transform_spec_plan(
+            self,
+            spec,
+            preserve_interactivity=True,
+            keep_signals=None,
+            keep_datasets=None,
+    ):
+        """
+        Diagnostic function that returns the plan used by the pre_transform_spec method
+
+        :param spec: A Vega specification dict or JSON string
+        :param preserve_interactivity: If True (default) then the interactive behavior of
+            the chart will pre preserved. This requires that all the data that participates
+            in interactions be included in the resulting spec rather than being pre-transformed.
+            If False, then all possible data transformations are applied even if they break
+            the original interactive behavior of the chart.
+        :param keep_signals: Signals from the input spec that must be included in the
+            pre-transformed spec. A list with elements that are either:
+              - The name of a top-level signal as a string
+              - A two-element tuple where the first element is the name of a signal as a string
+                and the second element is the nested scope of the dataset as a list of integers
+        :param keep_datasets: Datasets from the input spec that must be included in the
+            pre-transformed spec. A list with elements that are either:
+              - The name of a top-level dataset as a string
+              - A two-element tuple where the first element is the name of a dataset as a string
+                and the second element is the nested scope of the dataset as a list of integers
+        :return:
+            dict with keys:
+                - "client_spec": Planned client spec
+                - "server_spec: Planned server spec
+                - "comm_plan": Communication plan
+                - "warnings": List of planner warnings
+        """
+        if self._grpc_channel:
+            raise ValueError("build_pre_transform_spec_plan not yet supported over gRPC")
+        else:
+            # Parse input keep signals and datasets
+            keep_signals = parse_variables(keep_signals)
+            keep_datasets = parse_variables(keep_datasets)
+            return self.embedded_runtime.build_pre_transform_spec_plan(
+                spec,
+                preserve_interactivity=preserve_interactivity,
+                keep_signals=keep_signals,
+                keep_datasets=keep_datasets,
+            )
+
     def pre_transform_spec(
         self,
         spec,

--- a/vegafusion-core/src/planning/fuse.rs
+++ b/vegafusion-core/src/planning/fuse.rs
@@ -1,0 +1,386 @@
+use crate::planning::dependency_graph::{build_dependency_graph, toposort_dependency_graph};
+use crate::proto::gen::tasks::VariableNamespace;
+use crate::spec::chart::ChartSpec;
+use crate::task_graph::graph::ScopedVariable;
+use petgraph::prelude::{EdgeRef, NodeIndex};
+use petgraph::Direction;
+use vegafusion_common::error::Result;
+
+/// Optimize the server_spec by fusing datasets.
+/// Currently, this function fuses parent datasets into their children when the parent dataset
+/// does not include an aggregation or has exactly one child. This has the effect of pushing
+/// transforms up through at least the first aggregation into the root dataset's transform
+/// pipeline.
+pub fn fuse_datasets(server_spec: &mut ChartSpec, do_not_fuse: &[ScopedVariable]) -> Result<()> {
+    let data_graph = build_dependency_graph(server_spec, &Default::default())?;
+    let nodes: Vec<NodeIndex> = toposort_dependency_graph(&data_graph)?;
+
+    'outer: for node_index in &nodes {
+        let (parent_var, _) = data_graph.node_weight(*node_index).unwrap();
+        let Ok(parent_dataset) = server_spec.get_nested_data(&parent_var.1, &parent_var.0.name).cloned() else { continue };
+
+        // Don't push down datasets that are required by client
+        if do_not_fuse.contains(parent_var) {
+            continue;
+        }
+
+        // Extract child variables
+        let edges = data_graph.edges_directed(*node_index, Direction::Outgoing);
+        let child_vars = edges
+            .into_iter()
+            .map(|edge| {
+                let target_index = edge.target();
+                let (child_var, _) = data_graph.node_weight(target_index).unwrap();
+                child_var
+            })
+            .collect::<Vec<_>>();
+
+        if child_vars.is_empty() {
+            continue;
+        }
+
+        // Don't fuse down datasets with aggregate transforms and multiple children
+        if parent_dataset.has_aggregate() && child_vars.len() > 1 {
+            continue;
+        }
+
+        // Make sure all children are datasets
+        let all_children_data = child_vars
+            .iter()
+            .all(|v| v.0.ns() == VariableNamespace::Data);
+        if !all_children_data {
+            continue;
+        }
+
+        // Make sure all children have this named dataset as source
+        // (it's possible for a dataset's transform pipeline to reference this dataset, in which
+        // case we can't fuse.)
+        for child_var in &child_vars {
+            let Ok(child_dataset) = server_spec.get_nested_data(&child_var.1, &child_var.0.name) else { continue 'outer};
+            if child_dataset.source.as_ref() != Some(&parent_dataset.name) {
+                continue 'outer;
+            }
+        }
+
+        // Extract child datasets
+        for child_var in &child_vars {
+            let Ok(child_dataset) = server_spec.get_nested_data_mut(&child_var.1, &child_var.0.name) else { continue 'outer};
+            parent_dataset.fuse_into(child_dataset)?;
+        }
+
+        // Convert parent dataset into a stub
+        let Ok(parent_dataset) = server_spec.get_nested_data_mut(&parent_var.1, &parent_var.0.name) else { continue };
+        parent_dataset.transform = Default::default();
+        parent_dataset.source = Default::default();
+        parent_dataset.values = Default::default();
+        parent_dataset.url = Default::default();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::planning::fuse::fuse_datasets;
+    use crate::proto::gen::tasks::Variable;
+    use crate::spec::chart::ChartSpec;
+    use serde_json::json;
+
+    #[test]
+    fn test_simple_fuse() {
+        let chart: ChartSpec = serde_json::from_value(json!(
+            {
+                "data": [
+                    {
+                        "name": "data_0",
+                        "url": "path/to/data.json",
+                        "transform": [
+                            {
+                                "type": "filter",
+                                "expr": "datum.A > 0"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_1",
+                        "source": "data_0",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.A * 2",
+                                "as": "B"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_2",
+                        "source": "data_0",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.A * 3",
+                                "as": "C"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_3",
+                        "source": "data_1",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.A * 4",
+                                "as": "C"
+                            }
+                        ]
+                    },
+                ]
+            }
+        ))
+        .unwrap();
+
+        // try fuse
+        let mut new_chart = chart.clone();
+        fuse_datasets(
+            &mut new_chart,
+            &[
+                (Variable::new_data("data_2"), vec![]),
+                (Variable::new_data("data_3"), vec![]),
+            ],
+        )
+        .unwrap();
+        let pretty_output = serde_json::to_string_pretty(&new_chart).unwrap();
+        println!("{}", pretty_output);
+        assert_eq!(
+            pretty_output,
+            r#"{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "data": [
+    {
+      "name": "data_0"
+    },
+    {
+      "name": "data_1"
+    },
+    {
+      "name": "data_2",
+      "url": "path/to/data.json",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.A > 0"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.A * 3",
+          "as": "C"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "url": "path/to/data.json",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.A > 0"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.A * 2",
+          "as": "B"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.A * 4",
+          "as": "C"
+        }
+      ]
+    }
+  ]
+}"#
+        );
+        // Check that fuse is prevented if parent dataset is needed by client
+        let mut new_chart = chart.clone();
+        fuse_datasets(&mut new_chart, &[(Variable::new_data("data_0"), vec![])]).unwrap();
+        let pretty_output = serde_json::to_string_pretty(&new_chart).unwrap();
+        println!("{}", pretty_output);
+        assert_eq!(
+            pretty_output,
+            r#"{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "data": [
+    {
+      "name": "data_0",
+      "url": "path/to/data.json",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.A > 0"
+        }
+      ]
+    },
+    {
+      "name": "data_1"
+    },
+    {
+      "name": "data_2",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum.A * 3",
+          "as": "C"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum.A * 2",
+          "as": "B"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.A * 4",
+          "as": "C"
+        }
+      ]
+    }
+  ]
+}"#
+        );
+    }
+
+    #[test]
+    fn test_simple_fuse_with_aggregate() {
+        let chart: ChartSpec = serde_json::from_value(json!(
+            {
+                "data": [
+                    {
+                        "name": "data_0",
+                        "url": "path/to/data.json",
+                        "transform": [
+                            {
+                                "type": "filter",
+                                "expr": "datum.A > 0"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_1",
+                        "source": "data_0",
+                        "transform": [
+                            {
+                                "type": "aggregate",
+                                "fields": ["foo", "bar", "baz"],
+                                "ops": ["valid", "sum", "median"],
+                                "groupby": []
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_2",
+                        "source": "data_0",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.bar * 3",
+                                "as": "C"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data_3",
+                        "source": "data_1",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.A * 4",
+                                "as": "C"
+                            }
+                        ]
+                    },
+                ]
+            }
+        ))
+        .unwrap();
+
+        // try fuse
+        let mut new_chart = chart.clone();
+        fuse_datasets(
+            &mut new_chart,
+            &[
+                (Variable::new_data("data_2"), vec![]),
+                (Variable::new_data("data_3"), vec![]),
+            ],
+        )
+        .unwrap();
+        let pretty_output = serde_json::to_string_pretty(&new_chart).unwrap();
+        println!("{}", pretty_output);
+        assert_eq!(
+            pretty_output,
+            r#"{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "data": [
+    {
+      "name": "data_0"
+    },
+    {
+      "name": "data_1",
+      "url": "path/to/data.json",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.A > 0"
+        },
+        {
+          "type": "aggregate",
+          "groupby": [],
+          "fields": [
+            "foo",
+            "bar",
+            "baz"
+          ],
+          "ops": [
+            "valid",
+            "sum",
+            "median"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "url": "path/to/data.json",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.A > 0"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.bar * 3",
+          "as": "C"
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum.A * 4",
+          "as": "C"
+        }
+      ]
+    }
+  ]
+}"#
+        );
+    }
+}

--- a/vegafusion-core/src/planning/fuse.rs
+++ b/vegafusion-core/src/planning/fuse.rs
@@ -304,6 +304,17 @@ mod tests {
                             }
                         ]
                     },
+                    {
+                        "name": "data_4",
+                        "source": "data_1",
+                        "transform": [
+                            {
+                                "type": "formula",
+                                "expr": "datum.A * 5",
+                                "as": "D"
+                            }
+                        ]
+                    },
                 ]
             }
         ))
@@ -376,6 +387,17 @@ mod tests {
           "type": "formula",
           "expr": "datum.A * 4",
           "as": "C"
+        }
+      ]
+    },
+    {
+      "name": "data_4",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "datum.A * 5",
+          "as": "D"
         }
       ]
     }

--- a/vegafusion-core/src/planning/mod.rs
+++ b/vegafusion-core/src/planning/mod.rs
@@ -1,5 +1,6 @@
 pub mod dependency_graph;
 pub mod extract;
+pub mod fuse;
 pub mod optimize_server;
 pub mod plan;
 pub mod projection_pushdown;

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -498,6 +498,7 @@ impl VegaFusionRuntime {
                 split_domain_data: false,
                 projection_pushdown: false,
                 allow_client_to_server_comms: true,
+                keep_variables: Vec::from(variables),
                 ..Default::default()
             },
         )?;
@@ -752,13 +753,7 @@ impl VegaFusionRuntime {
         // Create spec plan
         let plan = SpecPlan::try_new(
             spec,
-            &PlannerConfig {
-                stringify_local_datetimes: true,
-                extract_inline_data: true,
-                allow_client_to_server_comms: !preserve_interactivity,
-                keep_variables,
-                ..Default::default()
-            },
+            &PlannerConfig::pre_transformed_spec_config(preserve_interactivity, keep_variables),
         )?;
         // println!("pre transform client_spec: {}", serde_json::to_string_pretty(&plan.client_spec).unwrap());
         // println!("pre transform server_spec: {}", serde_json::to_string_pretty(&plan.server_spec).unwrap());

--- a/vegafusion-runtime/tests/test_projection_pushdown.rs
+++ b/vegafusion-runtime/tests/test_projection_pushdown.rs
@@ -35,6 +35,7 @@ mod test_custom_specs {
 
         let planner_config = PlannerConfig {
             projection_pushdown: true,
+            fuse_datasets: false,
             ..Default::default()
         };
         let spec_plan = SpecPlan::try_new(&spec, &planner_config).unwrap();


### PR DESCRIPTION
This PR updates the planner to combine (fuse) parent datasets into their children in certain situations.

The motivation here is to ensure that the root datasets in the server spec have more of the transform pipeline than previously.

A simple motivating example is that Vega-Lite can sometimes generate Vega specs where the root dataset has no transforms and then a child dataset has a series of transforms. For example:

```json
  "data": [
    {"name": "source_0", "url": "vegafusion+dataset://source"},
    {
      "name": "data_0",
      "source": "source_0",
      "transform": [
        {
          "type": "aggregate",
          "groupby": ["A"],
          "ops": ["average"],
          "fields": ["B"],
        }
      ]
    },
  ]
```

Without these changes to the planner, VegaFusion will pull the entire `source_0` dataset into the runtime's cache. Then the `data_0` transforms are applied to the cached version of `source_0`.  This breaks down when `source_0` is larger than memory (e.g. it's a snowflake table). In this case, it's much better to perform the aggregation before caching the result.  This PR will convert the example above into:

```json
  "data": [
    {"name": "source_0"},
    {
      "name": "data_0",
      "url": "vegafusion+dataset://source"
      "transform": [
        {
          "type": "aggregate",
          "groupby": ["A"],
          "ops": ["average"],
          "fields": ["B"],
        }
      ]
    },
  ]
```

The `data_0` dataset now loads the source data and applies the aggregation immediately.  This will work with larger-than-memory data (as long as the aggregated result fits in memory).

The current heuristic is to fuse everything up to and including datasets that have an `aggregate` transform.  The rationale is that aggregate results are usually smaller that source data and will be reasonable to cache. This is an area that could be made more sophisticated in the future, but it should help a lot in the majority of cases.

To make it possible to inspect the planner solution in Python, this PR adds a `vf.runtime.build_pre_transform_spec_plan(vega_spec)` method that returns the plan as a Python dict.
