### PR TITLE
Fix cast timestamp to integer millisecond and add stack timestamp tests

### DIFF
--- a/vegafusion-common/src/datatypes.rs
+++ b/vegafusion-common/src/datatypes.rs
@@ -85,9 +85,12 @@ pub fn to_numeric(value: Expr, schema: &DFSchema) -> Result<Expr> {
         value
     } else if matches!(dtype, DataType::Timestamp(_, _)) {
         // Convert to milliseconds
-        Expr::ScalarFunction(expr::ScalarFunction {
-            fun: BuiltinScalarFunction::ToTimestampMillis,
-            args: vec![value],
+        Expr::TryCast(TryCast {
+            expr: Box::new(Expr::ScalarFunction(expr::ScalarFunction {
+                fun: BuiltinScalarFunction::ToTimestampMillis,
+                args: vec![value],
+            })),
+            data_type: DataType::Int64,
         })
     } else {
         // Cast non-numeric types (like UTF-8) to Float64

--- a/vegafusion-sql/src/dataframe/mod.rs
+++ b/vegafusion-sql/src/dataframe/mod.rs
@@ -1401,6 +1401,11 @@ fn make_new_schema_from_exprs(
         } else {
             // Add field for expression
             let schema_df = DFSchema::try_from(schema.clone())?;
+            println!(
+                "Expr: {:?}\n{:?}",
+                expr.to_sql_select(dialect, &schema_df).unwrap().to_string(),
+                schema_df
+            );
             let dtype = expr.get_type(&schema_df)?;
             let name = expr.display_name()?;
             fields.push(Field::new(name, dtype, true));


### PR DESCRIPTION
Fix error when using the stack transform on a timestamp column. We were failing to properly convert the column to integer milliseconds before stacking.