### PR TITLE
Support format function with empty format string, make sum of nulls evaluate to zero

### DIFF
--- a/vegafusion-core/src/expression/supported.rs
+++ b/vegafusion-core/src/expression/supported.rs
@@ -51,7 +51,7 @@ lazy_static! {
         // Datetime
         "year", "quarter", "month", "day", "date", "dayofyear", "hours", "minutes", "seconds", "milliseconds",
         "utcyear", "utcquarter", "utcmonth", "utcday", "utcdate", "utcdayofyear",
-        "utchours", "utcminutes", "utcseconds", "utcmilliseconds", "datetime", "utc", "time", "timeFormat", "utcFormat",
+        "utchours", "utcminutes", "utcseconds", "utcmilliseconds", "datetime", "utc", "time", "format", "timeFormat", "utcFormat",
 
         // Conversion
         "toBoolean", "toDate", "toNumber", "toString",

--- a/vegafusion-core/src/expression/visitors.rs
+++ b/vegafusion-core/src/expression/visitors.rs
@@ -203,6 +203,21 @@ impl ExpressionVisitor for CheckSupportedExprVisitor {
             if !(args.len() == 2 && matches!(args[0].expr, Some(Expr::Array(_)))) {
                 self.supported = false;
             }
+        } else if node.name == "format" {
+            // We only support format with an empty string as second argument
+            if args.len() != 2 {
+                self.supported = false;
+            } else if let Some(Expr::Literal(Literal {
+                value: Some(Value::String(v)),
+                ..
+            })) = &args[1].expr
+            {
+                if v != "" {
+                    self.supported = false;
+                }
+            } else {
+                self.supported = false;
+            }
         }
     }
 

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/format.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/format.rs
@@ -1,0 +1,46 @@
+use datafusion_common::ScalarValue;
+use datafusion_expr::{binary_expr, lit, when, Expr, ExprSchemable, Operator};
+use vegafusion_common::arrow::datatypes::DataType;
+use vegafusion_common::datafusion_common::DFSchema;
+use vegafusion_common::datatypes::{cast_to, is_integer_datatype, to_numeric};
+
+use vegafusion_core::error::{Result, VegaFusionError};
+
+/// `format(value, specifier)`
+///
+/// Formats a numeric value as a string. The specifier must be a valid d3-format specifier
+/// (e.g., format(value, ',.2f').
+///
+/// Note: Current implementation only supports empty string as specifier
+///
+/// See: https://vega.github.io/vega/docs/expressions/#format
+pub fn format_transform(args: &[Expr], schema: &DFSchema) -> Result<Expr> {
+    if args.len() == 2 {
+        match &args[1] {
+            Expr::Literal(ScalarValue::Utf8(Some(s))) if s == "" => {
+                let arg = to_numeric(args[0].clone(), schema)?;
+                if is_integer_datatype(&arg.get_type(schema)?) {
+                    // Integer type, just cast to string
+                    cast_to(args[0].clone(), &DataType::Utf8, schema)
+                } else {
+                    // Float type, need CASE statement so that integer values don't get decimal points
+                    Ok(when(
+                        binary_expr(arg.clone(), Operator::Modulo, lit(1.0)).eq(lit(0.0)),
+                        cast_to(cast_to(arg, &DataType::Int64, schema)?, &DataType::Utf8, schema)?
+                    ).otherwise(
+                        cast_to(args[0].clone(), &DataType::Utf8, schema)?
+                    )?)
+                }
+            }
+            _ => Err(VegaFusionError::parse(format!(
+                "format function only supported with empty string as second argument. Reveived {:?}",
+                args[1]
+            )))
+        }
+    } else {
+        Err(VegaFusionError::parse(format!(
+            "format function requires two arguments. Received {} arguments",
+            args.len()
+        )))
+    }
+}

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/mod.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/mod.rs
@@ -1,6 +1,7 @@
 pub mod control_flow;
 pub mod data;
 pub mod date_time;
+pub mod format;
 pub mod math;
 pub mod type_checking;
 pub mod type_coercion;

--- a/vegafusion-runtime/src/expression/compiler/call.rs
+++ b/vegafusion-runtime/src/expression/compiler/call.rs
@@ -38,6 +38,7 @@ use crate::expression::compiler::builtin_functions::date_time::date_parts::{
     UTCYEAR_TRANSFORM, YEAR_TRANSFORM,
 };
 use crate::expression::compiler::builtin_functions::date_time::time::time_fn;
+use crate::expression::compiler::builtin_functions::format::format_transform;
 use crate::expression::compiler::builtin_functions::math::isfinite::is_finite_fn;
 use crate::expression::compiler::builtin_functions::type_checking::isdate::is_date_fn;
 use crate::expression::compiler::builtin_functions::type_coercion::to_boolean::to_boolean_transform;
@@ -385,6 +386,12 @@ pub fn default_callables() -> HashMap<String, VegaFusionCallable> {
     callables.insert(
         "utcFormat".to_string(),
         VegaFusionCallable::LocalTransform(Arc::new(utc_format_fn)),
+    );
+
+    // format
+    callables.insert(
+        "format".to_string(),
+        VegaFusionCallable::Transform(Arc::new(format_transform)),
     );
 
     // coercion

--- a/vegafusion-runtime/src/transform/aggregate.rs
+++ b/vegafusion-runtime/src/transform/aggregate.rs
@@ -1,9 +1,7 @@
 use crate::expression::compiler::config::CompilationConfig;
 use crate::transform::TransformTrait;
 
-use datafusion_expr::{
-    avg, count, count_distinct, lit, max, min, sum, BuiltinScalarFunction, Expr,
-};
+use datafusion_expr::{avg, count, count_distinct, lit, max, min, sum, BuiltinScalarFunction, Expr, ExprSchemable};
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -12,7 +10,7 @@ use std::sync::Arc;
 use vegafusion_common::column::{flat_col, unescaped_col};
 use vegafusion_common::data::ORDER_COL;
 use vegafusion_common::datafusion_common::{DFSchema, ScalarValue};
-use vegafusion_common::datatypes::to_numeric;
+use vegafusion_common::datatypes::{cast_to, to_numeric};
 use vegafusion_common::error::ResultWithContext;
 use vegafusion_common::escape::unescape_field;
 use vegafusion_core::arrow::datatypes::DataType;
@@ -162,10 +160,15 @@ pub fn make_agg_expr_for_col_expr(
         AggregateOp::Mean | AggregateOp::Average => avg(numeric_column()?),
         AggregateOp::Min => min(column),
         AggregateOp::Max => max(column),
-        AggregateOp::Sum => Expr::ScalarFunction(expr::ScalarFunction {
-            fun: BuiltinScalarFunction::Coalesce,
-            args: vec![sum(numeric_column()?), lit(0.0)],
-        }),
+        AggregateOp::Sum => {
+            let numeric_col = numeric_column()?;
+            let dtype = numeric_col.get_type(schema)?;
+            let zero = cast_to(lit(0), &dtype, schema)?;
+            Expr::ScalarFunction(expr::ScalarFunction {
+                fun: BuiltinScalarFunction::Coalesce,
+                args: vec![sum(numeric_col), zero],
+            })
+        },
         AggregateOp::Median => Expr::AggregateFunction(expr::AggregateFunction {
             fun: aggregate_function::AggregateFunction::Median,
             distinct: false,

--- a/vegafusion-runtime/src/transform/aggregate.rs
+++ b/vegafusion-runtime/src/transform/aggregate.rs
@@ -1,7 +1,9 @@
 use crate::expression::compiler::config::CompilationConfig;
 use crate::transform::TransformTrait;
 
-use datafusion_expr::{avg, count, count_distinct, lit, max, min, sum, BuiltinScalarFunction, Expr, ExprSchemable};
+use datafusion_expr::{
+    avg, count, count_distinct, lit, max, min, sum, BuiltinScalarFunction, Expr, ExprSchemable,
+};
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -168,7 +170,7 @@ pub fn make_agg_expr_for_col_expr(
                 fun: BuiltinScalarFunction::Coalesce,
                 args: vec![sum(numeric_col), zero],
             })
-        },
+        }
         AggregateOp::Median => Expr::AggregateFunction(expr::AggregateFunction {
             fun: aggregate_function::AggregateFunction::Median,
             distinct: false,

--- a/vegafusion-runtime/src/transform/aggregate.rs
+++ b/vegafusion-runtime/src/transform/aggregate.rs
@@ -1,7 +1,9 @@
 use crate::expression::compiler::config::CompilationConfig;
 use crate::transform::TransformTrait;
 
-use datafusion_expr::{avg, count, count_distinct, lit, max, min, sum, Expr};
+use datafusion_expr::{
+    avg, count, count_distinct, lit, max, min, sum, BuiltinScalarFunction, Expr,
+};
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -160,7 +162,10 @@ pub fn make_agg_expr_for_col_expr(
         AggregateOp::Mean | AggregateOp::Average => avg(numeric_column()?),
         AggregateOp::Min => min(column),
         AggregateOp::Max => max(column),
-        AggregateOp::Sum => sum(numeric_column()?),
+        AggregateOp::Sum => Expr::ScalarFunction(expr::ScalarFunction {
+            fun: BuiltinScalarFunction::Coalesce,
+            args: vec![sum(numeric_column()?), lit(0.0)],
+        }),
         AggregateOp::Median => Expr::AggregateFunction(expr::AggregateFunction {
             fun: aggregate_function::AggregateFunction::Median,
             distinct: false,

--- a/vegafusion-runtime/tests/specs/custom/binned_ordinal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/binned_ordinal.comm_plan.json
@@ -1,0 +1,20 @@
+{
+  "server_to_client": [
+    {
+      "name": "data_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_0_x_domain_bin_maxbins_10_doy_range",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_0_y_domain_sum_value",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/binned_ordinal.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/binned_ordinal.vg.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "height": 10,
+  "style": "cell",
+  "data": [
+    {
+      "name": "data-80fc413b53d2d970f0f81ba51c6f3334",
+      "values": [
+        {"doy": 45, "variable": "doy_threshold_2011", "value": 16165},
+        {"doy": 46, "variable": "doy_threshold_2011", "value": 1922},
+        {"doy": 47, "variable": "doy_threshold_2011", "value": null},
+        {"doy": 48, "variable": "doy_threshold_2011", "value": null},
+        {"doy": 49, "variable": "doy_threshold_2011", "value": 65604},
+        {"doy": 50, "variable": "doy_threshold_2011", "value": null},
+        {"doy": 51, "variable": "doy_threshold_2011", "value": null},
+        {"doy": 52, "variable": "doy_threshold_2011", "value": 27549},
+        {"doy": 53, "variable": "doy_threshold_2011", "value": 294663},
+        {"doy": 54, "variable": "doy_threshold_2011", "value": 290251},
+        {"doy": 55, "variable": "doy_threshold_2011", "value": 10},
+        {"doy": 56, "variable": "doy_threshold_2011", "value": 394929},
+        {"doy": 57, "variable": "doy_threshold_2011", "value": 20165},
+        {"doy": 58, "variable": "doy_threshold_2011", "value": 117251},
+        {"doy": 59, "variable": "doy_threshold_2011", "value": 52055},
+        {"doy": 60, "variable": "doy_threshold_2011", "value": 76243},
+        {"doy": 61, "variable": "doy_threshold_2011", "value": 147},
+        {"doy": 62, "variable": "doy_threshold_2011", "value": 96486},
+        {"doy": 63, "variable": "doy_threshold_2011", "value": 79729},
+        {"doy": 64, "variable": "doy_threshold_2011", "value": 16243}
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "data-80fc413b53d2d970f0f81ba51c6f3334",
+      "transform": [
+        {
+          "type": "extent",
+          "field": "doy",
+          "signal": "bin_maxbins_10_doy_extent"
+        },
+        {
+          "type": "bin",
+          "field": "doy",
+          "as": ["bin_maxbins_10_doy", "bin_maxbins_10_doy_end"],
+          "signal": "bin_maxbins_10_doy_bins",
+          "extent": {"signal": "bin_maxbins_10_doy_extent"},
+          "maxbins": 10
+        },
+        {
+          "type": "formula",
+          "expr": "!isValid(datum[\"bin_maxbins_10_doy\"]) || !isFinite(+datum[\"bin_maxbins_10_doy\"]) ? \"null\" : format(datum[\"bin_maxbins_10_doy\"], \"\") + \" – \" + format(datum[\"bin_maxbins_10_doy_end\"], \"\")",
+          "as": "bin_maxbins_10_doy_range"
+        },
+        {
+          "type": "aggregate",
+          "groupby": [
+            "bin_maxbins_10_doy",
+            "bin_maxbins_10_doy_end",
+            "bin_maxbins_10_doy_range"
+          ],
+          "ops": ["sum"],
+          "fields": ["value"],
+          "as": ["sum_value"]
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 1, 0.5) * x_step"
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "area",
+      "style": ["area"],
+      "sort": {"field": "datum[\"bin_maxbins_10_doy\"]"},
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "interpolate": {"value": "monotone"},
+          "orient": {"value": "vertical"},
+          "fill": {"value": "#4c78a8"},
+          "description": {
+            "signal": "\"doy (binned): \" + (!isValid(datum[\"bin_maxbins_10_doy\"]) || !isFinite(+datum[\"bin_maxbins_10_doy\"]) ? \"null\" : format(datum[\"bin_maxbins_10_doy\"], \"\") + \" – \" + format(datum[\"bin_maxbins_10_doy_end\"], \"\")) + \"; Sum of value: \" + (format(datum[\"sum_value\"], \"\"))"
+          },
+          "x": {"scale": "x", "field": "bin_maxbins_10_doy_range"},
+          "y": {"scale": "y", "field": "sum_value"},
+          "y2": {"scale": "y", "value": 0},
+          "defined": {
+            "signal": "isValid(datum[\"sum_value\"]) && isFinite(+datum[\"sum_value\"])"
+          }
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "point",
+      "domain": {
+        "data": "data_0",
+        "field": "bin_maxbins_10_doy_range",
+        "sort": {"field": "bin_maxbins_10_doy", "op": "min"}
+      },
+      "range": {"step": {"signal": "x_step"}},
+      "padding": 0.5
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_0", "field": "sum_value"},
+      "range": [10, -10],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "doy (binned)",
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle",
+      "zindex": 0
+    }
+  ],
+  "config": {"style": {"cell": {"stroke": null}}}
+}

--- a/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_x_domain_bin_maxbins_10_IMDB",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_y_domain___count",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal.comm_plan.json
@@ -7,7 +7,7 @@
     },
     {
       "namespace": "data",
-      "name": "source_0_x_domain_bin_maxbins_10_IMDB",
+      "name": "source_0_x_domain_bin_maxbins_10_IMDB Rating_range",
       "scope": []
     },
     {

--- a/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
@@ -2,7 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "_server_source_0",
+      "name": "source_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_x_domain_bin_maxbins_10_IMDB",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "source_0_y_domain___count",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
@@ -2,17 +2,17 @@
   "server_to_client": [
     {
       "namespace": "data",
-      "name": "source_0",
+      "name": "data_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_0_y_domain___count",
       "scope": []
     },
     {
       "namespace": "data",
       "name": "source_0_x_domain_bin_maxbins_10_IMDB",
-      "scope": []
-    },
-    {
-      "namespace": "data",
-      "name": "source_0_y_domain___count",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/vegalite/histogram_ordinal_sort.comm_plan.json
@@ -12,7 +12,7 @@
     },
     {
       "namespace": "data",
-      "name": "source_0_x_domain_bin_maxbins_10_IMDB",
+      "name": "source_0_x_domain_bin_maxbins_10_IMDB Rating_range",
       "scope": []
     }
   ],

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -143,7 +143,8 @@ mod test_custom_specs {
         case("custom/gh_383", 0.001, true),
         case("custom/gh_391", 0.001, true),
         case("custom/facet_grouped_bar_with_error_bars", 0.001, true),
-        case("custom/facet_grouped_bar_with_error_bars_with_sort", 0.001, true)
+        case("custom/facet_grouped_bar_with_error_bars_with_sort", 0.001, true),
+        case("custom/binned_ordinal", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");

--- a/vegafusion-runtime/tests/test_transform_aggregate.rs
+++ b/vegafusion-runtime/tests/test_transform_aggregate.rs
@@ -325,3 +325,63 @@ mod test_aggregate_strings {
         );
     }
 }
+
+mod test_aggregate_nulls {
+    use crate::*;
+    use serde_json::json;
+    use vegafusion_common::data::table::VegaFusionTable;
+
+    #[rstest(
+        op,
+        case(AggregateOpSpec::Count),
+        case(AggregateOpSpec::Valid),
+        case(AggregateOpSpec::Missing),
+        case(AggregateOpSpec::Distinct),
+        case(AggregateOpSpec::Sum),
+        case(AggregateOpSpec::Mean),
+        case(AggregateOpSpec::Average),
+        case(AggregateOpSpec::Min),
+        case(AggregateOpSpec::Max),
+        case(AggregateOpSpec::Median),
+        case(AggregateOpSpec::Q1),
+        case(AggregateOpSpec::Q3)
+    )]
+    fn test(op: AggregateOpSpec) {
+        let dataset = VegaFusionTable::from_json(&json!(
+            [
+                {"a": 1, "b": 1.0},
+                {"a": 1, "b": null},
+                {"a": 2, "b": null},
+                {"a": 2, "b": null},
+                {"a": 2, "b": null}
+            ]
+        ))
+        .unwrap();
+
+        let aggregate_spec = AggregateTransformSpec {
+            groupby: vec![Field::String("a".to_string())],
+            fields: Some(vec![Some(Field::String("b".to_string()))]),
+            ops: Some(vec![op]),
+            as_: None,
+            cross: None,
+            drop: None,
+            key: None,
+            extra: Default::default(),
+        };
+        let transform_specs = vec![TransformSpec::Aggregate(aggregate_spec)];
+
+        let comp_config = Default::default();
+
+        let eq_config = TablesEqualConfig {
+            row_order: true,
+            ..Default::default()
+        };
+
+        check_transform_evaluation(
+            &dataset,
+            transform_specs.as_slice(),
+            &comp_config,
+            &eq_config,
+        );
+    }
+}

--- a/vegafusion-sql/src/dataframe/mod.rs
+++ b/vegafusion-sql/src/dataframe/mod.rs
@@ -1401,11 +1401,6 @@ fn make_new_schema_from_exprs(
         } else {
             // Add field for expression
             let schema_df = DFSchema::try_from(schema.clone())?;
-            println!(
-                "Expr: {:?}\n{:?}",
-                expr.to_sql_select(dialect, &schema_df).unwrap().to_string(),
-                schema_df
-            );
             let dtype = expr.get_type(&schema_df)?;
             let name = expr.display_name()?;
             fields.push(Field::new(name, dtype, true));


### PR DESCRIPTION
Closes #409 

Adds support for the `format` function when the format string argument is the empty string. In this case, numbers are converted to strings such that integer values in float columns are formatted without a decimal point.

While making a test case from the example in #409, I happened upon an unrelated issue. In the Vega aggregate/joinaggregate transforms, the `sum` aggregation returns zero if it inputs all null values. In SQL it returns null. I added a `coalesce` to replace these nulls with zeros.