### PR TITLE
Experimental s3 and parquet support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,8 +3,29 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 jobs:
+  check-rust:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Check fmt
+        run: pixi run check-rs-fmt
+      - name: Check warnings
+        run: pixi run check-rs-warnings
+      - name: Check clippy
+        run: pixi run check-rs-clippy
 
-  try-it-1:
+  test-rust:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,572 +45,463 @@ jobs:
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: start minio server
-        run: pixi run start-minio
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: start minio server in the background
+        run: pixi run start-minio &
+      - name: Test rust
+        run: |
+          pixi run test-rs --release
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        if: always()
+        with:
+          name: vegafusion-rt-test-images
+          path: |
+            vegafusion-runtime/tests/output
 
-  try-it-2:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-20.04
-          - windows-2022
-          - macos-11
+  build-vegafusion-wasm:
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
       - name: Install pixi (linux / osx)
-        if: ${{ runner.os != 'Windows' }}
         run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Install pixi (windows)
-        if: ${{ runner.os == 'Windows' }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build package
+        run: |
+          pixi run pack-wasm
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-wasm-packages
+          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
+
+  # Use maturin action to build linux wheels within proper manylinux compatible containers
+  # (This is why we don't use the pixi "build-py-embed" action)
+  build-vegafusion-python-embed-linux-64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels (Linux)
+        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Build arm64 wheels
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-win-64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: start minio server
-        run: pixi run minio server minio_data
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-python-embed
+        run: |
+          pixi run build-py-embed
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
 
-#  check-rust:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Check fmt
-#        run: pixi run check-rs-fmt
-#      - name: Check warnings
-#        run: pixi run check-rs-warnings
-#      - name: Check clippy
-#        run: pixi run check-rs-clippy
-#
-#  test-rust:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os:
-#          - ubuntu-20.04
-#          - windows-2022
-#          - macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        if: ${{ runner.os != 'Windows' }}
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Install pixi (windows)
-#        if: ${{ runner.os == 'Windows' }}
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: start minio server in the background
-#        run: pixi run start-minio &
-#      - name: Test rust
-#        run: |
-#          pixi run test-rs --release
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        if: always()
-#        with:
-#          name: vegafusion-rt-test-images
-#          path: |
-#            vegafusion-runtime/tests/output
-#
-#  build-vegafusion-wasm:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build package
-#        run: |
-#          pixi run pack-wasm
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-wasm-packages
-#          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
-#
-#  # Use maturin action to build linux wheels within proper manylinux compatible containers
-#  # (This is why we don't use the pixi "build-py-embed" action)
-#  build-vegafusion-python-embed-linux-64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build wheels (Linux)
-#        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-linux-arm64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download arm64 toolchain
-#        run: |
-#          rustup target add aarch64-unknown-linux-gnu
-#      - name: Build arm64 wheels
-#        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-win-64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-python-embed
-#        run: |
-#          pixi run build-py-embed
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-python-embed
-#        run: |
-#          pixi run build-py-embed
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-#          pixi run build-py-embed --target aarch64-apple-darwin
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-packages:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion wheel
-#        run: |
-#          pixi run build-py-vegafusion
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-packages
-#          path: |
-#            python/vegafusion/dist/*.whl
-#            python/vegafusion/dist/*.tar.gz
-#
-#  build-vegafusion-jupyter-packages:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-jupyter wheel
-#        run: |
-#          echo JupyterLab Version: `pixi run jupyter-lab --version`
-#          pixi run build-py-jupyter
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: |
-#            python/vegafusion-jupyter/dist/*.whl
-#            python/vegafusion-jupyter/dist/*.tar.gz
-#
-#  test-vegafusion-python-linux-64:
-#    runs-on: ubuntu-20.04
-#    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.11'
-#      - name: Install fonts on Linux
-#        if: runner.os == 'Linux'
-#        run: |
-#          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-#          sudo apt-get install ttf-mscorefonts-installer
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        run: |
-#          ls -la
-#          python -m pip install vegafusion-*.whl
-#          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-#          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-python-osx-64:
-#    runs-on: macos-11
-#    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.10'
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        run: |
-#          ls -la
-#          python -m pip install vegafusion-*.whl
-#          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-#          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-#
-#          # Downgrade pyarrow to 10.0.1
-#          python -m pip install pyarrow==10.0.1
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-python-win-64:
-#    runs-on: windows-2022
-#    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.8'
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        shell: powershell
-#        run: |
-#          Get-ChildItem -Force
-#          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
-#          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
-#
-#          python -m pip install $vegafusion
-#          python -m pip install $vegafusion_python_embed
-#          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-jupyter-linux-64:
-#    runs-on: ubuntu-20.04
-#    needs:
-#      - build-vegafusion-python-embed-linux-64
-#      - build-vegafusion-packages
-#      - build-vegafusion-jupyter-packages
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi on linux
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
-#          path: |
-#            .pixi
-#      - name: Install Chrome
-#        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
-#        with:
-#          chrome-version: stable
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: Download vegafusion-jupyter wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        run: |
-#          ls -la target/wheels/
-#          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-#          pixi run pip install target/wheels/vegafusion-*.whl
-#          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
-#          pixi run pip install chromedriver-binary-auto
-#          pixi run pip list
-#      - name: Test vegafusion jupyter
-#        run: |
-#          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        if: always()
-#        with:
-#          name: vegafusion-jupyter-test-failures
-#          path: |
-#            python/vegafusion-jupyter/tests/failures/*
-#
-#  build-vegafusion-server-linux-64:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-linux-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-## # Below is an Attempt to cross compile to linux aarch64 within conda environment.
-## # It fails in compiling protobuf-src. So instead we fall back to the direct use of
-## # cargo (without involving conda).
-##
-##  build-vegafusion-server-linux-arm64:
-##    runs-on: ubuntu-20.04
-##    steps:
-##      - name: Check out repository code
-##        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-##      - name: Install pixi
-##        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-##      - name: Cache
-##        uses: actions/cache@v3
-##        with:
-##          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
-##          path: |
-##            ~/.cargo
-##            target
-##            .pixi
-##      - name: Build vegafusion-server
-##        run: |
-##          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
-##          pixi add gcc_linux-aarch64 -p linux-64
-##          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
-##          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
-##      - name: zip executable
-##        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-##        with:
-##          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
-##          dest: vegafusion-server-linux-arm64.zip
-##      - name: Upload artifacts
-##        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-##        with:
-##          name: vegafusion-server
-##          path: |
-##            vegafusion-server-*
-#
+  build-vegafusion-python-embed-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-python-embed
+        run: |
+          pixi run build-py-embed
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+          pixi run build-py-embed --target aarch64-apple-darwin
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-packages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion wheel
+        run: |
+          pixi run build-py-vegafusion
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-packages
+          path: |
+            python/vegafusion/dist/*.whl
+            python/vegafusion/dist/*.tar.gz
+
+  build-vegafusion-jupyter-packages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-jupyter wheel
+        run: |
+          echo JupyterLab Version: `pixi run jupyter-lab --version`
+          pixi run build-py-jupyter
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-jupyter-packages
+          path: |
+            python/vegafusion-jupyter/dist/*.whl
+            python/vegafusion-jupyter/dist/*.tar.gz
+
+  test-vegafusion-python-linux-64:
+    runs-on: ubuntu-20.04
+    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.11'
+      - name: Install fonts on Linux
+        if: runner.os == 'Linux'
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get install ttf-mscorefonts-installer
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        run: |
+          ls -la
+          python -m pip install vegafusion-*.whl
+          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-python-osx-64:
+    runs-on: macos-11
+    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.10'
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        run: |
+          ls -la
+          python -m pip install vegafusion-*.whl
+          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
+          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+          
+          # Downgrade pyarrow to 10.0.1
+          python -m pip install pyarrow==10.0.1
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-python-win-64:
+    runs-on: windows-2022
+    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.8'
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        shell: powershell
+        run: |
+          Get-ChildItem -Force
+          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
+          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
+
+          python -m pip install $vegafusion
+          python -m pip install $vegafusion_python_embed
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-jupyter-linux-64:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-vegafusion-python-embed-linux-64
+      - build-vegafusion-packages
+      - build-vegafusion-jupyter-packages
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi on linux
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
+          path: |
+            .pixi
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
+        with:
+          chrome-version: stable
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: Download vegafusion-jupyter wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-jupyter-packages
+          path: target/wheels/
+      - name: install wheels
+        run: |
+          ls -la target/wheels/
+          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+          pixi run pip install target/wheels/vegafusion-*.whl
+          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
+          pixi run pip install chromedriver-binary-auto
+          pixi run pip list
+      - name: Test vegafusion jupyter
+        run: |
+          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        if: always()
+        with:
+          name: vegafusion-jupyter-test-failures
+          path: |
+            python/vegafusion-jupyter/tests/failures/*
+
+  build-vegafusion-server-linux-64:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-linux-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+# # Below is an Attempt to cross compile to linux aarch64 within conda environment.
+# # It fails in compiling protobuf-src. So instead we fall back to the direct use of
+# # cargo (without involving conda).
 #
 #  build-vegafusion-server-linux-arm64:
-#    runs-on: ubuntu-latest
+#    runs-on: ubuntu-20.04
 #    steps:
 #      - name: Check out repository code
 #        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
 #        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download arm64 toolchain
-#        run: |
-#          rustup target add aarch64-unknown-linux-gnu
-#      - name: Download gcc for cross compilation
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install gcc-aarch64-linux-gnu
+#          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
 #      - name: Build vegafusion-server
-#        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-#        env:
-#          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+#        run: |
+#          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
+#          pixi add gcc_linux-aarch64 -p linux-64
+#          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+#          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
 #      - name: zip executable
 #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
 #        with:
@@ -601,97 +513,138 @@ jobs:
 #          name: vegafusion-server
 #          path: |
 #            vegafusion-server-*
-#
-#  build-vegafusion-server-win-64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi install -vvv
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server.exe
-#          dest: vegafusion-server-win-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-osx-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-#          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/aarch64-apple-darwin/release/vegafusion-server
-#          dest: vegafusion-server-osx-arm64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
+
+
+  build-vegafusion-server-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Download gcc for cross compilation
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-aarch64-linux-gnu
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+        env:
+          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+          dest: vegafusion-server-linux-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-win-64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: |
+          iwr -useb https://pixi.sh/install.ps1 | iex
+          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi install -vvv
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server.exe
+          dest: vegafusion-server-win-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-osx-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
+          dest: vegafusion-server-osx-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,6 +53,8 @@ jobs:
             ~/.cargo
             target
             .pixi
+      - name: start minio server in the background
+        run: pixi run start-minio &
       - name: Test rust
         run: |
           pixi run test-rs --release

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,14 +23,34 @@ jobs:
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
+      - uses: JarvusInnovations/background-action@v1
+        name: start minio server in the background
         with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
-          path: |
-            ~/.cargo
-            target
-            .pixi
+          run: pixi run start-minio &
+          wait-on: |
+            http://127.0.0.1:9000
+          tail: true
+
+  try-it2:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - windows-2022
+          - macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        if: ${{ runner.os != 'Windows' }}
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Install pixi (windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          iwr -useb https://pixi.sh/install.ps1 | iex
+          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: start minio server in the background
         run: pixi run start-minio
 #

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,8 +53,13 @@ jobs:
             ~/.cargo
             target
             .pixi
-      - name: start minio server in the background
-        run: pixi run start-minio &
+      - uses: JarvusInnovations/background-action@v1
+        name: start minio server in the background
+        with:
+          run: pixi run start-minio &
+          wait-on: |
+            http://127.0.0.1:9000
+          tail: true
       - name: Test rust
         run: |
           pixi run test-rs --release

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,29 +3,8 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 jobs:
-  check-rust:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Check fmt
-        run: pixi run check-rs-fmt
-      - name: Check warnings
-        run: pixi run check-rs-warnings
-      - name: Check clippy
-        run: pixi run check-rs-clippy
 
-  test-rust:
+  try-it-1:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -45,443 +24,33 @@ jobs:
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: start minio server in the background
-        run: pixi run start-minio &
-      - name: Test rust
-        run: |
-          pixi run test-rs --release
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        if: always()
-        with:
-          name: vegafusion-rt-test-images
-          path: |
-            vegafusion-runtime/tests/output
+      - name: start minio server
+        run: pixi run start-minio
 
-  build-vegafusion-wasm:
-    runs-on: ubuntu-20.04
+  try-it-2:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - windows-2022
+          - macos-11
     steps:
       - name: Check out repository code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
       - name: Install pixi (linux / osx)
+        if: ${{ runner.os != 'Windows' }}
         run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build package
-        run: |
-          pixi run pack-wasm
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-wasm-packages
-          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
-
-  # Use maturin action to build linux wheels within proper manylinux compatible containers
-  # (This is why we don't use the pixi "build-py-embed" action)
-  build-vegafusion-python-embed-linux-64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Build wheels (Linux)
-        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Build arm64 wheels
-        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-win-64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
+      - name: Install pixi (windows)
+        if: ${{ runner.os == 'Windows' }}
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-python-embed
-        run: |
-          pixi run build-py-embed
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
+      - name: start minio server
+        run: pixi run minio server minio_data
 
-  build-vegafusion-python-embed-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-python-embed
-        run: |
-          pixi run build-py-embed
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-          pixi run build-py-embed --target aarch64-apple-darwin
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-packages:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion wheel
-        run: |
-          pixi run build-py-vegafusion
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-packages
-          path: |
-            python/vegafusion/dist/*.whl
-            python/vegafusion/dist/*.tar.gz
-
-  build-vegafusion-jupyter-packages:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-jupyter wheel
-        run: |
-          echo JupyterLab Version: `pixi run jupyter-lab --version`
-          pixi run build-py-jupyter
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-jupyter-packages
-          path: |
-            python/vegafusion-jupyter/dist/*.whl
-            python/vegafusion-jupyter/dist/*.tar.gz
-
-  test-vegafusion-python-linux-64:
-    runs-on: ubuntu-20.04
-    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.11'
-      - name: Install fonts on Linux
-        if: runner.os == 'Linux'
-        run: |
-          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        run: |
-          ls -la
-          python -m pip install vegafusion-*.whl
-          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-python-osx-64:
-    runs-on: macos-11
-    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.10'
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        run: |
-          ls -la
-          python -m pip install vegafusion-*.whl
-          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-          
-          # Downgrade pyarrow to 10.0.1
-          python -m pip install pyarrow==10.0.1
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-python-win-64:
-    runs-on: windows-2022
-    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.8'
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        shell: powershell
-        run: |
-          Get-ChildItem -Force
-          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
-          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
-
-          python -m pip install $vegafusion
-          python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-jupyter-linux-64:
-    runs-on: ubuntu-20.04
-    needs:
-      - build-vegafusion-python-embed-linux-64
-      - build-vegafusion-packages
-      - build-vegafusion-jupyter-packages
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi on linux
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
-          path: |
-            .pixi
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
-        with:
-          chrome-version: stable
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: Download vegafusion-jupyter wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-jupyter-packages
-          path: target/wheels/
-      - name: install wheels
-        run: |
-          ls -la target/wheels/
-          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          pixi run pip install target/wheels/vegafusion-*.whl
-          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
-          pixi run pip install chromedriver-binary-auto
-          pixi run pip list
-      - name: Test vegafusion jupyter
-        run: |
-          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        if: always()
-        with:
-          name: vegafusion-jupyter-test-failures
-          path: |
-            python/vegafusion-jupyter/tests/failures/*
-
-  build-vegafusion-server-linux-64:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-linux-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-# # Below is an Attempt to cross compile to linux aarch64 within conda environment.
-# # It fails in compiling protobuf-src. So instead we fall back to the direct use of
-# # cargo (without involving conda).
-#
-#  build-vegafusion-server-linux-arm64:
+#  check-rust:
 #    runs-on: ubuntu-20.04
 #    steps:
 #      - name: Check out repository code
@@ -491,17 +60,536 @@ jobs:
 #      - name: Cache
 #        uses: actions/cache@v3
 #        with:
-#          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Check fmt
+#        run: pixi run check-rs-fmt
+#      - name: Check warnings
+#        run: pixi run check-rs-warnings
+#      - name: Check clippy
+#        run: pixi run check-rs-clippy
+#
+#  test-rust:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#          - ubuntu-20.04
+#          - windows-2022
+#          - macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        if: ${{ runner.os != 'Windows' }}
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Install pixi (windows)
+#        if: ${{ runner.os == 'Windows' }}
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: start minio server in the background
+#        run: pixi run start-minio &
+#      - name: Test rust
+#        run: |
+#          pixi run test-rs --release
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        if: always()
+#        with:
+#          name: vegafusion-rt-test-images
+#          path: |
+#            vegafusion-runtime/tests/output
+#
+#  build-vegafusion-wasm:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build package
+#        run: |
+#          pixi run pack-wasm
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-wasm-packages
+#          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
+#
+#  # Use maturin action to build linux wheels within proper manylinux compatible containers
+#  # (This is why we don't use the pixi "build-py-embed" action)
+#  build-vegafusion-python-embed-linux-64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build wheels (Linux)
+#        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-linux-arm64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download arm64 toolchain
+#        run: |
+#          rustup target add aarch64-unknown-linux-gnu
+#      - name: Build arm64 wheels
+#        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-win-64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-python-embed
+#        run: |
+#          pixi run build-py-embed
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-python-embed
+#        run: |
+#          pixi run build-py-embed
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
 #          path: |
 #            ~/.cargo
 #            target
 #            .pixi
 #      - name: Build vegafusion-server
 #        run: |
-#          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
-#          pixi add gcc_linux-aarch64 -p linux-64
-#          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
-#          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
+#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+#          pixi run build-py-embed --target aarch64-apple-darwin
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-packages:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion wheel
+#        run: |
+#          pixi run build-py-vegafusion
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-packages
+#          path: |
+#            python/vegafusion/dist/*.whl
+#            python/vegafusion/dist/*.tar.gz
+#
+#  build-vegafusion-jupyter-packages:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-jupyter wheel
+#        run: |
+#          echo JupyterLab Version: `pixi run jupyter-lab --version`
+#          pixi run build-py-jupyter
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: |
+#            python/vegafusion-jupyter/dist/*.whl
+#            python/vegafusion-jupyter/dist/*.tar.gz
+#
+#  test-vegafusion-python-linux-64:
+#    runs-on: ubuntu-20.04
+#    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.11'
+#      - name: Install fonts on Linux
+#        if: runner.os == 'Linux'
+#        run: |
+#          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+#          sudo apt-get install ttf-mscorefonts-installer
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        run: |
+#          ls -la
+#          python -m pip install vegafusion-*.whl
+#          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+#          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-python-osx-64:
+#    runs-on: macos-11
+#    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.10'
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        run: |
+#          ls -la
+#          python -m pip install vegafusion-*.whl
+#          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
+#          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+#
+#          # Downgrade pyarrow to 10.0.1
+#          python -m pip install pyarrow==10.0.1
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-python-win-64:
+#    runs-on: windows-2022
+#    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.8'
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        shell: powershell
+#        run: |
+#          Get-ChildItem -Force
+#          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
+#          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
+#
+#          python -m pip install $vegafusion
+#          python -m pip install $vegafusion_python_embed
+#          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-jupyter-linux-64:
+#    runs-on: ubuntu-20.04
+#    needs:
+#      - build-vegafusion-python-embed-linux-64
+#      - build-vegafusion-packages
+#      - build-vegafusion-jupyter-packages
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi on linux
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
+#          path: |
+#            .pixi
+#      - name: Install Chrome
+#        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
+#        with:
+#          chrome-version: stable
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: Download vegafusion-jupyter wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        run: |
+#          ls -la target/wheels/
+#          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+#          pixi run pip install target/wheels/vegafusion-*.whl
+#          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
+#          pixi run pip install chromedriver-binary-auto
+#          pixi run pip list
+#      - name: Test vegafusion jupyter
+#        run: |
+#          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        if: always()
+#        with:
+#          name: vegafusion-jupyter-test-failures
+#          path: |
+#            python/vegafusion-jupyter/tests/failures/*
+#
+#  build-vegafusion-server-linux-64:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-linux-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+## # Below is an Attempt to cross compile to linux aarch64 within conda environment.
+## # It fails in compiling protobuf-src. So instead we fall back to the direct use of
+## # cargo (without involving conda).
+##
+##  build-vegafusion-server-linux-arm64:
+##    runs-on: ubuntu-20.04
+##    steps:
+##      - name: Check out repository code
+##        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+##      - name: Install pixi
+##        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+##      - name: Cache
+##        uses: actions/cache@v3
+##        with:
+##          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+##          path: |
+##            ~/.cargo
+##            target
+##            .pixi
+##      - name: Build vegafusion-server
+##        run: |
+##          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
+##          pixi add gcc_linux-aarch64 -p linux-64
+##          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+##          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
+##      - name: zip executable
+##        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+##        with:
+##          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+##          dest: vegafusion-server-linux-arm64.zip
+##      - name: Upload artifacts
+##        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+##        with:
+##          name: vegafusion-server
+##          path: |
+##            vegafusion-server-*
+#
+#
+#  build-vegafusion-server-linux-arm64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download arm64 toolchain
+#        run: |
+#          rustup target add aarch64-unknown-linux-gnu
+#      - name: Download gcc for cross compilation
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install gcc-aarch64-linux-gnu
+#      - name: Build vegafusion-server
+#        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+#        env:
+#          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
 #      - name: zip executable
 #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
 #        with:
@@ -513,138 +601,97 @@ jobs:
 #          name: vegafusion-server
 #          path: |
 #            vegafusion-server-*
-
-
-  build-vegafusion-server-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Download gcc for cross compilation
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-aarch64-linux-gnu
-      - name: Build vegafusion-server
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        env:
-          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
-        with:
-          command: build
-          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
-          dest: vegafusion-server-linux-arm64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-win-64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: |
-          iwr -useb https://pixi.sh/install.ps1 | iex
-          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi install -vvv
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server.exe
-          dest: vegafusion-server-win-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-osx-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
-          dest: vegafusion-server-osx-arm64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
+#
+#  build-vegafusion-server-win-64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi install -vvv
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server.exe
+#          dest: vegafusion-server-win-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-osx-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+#          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/aarch64-apple-darwin/release/vegafusion-server
+#          dest: vegafusion-server-osx-arm64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,29 +3,7 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 jobs:
-  check-rust:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Check fmt
-        run: pixi run check-rs-fmt
-      - name: Check warnings
-        run: pixi run check-rs-warnings
-      - name: Check clippy
-        run: pixi run check-rs-clippy
-
-  test-rust:
+  try-it:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -53,440 +31,10 @@ jobs:
             ~/.cargo
             target
             .pixi
-      - uses: JarvusInnovations/background-action@v1
-        name: start minio server in the background
-        with:
-          run: pixi run start-minio &
-          wait-on: |
-            http://127.0.0.1:9000
-          tail: true
-      - name: Test rust
-        run: |
-          pixi run test-rs --release
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        if: always()
-        with:
-          name: vegafusion-rt-test-images
-          path: |
-            vegafusion-runtime/tests/output
-
-  build-vegafusion-wasm:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build package
-        run: |
-          pixi run pack-wasm
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-wasm-packages
-          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
-
-  # Use maturin action to build linux wheels within proper manylinux compatible containers
-  # (This is why we don't use the pixi "build-py-embed" action)
-  build-vegafusion-python-embed-linux-64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Build wheels (Linux)
-        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Build arm64 wheels
-        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
-        with:
-          command: build
-          manylinux: 2014
-          rust-toolchain: stable
-          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-win-64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: |
-          iwr -useb https://pixi.sh/install.ps1 | iex
-          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-python-embed
-        run: |
-          pixi run build-py-embed
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-python-embed
-        run: |
-          pixi run build-py-embed
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-python-embed-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-          pixi run build-py-embed --target aarch64-apple-darwin
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: |
-            target/wheels/*.tar.gz
-            target/wheels/*.whl
-
-  build-vegafusion-packages:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion wheel
-        run: |
-          pixi run build-py-vegafusion
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-packages
-          path: |
-            python/vegafusion/dist/*.whl
-            python/vegafusion/dist/*.tar.gz
-
-  build-vegafusion-jupyter-packages:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-jupyter wheel
-        run: |
-          echo JupyterLab Version: `pixi run jupyter-lab --version`
-          pixi run build-py-jupyter
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-jupyter-packages
-          path: |
-            python/vegafusion-jupyter/dist/*.whl
-            python/vegafusion-jupyter/dist/*.tar.gz
-
-  test-vegafusion-python-linux-64:
-    runs-on: ubuntu-20.04
-    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.11'
-      - name: Install fonts on Linux
-        if: runner.os == 'Linux'
-        run: |
-          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        run: |
-          ls -la
-          python -m pip install vegafusion-*.whl
-          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-python-osx-64:
-    runs-on: macos-11
-    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.10'
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        run: |
-          ls -la
-          python -m pip install vegafusion-*.whl
-          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-          
-          # Downgrade pyarrow to 10.0.1
-          python -m pip install pyarrow==10.0.1
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-python-win-64:
-    runs-on: windows-2022
-    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: '3.8'
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: install wheels
-        working-directory: target/wheels/
-        shell: powershell
-        run: |
-          Get-ChildItem -Force
-          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
-          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
-
-          python -m pip install $vegafusion
-          python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
-      - name: Test vegafusion
-        working-directory: python/vegafusion/
-        run: pytest
-
-  test-vegafusion-jupyter-linux-64:
-    runs-on: ubuntu-20.04
-    needs:
-      - build-vegafusion-python-embed-linux-64
-      - build-vegafusion-packages
-      - build-vegafusion-jupyter-packages
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi on linux
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
-          path: |
-            .pixi
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
-        with:
-          chrome-version: stable
-      - name: Download vegafusion-python-embed wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-python-embed-wheels
-          path: target/wheels/
-      - name: Download vegafusion wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-packages
-          path: target/wheels/
-      - name: Download vegafusion-jupyter wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-        with:
-          name: vegafusion-jupyter-packages
-          path: target/wheels/
-      - name: install wheels
-        run: |
-          ls -la target/wheels/
-          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          pixi run pip install target/wheels/vegafusion-*.whl
-          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
-          pixi run pip install chromedriver-binary-auto
-          pixi run pip list
-      - name: Test vegafusion jupyter
-        run: |
-          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        if: always()
-        with:
-          name: vegafusion-jupyter-test-failures
-          path: |
-            python/vegafusion-jupyter/tests/failures/*
-
-  build-vegafusion-server-linux-64:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-linux-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-# # Below is an Attempt to cross compile to linux aarch64 within conda environment.
-# # It fails in compiling protobuf-src. So instead we fall back to the direct use of
-# # cargo (without involving conda).
+      - name: start minio server in the background
+        run: pixi run start-minio
 #
-#  build-vegafusion-server-linux-arm64:
+#  check-rust:
 #    runs-on: ubuntu-20.04
 #    steps:
 #      - name: Check out repository code
@@ -496,17 +44,541 @@ jobs:
 #      - name: Cache
 #        uses: actions/cache@v3
 #        with:
-#          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Check fmt
+#        run: pixi run check-rs-fmt
+#      - name: Check warnings
+#        run: pixi run check-rs-warnings
+#      - name: Check clippy
+#        run: pixi run check-rs-clippy
+#
+#  test-rust:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#          - ubuntu-20.04
+#          - windows-2022
+#          - macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        if: ${{ runner.os != 'Windows' }}
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Install pixi (windows)
+#        if: ${{ runner.os == 'Windows' }}
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - uses: JarvusInnovations/background-action@v1
+#        name: start minio server in the background
+#        with:
+#          run: pixi run start-minio &
+#          wait-on: |
+#            http://127.0.0.1:9000
+#          tail: true
+#      - name: Test rust
+#        run: |
+#          pixi run test-rs --release
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        if: always()
+#        with:
+#          name: vegafusion-rt-test-images
+#          path: |
+#            vegafusion-runtime/tests/output
+#
+#  build-vegafusion-wasm:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build package
+#        run: |
+#          pixi run pack-wasm
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-wasm-packages
+#          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
+#
+#  # Use maturin action to build linux wheels within proper manylinux compatible containers
+#  # (This is why we don't use the pixi "build-py-embed" action)
+#  build-vegafusion-python-embed-linux-64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Build wheels (Linux)
+#        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-linux-arm64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download arm64 toolchain
+#        run: |
+#          rustup target add aarch64-unknown-linux-gnu
+#      - name: Build arm64 wheels
+#        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
+#        with:
+#          command: build
+#          manylinux: 2014
+#          rust-toolchain: stable
+#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-win-64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-python-embed
+#        run: |
+#          pixi run build-py-embed
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-python-embed
+#        run: |
+#          pixi run build-py-embed
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-python-embed-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
 #          path: |
 #            ~/.cargo
 #            target
 #            .pixi
 #      - name: Build vegafusion-server
 #        run: |
-#          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
-#          pixi add gcc_linux-aarch64 -p linux-64
-#          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
-#          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
+#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+#          pixi run build-py-embed --target aarch64-apple-darwin
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: |
+#            target/wheels/*.tar.gz
+#            target/wheels/*.whl
+#
+#  build-vegafusion-packages:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion wheel
+#        run: |
+#          pixi run build-py-vegafusion
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-packages
+#          path: |
+#            python/vegafusion/dist/*.whl
+#            python/vegafusion/dist/*.tar.gz
+#
+#  build-vegafusion-jupyter-packages:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi (linux / osx)
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-jupyter wheel
+#        run: |
+#          echo JupyterLab Version: `pixi run jupyter-lab --version`
+#          pixi run build-py-jupyter
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: |
+#            python/vegafusion-jupyter/dist/*.whl
+#            python/vegafusion-jupyter/dist/*.tar.gz
+#
+#  test-vegafusion-python-linux-64:
+#    runs-on: ubuntu-20.04
+#    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.11'
+#      - name: Install fonts on Linux
+#        if: runner.os == 'Linux'
+#        run: |
+#          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+#          sudo apt-get install ttf-mscorefonts-installer
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        run: |
+#          ls -la
+#          python -m pip install vegafusion-*.whl
+#          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+#          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-python-osx-64:
+#    runs-on: macos-11
+#    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.10'
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        run: |
+#          ls -la
+#          python -m pip install vegafusion-*.whl
+#          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
+#          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+#
+#          # Downgrade pyarrow to 10.0.1
+#          python -m pip install pyarrow==10.0.1
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-python-win-64:
+#    runs-on: windows-2022
+#    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Setup Python
+#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+#        with:
+#          python-version: '3.8'
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        working-directory: target/wheels/
+#        shell: powershell
+#        run: |
+#          Get-ChildItem -Force
+#          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
+#          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
+#
+#          python -m pip install $vegafusion
+#          python -m pip install $vegafusion_python_embed
+#          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+#      - name: Test vegafusion
+#        working-directory: python/vegafusion/
+#        run: pytest
+#
+#  test-vegafusion-jupyter-linux-64:
+#    runs-on: ubuntu-20.04
+#    needs:
+#      - build-vegafusion-python-embed-linux-64
+#      - build-vegafusion-packages
+#      - build-vegafusion-jupyter-packages
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi on linux
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
+#          path: |
+#            .pixi
+#      - name: Install Chrome
+#        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
+#        with:
+#          chrome-version: stable
+#      - name: Download vegafusion-python-embed wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-python-embed-wheels
+#          path: target/wheels/
+#      - name: Download vegafusion wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-packages
+#          path: target/wheels/
+#      - name: Download vegafusion-jupyter wheel
+#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+#        with:
+#          name: vegafusion-jupyter-packages
+#          path: target/wheels/
+#      - name: install wheels
+#        run: |
+#          ls -la target/wheels/
+#          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+#          pixi run pip install target/wheels/vegafusion-*.whl
+#          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
+#          pixi run pip install chromedriver-binary-auto
+#          pixi run pip list
+#      - name: Test vegafusion jupyter
+#        run: |
+#          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
+#      - name: Upload test artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        if: always()
+#        with:
+#          name: vegafusion-jupyter-test-failures
+#          path: |
+#            python/vegafusion-jupyter/tests/failures/*
+#
+#  build-vegafusion-server-linux-64:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-linux-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+## # Below is an Attempt to cross compile to linux aarch64 within conda environment.
+## # It fails in compiling protobuf-src. So instead we fall back to the direct use of
+## # cargo (without involving conda).
+##
+##  build-vegafusion-server-linux-arm64:
+##    runs-on: ubuntu-20.04
+##    steps:
+##      - name: Check out repository code
+##        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+##      - name: Install pixi
+##        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+##      - name: Cache
+##        uses: actions/cache@v3
+##        with:
+##          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+##          path: |
+##            ~/.cargo
+##            target
+##            .pixi
+##      - name: Build vegafusion-server
+##        run: |
+##          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
+##          pixi add gcc_linux-aarch64 -p linux-64
+##          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+##          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
+##      - name: zip executable
+##        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+##        with:
+##          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+##          dest: vegafusion-server-linux-arm64.zip
+##      - name: Upload artifacts
+##        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+##        with:
+##          name: vegafusion-server
+##          path: |
+##            vegafusion-server-*
+#
+#
+#  build-vegafusion-server-linux-arm64:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install latest stable Rust toolchain
+#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - name: Cache rust dependencies
+#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+#        with:
+#          cache-on-failure: True
+#      - name: Download arm64 toolchain
+#        run: |
+#          rustup target add aarch64-unknown-linux-gnu
+#      - name: Download gcc for cross compilation
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install gcc-aarch64-linux-gnu
+#      - name: Build vegafusion-server
+#        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+#        env:
+#          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
+#        with:
+#          command: build
+#          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
 #      - name: zip executable
 #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
 #        with:
@@ -518,138 +590,97 @@ jobs:
 #          name: vegafusion-server
 #          path: |
 #            vegafusion-server-*
-
-
-  build-vegafusion-server-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-      - name: Download gcc for cross compilation
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-aarch64-linux-gnu
-      - name: Build vegafusion-server
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        env:
-          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
-        with:
-          command: build
-          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
-          dest: vegafusion-server-linux-arm64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-win-64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: |
-          iwr -useb https://pixi.sh/install.ps1 | iex
-          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi install -vvv
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server.exe
-          dest: vegafusion-server-win-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run build-rs-vegafusion-server
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/release/vegafusion-server
-          dest: vegafusion-server-osx-64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
-
-  build-vegafusion-server-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build vegafusion-server
-        run: |
-          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
-      - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-        with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
-          dest: vegafusion-server-osx-arm64.zip
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: vegafusion-server
-          path: |
-            vegafusion-server-*
+#
+#  build-vegafusion-server-win-64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi install -vvv
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server.exe
+#          dest: vegafusion-server-win-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run build-rs-vegafusion-server
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/release/vegafusion-server
+#          dest: vegafusion-server-osx-64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*
+#
+#  build-vegafusion-server-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build vegafusion-server
+#        run: |
+#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+#          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
+#      - name: zip executable
+#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+#        with:
+#          files: target/aarch64-apple-darwin/release/vegafusion-server
+#          dest: vegafusion-server-osx-arm64.zip
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: vegafusion-server
+#          path: |
+#            vegafusion-server-*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,35 +3,29 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 jobs:
-  try-it:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-20.04
-          - windows-2022
-          - macos-11
+  check-rust:
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi (linux / osx)
-        if: ${{ runner.os != 'Windows' }}
+      - name: Install pixi
         run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Install pixi (windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          iwr -useb https://pixi.sh/install.ps1 | iex
-          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - uses: JarvusInnovations/background-action@v1
-        name: start minio server in the background
+      - name: Cache
+        uses: actions/cache@v3
         with:
-          run: pixi run start-minio &
-          wait-on: |
-            http://127.0.0.1:9000
-          tail: true
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Check fmt
+        run: pixi run check-rs-fmt
+      - name: Check warnings
+        run: pixi run check-rs-warnings
+      - name: Check clippy
+        run: pixi run check-rs-clippy
 
-  try-it2:
+  test-rust:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,554 +45,463 @@ jobs:
         run: |
           iwr -useb https://pixi.sh/install.ps1 | iex
           echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
+          path: |
+            ~/.cargo
+            target
+            .pixi
       - name: start minio server in the background
-        run: pixi run start-minio
-#
-#  check-rust:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-check-rust
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Check fmt
-#        run: pixi run check-rs-fmt
-#      - name: Check warnings
-#        run: pixi run check-rs-warnings
-#      - name: Check clippy
-#        run: pixi run check-rs-clippy
-#
-#  test-rust:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os:
-#          - ubuntu-20.04
-#          - windows-2022
-#          - macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        if: ${{ runner.os != 'Windows' }}
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Install pixi (windows)
-#        if: ${{ runner.os == 'Windows' }}
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-rust
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - uses: JarvusInnovations/background-action@v1
-#        name: start minio server in the background
-#        with:
-#          run: pixi run start-minio &
-#          wait-on: |
-#            http://127.0.0.1:9000
-#          tail: true
-#      - name: Test rust
-#        run: |
-#          pixi run test-rs --release
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        if: always()
-#        with:
-#          name: vegafusion-rt-test-images
-#          path: |
-#            vegafusion-runtime/tests/output
-#
-#  build-vegafusion-wasm:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build package
-#        run: |
-#          pixi run pack-wasm
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-wasm-packages
-#          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
-#
-#  # Use maturin action to build linux wheels within proper manylinux compatible containers
-#  # (This is why we don't use the pixi "build-py-embed" action)
-#  build-vegafusion-python-embed-linux-64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Build wheels (Linux)
-#        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-linux-arm64:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download arm64 toolchain
-#        run: |
-#          rustup target add aarch64-unknown-linux-gnu
-#      - name: Build arm64 wheels
-#        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
-#        with:
-#          command: build
-#          manylinux: 2014
-#          rust-toolchain: stable
-#          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-win-64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-python-embed
-#        run: |
-#          pixi run build-py-embed
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-python-embed
-#        run: |
-#          pixi run build-py-embed
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-python-embed-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-#          pixi run build-py-embed --target aarch64-apple-darwin
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: |
-#            target/wheels/*.tar.gz
-#            target/wheels/*.whl
-#
-#  build-vegafusion-packages:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion wheel
-#        run: |
-#          pixi run build-py-vegafusion
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-packages
-#          path: |
-#            python/vegafusion/dist/*.whl
-#            python/vegafusion/dist/*.tar.gz
-#
-#  build-vegafusion-jupyter-packages:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi (linux / osx)
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-jupyter wheel
-#        run: |
-#          echo JupyterLab Version: `pixi run jupyter-lab --version`
-#          pixi run build-py-jupyter
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: |
-#            python/vegafusion-jupyter/dist/*.whl
-#            python/vegafusion-jupyter/dist/*.tar.gz
-#
-#  test-vegafusion-python-linux-64:
-#    runs-on: ubuntu-20.04
-#    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.11'
-#      - name: Install fonts on Linux
-#        if: runner.os == 'Linux'
-#        run: |
-#          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-#          sudo apt-get install ttf-mscorefonts-installer
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        run: |
-#          ls -la
-#          python -m pip install vegafusion-*.whl
-#          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-#          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-python-osx-64:
-#    runs-on: macos-11
-#    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.10'
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        run: |
-#          ls -la
-#          python -m pip install vegafusion-*.whl
-#          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-#          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-#
-#          # Downgrade pyarrow to 10.0.1
-#          python -m pip install pyarrow==10.0.1
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-python-win-64:
-#    runs-on: windows-2022
-#    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Setup Python
-#        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-#        with:
-#          python-version: '3.8'
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        working-directory: target/wheels/
-#        shell: powershell
-#        run: |
-#          Get-ChildItem -Force
-#          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
-#          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
-#
-#          python -m pip install $vegafusion
-#          python -m pip install $vegafusion_python_embed
-#          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
-#      - name: Test vegafusion
-#        working-directory: python/vegafusion/
-#        run: pytest
-#
-#  test-vegafusion-jupyter-linux-64:
-#    runs-on: ubuntu-20.04
-#    needs:
-#      - build-vegafusion-python-embed-linux-64
-#      - build-vegafusion-packages
-#      - build-vegafusion-jupyter-packages
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi on linux
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
-#          path: |
-#            .pixi
-#      - name: Install Chrome
-#        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
-#        with:
-#          chrome-version: stable
-#      - name: Download vegafusion-python-embed wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-python-embed-wheels
-#          path: target/wheels/
-#      - name: Download vegafusion wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-packages
-#          path: target/wheels/
-#      - name: Download vegafusion-jupyter wheel
-#        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
-#        with:
-#          name: vegafusion-jupyter-packages
-#          path: target/wheels/
-#      - name: install wheels
-#        run: |
-#          ls -la target/wheels/
-#          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-#          pixi run pip install target/wheels/vegafusion-*.whl
-#          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
-#          pixi run pip install chromedriver-binary-auto
-#          pixi run pip list
-#      - name: Test vegafusion jupyter
-#        run: |
-#          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
-#      - name: Upload test artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        if: always()
-#        with:
-#          name: vegafusion-jupyter-test-failures
-#          path: |
-#            python/vegafusion-jupyter/tests/failures/*
-#
-#  build-vegafusion-server-linux-64:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-linux-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-## # Below is an Attempt to cross compile to linux aarch64 within conda environment.
-## # It fails in compiling protobuf-src. So instead we fall back to the direct use of
-## # cargo (without involving conda).
-##
-##  build-vegafusion-server-linux-arm64:
-##    runs-on: ubuntu-20.04
-##    steps:
-##      - name: Check out repository code
-##        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-##      - name: Install pixi
-##        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-##      - name: Cache
-##        uses: actions/cache@v3
-##        with:
-##          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
-##          path: |
-##            ~/.cargo
-##            target
-##            .pixi
-##      - name: Build vegafusion-server
-##        run: |
-##          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
-##          pixi add gcc_linux-aarch64 -p linux-64
-##          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
-##          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
-##      - name: zip executable
-##        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-##        with:
-##          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
-##          dest: vegafusion-server-linux-arm64.zip
-##      - name: Upload artifacts
-##        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-##        with:
-##          name: vegafusion-server
-##          path: |
-##            vegafusion-server-*
-#
+        run: pixi run start-minio &
+      - name: Test rust
+        run: |
+          pixi run test-rs --release
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        if: always()
+        with:
+          name: vegafusion-rt-test-images
+          path: |
+            vegafusion-runtime/tests/output
+
+  build-vegafusion-wasm:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-wasm
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build package
+        run: |
+          pixi run pack-wasm
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-wasm-packages
+          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
+
+  # Use maturin action to build linux wheels within proper manylinux compatible containers
+  # (This is why we don't use the pixi "build-py-embed" action)
+  build-vegafusion-python-embed-linux-64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Build wheels (Linux)
+        uses: messense/maturin-action@9357a23898d2fca5ef8da7ac38aaaedab4ef218f # pin@v1.40.2
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Build arm64 wheels
+        uses: messense/maturin-action@6d52485c3b3044e20b4c8ee6ce6f61e20a7645b0 # pin@v1
+        with:
+          command: build
+          manylinux: 2014
+          rust-toolchain: stable
+          args: --release -m vegafusion-python-embed/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-win-64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: |
+          iwr -useb https://pixi.sh/install.ps1 | iex
+          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-win-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-python-embed
+        run: |
+          pixi run build-py-embed
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-python-embed
+        run: |
+          pixi run build-py-embed
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-python-embed-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-python-embed-osx-arm64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+          pixi run build-py-embed --target aarch64-apple-darwin
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: |
+            target/wheels/*.tar.gz
+            target/wheels/*.whl
+
+  build-vegafusion-packages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-packages
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion wheel
+        run: |
+          pixi run build-py-vegafusion
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-packages
+          path: |
+            python/vegafusion/dist/*.whl
+            python/vegafusion/dist/*.tar.gz
+
+  build-vegafusion-jupyter-packages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi (linux / osx)
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-jupyter-packages
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-jupyter wheel
+        run: |
+          echo JupyterLab Version: `pixi run jupyter-lab --version`
+          pixi run build-py-jupyter
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-jupyter-packages
+          path: |
+            python/vegafusion-jupyter/dist/*.whl
+            python/vegafusion-jupyter/dist/*.tar.gz
+
+  test-vegafusion-python-linux-64:
+    runs-on: ubuntu-20.04
+    needs: [build-vegafusion-python-embed-linux-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.11'
+      - name: Install fonts on Linux
+        if: runner.os == 'Linux'
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get install ttf-mscorefonts-installer
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        run: |
+          ls -la
+          python -m pip install vegafusion-*.whl
+          python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+          python -m pip install pytest vega-datasets polars duckdb "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-python-osx-64:
+    runs-on: macos-11
+    needs: [build-vegafusion-python-embed-osx-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.10'
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        run: |
+          ls -la
+          python -m pip install vegafusion-*.whl
+          python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
+          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+
+          # Downgrade pyarrow to 10.0.1
+          python -m pip install pyarrow==10.0.1
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-python-win-64:
+    runs-on: windows-2022
+    needs: [build-vegafusion-python-embed-win-64, build-vegafusion-packages]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        with:
+          python-version: '3.8'
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: install wheels
+        working-directory: target/wheels/
+        shell: powershell
+        run: |
+          Get-ChildItem -Force
+          $vegafusion = Get-ChildItem -Name "vegafusion-*.whl" | Select-Object -First 1
+          $vegafusion_python_embed = Get-ChildItem -Name "vegafusion_python_embed-*win_amd64.whl" | Select-Object -First 1
+
+          python -m pip install $vegafusion
+          python -m pip install $vegafusion_python_embed
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image
+      - name: Test vegafusion
+        working-directory: python/vegafusion/
+        run: pytest
+
+  test-vegafusion-jupyter-linux-64:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-vegafusion-python-embed-linux-64
+      - build-vegafusion-packages
+      - build-vegafusion-jupyter-packages
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi on linux
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-test-vegafusion-jupyter-linux-64
+          path: |
+            .pixi
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
+        with:
+          chrome-version: stable
+      - name: Download vegafusion-python-embed wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-python-embed-wheels
+          path: target/wheels/
+      - name: Download vegafusion wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-packages
+          path: target/wheels/
+      - name: Download vegafusion-jupyter wheel
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        with:
+          name: vegafusion-jupyter-packages
+          path: target/wheels/
+      - name: install wheels
+        run: |
+          ls -la target/wheels/
+          pixi run pip install target/wheels/vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
+          pixi run pip install target/wheels/vegafusion-*.whl
+          pixi run pip install target/wheels/vegafusion_jupyter-*.whl
+          pixi run pip install chromedriver-binary-auto
+          pixi run pip list
+      - name: Test vegafusion jupyter
+        run: |
+          VEGAFUSION_TEST_HEADLESS=1 pixi run pytest python/vegafusion-jupyter/tests
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        if: always()
+        with:
+          name: vegafusion-jupyter-test-failures
+          path: |
+            python/vegafusion-jupyter/tests/failures/*
+
+  build-vegafusion-server-linux-64:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-linux-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-linux-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+# # Below is an Attempt to cross compile to linux aarch64 within conda environment.
+# # It fails in compiling protobuf-src. So instead we fall back to the direct use of
+# # cargo (without involving conda).
 #
 #  build-vegafusion-server-linux-arm64:
-#    runs-on: ubuntu-latest
+#    runs-on: ubuntu-20.04
 #    steps:
 #      - name: Check out repository code
 #        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install latest stable Rust toolchain
-#        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
 #        with:
-#          toolchain: stable
-#          override: true
-#      - name: Cache rust dependencies
-#        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-#        with:
-#          cache-on-failure: True
-#      - name: Download arm64 toolchain
-#        run: |
-#          rustup target add aarch64-unknown-linux-gnu
-#      - name: Download gcc for cross compilation
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install gcc-aarch64-linux-gnu
+#          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-server
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
 #      - name: Build vegafusion-server
-#        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-#        env:
-#          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
-#        with:
-#          command: build
-#          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+#        run: |
+#          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
+#          pixi add gcc_linux-aarch64 -p linux-64
+#          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+#          pixi run build-rs-vegafusion-server --features=protobuf-src --target aarch64-unknown-linux-gnu
 #      - name: zip executable
 #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
 #        with:
@@ -610,97 +513,138 @@ jobs:
 #          name: vegafusion-server
 #          path: |
 #            vegafusion-server-*
-#
-#  build-vegafusion-server-win-64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi install -vvv
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server.exe
-#          dest: vegafusion-server-win-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run build-rs-vegafusion-server
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/release/vegafusion-server
-#          dest: vegafusion-server-osx-64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-#
-#  build-vegafusion-server-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-#          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/aarch64-apple-darwin/release/vegafusion-server
-#          dest: vegafusion-server-osx-arm64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
+
+
+  build-vegafusion-server-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install latest stable Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        with:
+          cache-on-failure: True
+      - name: Download arm64 toolchain
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+      - name: Download gcc for cross compilation
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-aarch64-linux-gnu
+      - name: Build vegafusion-server
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
+        env:
+          RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
+        with:
+          command: build
+          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+          dest: vegafusion-server-linux-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-win-64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: |
+          iwr -useb https://pixi.sh/install.ps1 | iex
+          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-win-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi install -vvv
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server.exe
+          dest: vegafusion-server-win-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run build-rs-vegafusion-server
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/release/vegafusion-server
+          dest: vegafusion-server-osx-64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*
+
+  build-vegafusion-server-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-vegafusion-server-osx-arm64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build vegafusion-server
+        run: |
+          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+          pixi run build-rs-vegafusion-server --target aarch64-apple-darwin
+      - name: zip executable
+        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        with:
+          files: target/aarch64-apple-darwin/release/vegafusion-server
+          dest: vegafusion-server-osx-arm64.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: vegafusion-server
+          path: |
+            vegafusion-server-*

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,185 +1,185 @@
-#name: java
-#on:
-#  pull_request:
-#    types: [ opened, synchronize ]
-#jobs:
-#  build-test-java-linux-64:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-linux-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Test Java
-#        run: pixi run test-java
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/linux-64
-#          cp target/release/libvegafusion_jni.so native/linux-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-test-java-osx-64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-osx-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Test Java
-#        run: pixi run test-java
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/osx-64
-#          cp target/release/libvegafusion_jni.dylib native/osx-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-java-osx-arm64:
-#    runs-on: macos-11
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-java-osx-arm64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build jni library
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-#          pixi run build-jni --target aarch64-apple-darwin
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/osx-arm64
-#          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-test-java-win-64:
-#    runs-on: windows-2022
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: |
-#          iwr -useb https://pixi.sh/install.ps1 | iex
-#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-win-64
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Test Java
-#        run: pixi run test-java-win
-#      - name: Copy native lib
-#        run: |
-#          mkdir -p native/win-64
-#          cp target/release/vegafusion_jni.dll native/win-64
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: jni-native
-#          path: |
-#            native
-#
-#  build-jar:
-#    runs-on: ubuntu-20.04
-#    needs:
-#      - build-test-java-linux-64
-#      - build-test-java-osx-64
-#      - build-java-osx-arm64
-#      - build-test-java-win-64
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-jar
-#          path: |
-#            .pixi
-#      - name: Download jni libs
-#        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
-#        with:
-#          name: jni-native
-#          path: jni-native
-#      - name: Build jar
-#        run: |
-#          export VEGAFUSION_JNI_LIBRARIES=/home/runner/work/vegafusion/vegafusion/jni-native
-#          pixi run build-jar
-#      - name: Upload jar
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: jar
-#          path: |
-#            java/lib/build/libs/vegafusion-*.jar
-#
-#  try-jar:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os:
-#          - ubuntu-20.04
-#          - macos-11
-#          - windows-2022
-#    runs-on: ${{ matrix.os }}
-#    needs: [ build-jar ]
-#    steps:
-#      - name: Install Java
-#        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: '17'
-#      - name: Download jar
-#        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
-#        with:
-#          name: jar
-#          path: .
-#      - name: Run jar (non-Windows)
-#        if: ${{ runner.os != 'Windows' }}
-#        run: |
-#          java -jar vegafusion-*.jar
-#      - name: Run jar (Windows)
-#        if: ${{ runner.os == 'Windows' }}
-#        run: |
-#          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
-#          java -jar $jarFile
+name: java
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+jobs:
+  build-test-java-linux-64:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-linux-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Test Java
+        run: pixi run test-java
+      - name: Copy native lib
+        run: |
+          mkdir -p native/linux-64
+          cp target/release/libvegafusion_jni.so native/linux-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-test-java-osx-64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-osx-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Test Java
+        run: pixi run test-java
+      - name: Copy native lib
+        run: |
+          mkdir -p native/osx-64
+          cp target/release/libvegafusion_jni.dylib native/osx-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-java-osx-arm64:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-java-osx-arm64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Build jni library
+        run: |
+          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+          pixi run build-jni --target aarch64-apple-darwin
+      - name: Copy native lib
+        run: |
+          mkdir -p native/osx-arm64
+          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-test-java-win-64:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: |
+          iwr -useb https://pixi.sh/install.ps1 | iex
+          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-win-64
+          path: |
+            ~/.cargo
+            target
+            .pixi
+      - name: Test Java
+        run: pixi run test-java-win
+      - name: Copy native lib
+        run: |
+          mkdir -p native/win-64
+          cp target/release/vegafusion_jni.dll native/win-64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: jni-native
+          path: |
+            native
+
+  build-jar:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-test-java-linux-64
+      - build-test-java-osx-64
+      - build-java-osx-arm64
+      - build-test-java-win-64
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-jar
+          path: |
+            .pixi
+      - name: Download jni libs
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+        with:
+          name: jni-native
+          path: jni-native
+      - name: Build jar
+        run: |
+          export VEGAFUSION_JNI_LIBRARIES=/home/runner/work/vegafusion/vegafusion/jni-native
+          pixi run build-jar
+      - name: Upload jar
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        with:
+          name: jar
+          path: |
+            java/lib/build/libs/vegafusion-*.jar
+
+  try-jar:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-11
+          - windows-2022
+    runs-on: ${{ matrix.os }}
+    needs: [ build-jar ]
+    steps:
+      - name: Install Java
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Download jar
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+        with:
+          name: jar
+          path: .
+      - name: Run jar (non-Windows)
+        if: ${{ runner.os != 'Windows' }}
+        run: |
+          java -jar vegafusion-*.jar
+      - name: Run jar (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
+          java -jar $jarFile

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,185 +1,185 @@
-name: java
-on:
-  pull_request:
-    types: [ opened, synchronize ]
-jobs:
-  build-test-java-linux-64:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-linux-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Test Java
-        run: pixi run test-java
-      - name: Copy native lib
-        run: |
-          mkdir -p native/linux-64
-          cp target/release/libvegafusion_jni.so native/linux-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-test-java-osx-64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-osx-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Test Java
-        run: pixi run test-java
-      - name: Copy native lib
-        run: |
-          mkdir -p native/osx-64
-          cp target/release/libvegafusion_jni.dylib native/osx-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-java-osx-arm64:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-java-osx-arm64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Build jni library
-        run: |
-          pixi run python automation/download_rust_target.py aarch64-apple-darwin
-          pixi run build-jni --target aarch64-apple-darwin
-      - name: Copy native lib
-        run: |
-          mkdir -p native/osx-arm64
-          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-test-java-win-64:
-    runs-on: windows-2022
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: |
-          iwr -useb https://pixi.sh/install.ps1 | iex
-          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-win-64
-          path: |
-            ~/.cargo
-            target
-            .pixi
-      - name: Test Java
-        run: pixi run test-java-win
-      - name: Copy native lib
-        run: |
-          mkdir -p native/win-64
-          cp target/release/vegafusion_jni.dll native/win-64
-      - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: jni-native
-          path: |
-            native
-
-  build-jar:
-    runs-on: ubuntu-20.04
-    needs:
-      - build-test-java-linux-64
-      - build-test-java-osx-64
-      - build-java-osx-arm64
-      - build-test-java-win-64
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-jar
-          path: |
-            .pixi
-      - name: Download jni libs
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
-        with:
-          name: jni-native
-          path: jni-native
-      - name: Build jar
-        run: |
-          export VEGAFUSION_JNI_LIBRARIES=/home/runner/work/vegafusion/vegafusion/jni-native
-          pixi run build-jar
-      - name: Upload jar
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-        with:
-          name: jar
-          path: |
-            java/lib/build/libs/vegafusion-*.jar
-
-  try-jar:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-20.04
-          - macos-11
-          - windows-2022
-    runs-on: ${{ matrix.os }}
-    needs: [ build-jar ]
-    steps:
-      - name: Install Java
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Download jar
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
-        with:
-          name: jar
-          path: .
-      - name: Run jar (non-Windows)
-        if: ${{ runner.os != 'Windows' }}
-        run: |
-          java -jar vegafusion-*.jar
-      - name: Run jar (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
-          java -jar $jarFile
+#name: java
+#on:
+#  pull_request:
+#    types: [ opened, synchronize ]
+#jobs:
+#  build-test-java-linux-64:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-linux-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Test Java
+#        run: pixi run test-java
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/linux-64
+#          cp target/release/libvegafusion_jni.so native/linux-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-test-java-osx-64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-osx-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Test Java
+#        run: pixi run test-java
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/osx-64
+#          cp target/release/libvegafusion_jni.dylib native/osx-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-java-osx-arm64:
+#    runs-on: macos-11
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-java-osx-arm64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Build jni library
+#        run: |
+#          pixi run python automation/download_rust_target.py aarch64-apple-darwin
+#          pixi run build-jni --target aarch64-apple-darwin
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/osx-arm64
+#          cp target/aarch64-apple-darwin/release/libvegafusion_jni.dylib native/osx-arm64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-test-java-win-64:
+#    runs-on: windows-2022
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: |
+#          iwr -useb https://pixi.sh/install.ps1 | iex
+#          echo "${HOME}/AppData/Local/pixi/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-test-java-win-64
+#          path: |
+#            ~/.cargo
+#            target
+#            .pixi
+#      - name: Test Java
+#        run: pixi run test-java-win
+#      - name: Copy native lib
+#        run: |
+#          mkdir -p native/win-64
+#          cp target/release/vegafusion_jni.dll native/win-64
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: jni-native
+#          path: |
+#            native
+#
+#  build-jar:
+#    runs-on: ubuntu-20.04
+#    needs:
+#      - build-test-java-linux-64
+#      - build-test-java-osx-64
+#      - build-java-osx-arm64
+#      - build-test-java-win-64
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+#      - name: Install pixi
+#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+#      - name: Cache
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock') }}-build-jar
+#          path: |
+#            .pixi
+#      - name: Download jni libs
+#        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+#        with:
+#          name: jni-native
+#          path: jni-native
+#      - name: Build jar
+#        run: |
+#          export VEGAFUSION_JNI_LIBRARIES=/home/runner/work/vegafusion/vegafusion/jni-native
+#          pixi run build-jar
+#      - name: Upload jar
+#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+#        with:
+#          name: jar
+#          path: |
+#            java/lib/build/libs/vegafusion-*.jar
+#
+#  try-jar:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os:
+#          - ubuntu-20.04
+#          - macos-11
+#          - windows-2022
+#    runs-on: ${{ matrix.os }}
+#    needs: [ build-jar ]
+#    steps:
+#      - name: Install Java
+#        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # pin@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: '17'
+#      - name: Download jar
+#        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3.0.2
+#        with:
+#          name: jar
+#          path: .
+#      - name: Run jar (non-Windows)
+#        if: ${{ runner.os != 'Windows' }}
+#        run: |
+#          java -jar vegafusion-*.jar
+#      - name: Run jar (Windows)
+#        if: ${{ runner.os == 'Windows' }}
+#        run: |
+#          $jarFile = Get-ChildItem -Path .\ -Filter "vegafusion-*.jar" | Select-Object -First 1
+#          java -jar $jarFile

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ __pycache__
 /java/.idea/
 /.pixi/
 /python/vegafusion-jupyter/MANIFEST
+/minio_data/

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,6 +18,13 @@ Then restart your shell.
 For more information on installing Pixi, see https://prefix.dev/docs/pixi/overview.
 
 ## Build and test Rust
+
+Start the test minio server in a dedicated terminal
+
+```
+pixi run start-minio
+```
+
 Build and test the VegaFusion Rust crates with:
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,12 +640,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -823,6 +817,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.0",
 ]
@@ -1031,6 +1026,16 @@ name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1263,7 +1268,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num_cpus",
- "object_store",
+ "object_store 0.7.0",
  "parking_lot 0.12.1",
  "parquet",
  "percent-encoding",
@@ -1293,7 +1298,7 @@ dependencies = [
  "chrono",
  "half 2.2.1",
  "num_cpus",
- "object_store",
+ "object_store 0.7.0",
  "parquet",
  "pyo3",
  "sqlparser 0.38.0",
@@ -1313,7 +1318,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.0",
  "log",
- "object_store",
+ "object_store 0.7.0",
  "parking_lot 0.12.1",
  "rand",
  "tempfile",
@@ -1364,7 +1369,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
- "base64 0.21.2",
+ "base64",
  "blake2",
  "blake3",
  "chrono",
@@ -1429,7 +1434,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
- "object_store",
+ "object_store 0.7.0",
  "prost",
 ]
 
@@ -1999,15 +2004,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "rustls 0.20.8",
+ "rustls",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2651,6 +2657,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2524735495ea1268be33d200e1ee97455096a0846295a21548cd2f3541de7050"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper",
+ "itertools 0.11.0",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring 0.17.3",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,7 +2789,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.21.2",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
@@ -2764,7 +2799,7 @@ dependencies = [
  "lz4",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.7.0",
  "paste",
  "seq-macro",
  "snap",
@@ -3151,6 +3186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,11 +3317,11 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3294,17 +3339,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -3386,10 +3434,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3464,24 +3526,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki",
  "sct",
 ]
@@ -3492,7 +3542,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.2",
+ "base64",
 ]
 
 [[package]]
@@ -3501,8 +3551,8 @@ version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -3550,8 +3600,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -3706,6 +3756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "sqlparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +3877,27 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -4012,22 +4089,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls",
  "tokio",
 ]
 
@@ -4099,7 +4165,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -4109,10 +4175,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls 0.21.7",
+ "rustls",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -4139,7 +4205,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "bytes",
  "http",
  "http-body",
@@ -4321,6 +4387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,12 +4429,13 @@ name = "vegafusion-common"
 version = "1.4.3"
 dependencies = [
  "arrow",
- "base64 0.21.2",
+ "base64",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-proto",
  "jni",
+ "object_store 0.8.0",
  "pyo3",
  "serde_json",
  "sqlparser 0.37.0",
@@ -4467,7 +4540,7 @@ dependencies = [
  "async-lock",
  "async-recursion",
  "async-trait",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -4488,6 +4561,7 @@ dependencies = [
  "log",
  "lru",
  "num-traits",
+ "object_store 0.8.0",
  "ordered-float 3.6.0",
  "prost",
  "prost-types",
@@ -4725,6 +4799,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,23 +4837,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
@@ -4962,11 +5036,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num_cpus",
- "object_store 0.7.0",
+ "object_store",
  "parking_lot 0.12.1",
  "parquet",
  "percent-encoding",
@@ -1298,7 +1298,7 @@ dependencies = [
  "chrono",
  "half 2.2.1",
  "num_cpus",
- "object_store 0.7.0",
+ "object_store",
  "parquet",
  "pyo3",
  "sqlparser 0.38.0",
@@ -1318,7 +1318,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.0",
  "log",
- "object_store 0.7.0",
+ "object_store",
  "parking_lot 0.12.1",
  "rand",
  "tempfile",
@@ -1434,7 +1434,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
- "object_store 0.7.0",
+ "object_store",
  "prost",
 ]
 
@@ -2642,40 +2642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d359e231e5451f4f9fa889d56e3ce34f8724f1a61db2107739359717cf2bbf08"
 dependencies = [
  "async-trait",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "itertools 0.10.5",
- "parking_lot 0.12.1",
- "percent-encoding",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "object_store"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2524735495ea1268be33d200e1ee97455096a0846295a21548cd2f3541de7050"
-dependencies = [
- "async-trait",
  "base64",
  "bytes",
  "chrono",
  "futures",
  "humantime",
  "hyper",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml",
  "rand",
  "reqwest",
- "ring 0.17.3",
+ "ring",
  "serde",
  "serde_json",
  "snafu",
@@ -2799,7 +2778,7 @@ dependencies = [
  "lz4",
  "num",
  "num-bigint",
- "object_store 0.7.0",
+ "object_store",
  "paste",
  "seq-macro",
  "snap",
@@ -3187,9 +3166,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "memchr",
  "serde",
@@ -3434,24 +3413,10 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
+ "spin",
+ "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
-dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3531,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring 0.16.20",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -3551,8 +3516,8 @@ version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3600,8 +3565,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3754,12 +3719,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
@@ -4387,12 +4346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,7 +4388,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-proto",
  "jni",
- "object_store 0.8.0",
+ "object_store",
  "pyo3",
  "serde_json",
  "sqlparser 0.37.0",
@@ -4561,7 +4514,7 @@ dependencies = [
  "log",
  "lru",
  "num-traits",
- "object_store 0.8.0",
+ "object_store",
  "ordered-float 3.6.0",
  "prost",
  "prost-types",
@@ -4623,6 +4576,7 @@ dependencies = [
  "deterministic-hash",
  "lazy_static",
  "log",
+ "object_store",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -4635,6 +4589,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "url",
  "vegafusion-common",
  "vegafusion-dataframe",
  "vegafusion-datafusion-udfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ members = [
 arrow = { version = "47.0.0", default_features = false }
 sqlparser = { version = "0.37.0" }
 chrono = { version = "0.4.31", default_features = false }
-reqwest = { version = "=0.11.13", default-features = false }
+reqwest = { version = "0.11.22", default-features = false }
 tokio = { version = "1.32.0" }
 pyo3 = { version = "0.19" }
 prost = { version = "0.12.1" }
 prost-types = { version = "0.12.1" }
+object_store = { version="0.8.0" }
 
 datafusion = { version = "32.0.0" }
 datafusion-common = { version = "32.0.0", default_features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.32.0" }
 pyo3 = { version = "0.19" }
 prost = { version = "0.12.1" }
 prost-types = { version = "0.12.1" }
-object_store = { version="0.8.0" }
+object_store = { version="0.7" }
 
 datafusion = { version = "32.0.0" }
 datafusion-common = { version = "32.0.0", default_features = false}

--- a/automation/start_minio.py
+++ b/automation/start_minio.py
@@ -1,0 +1,74 @@
+from minio import Minio
+from minio.error import S3Error
+import os
+import subprocess
+import time
+from pathlib import Path
+import shutil
+
+root = Path(__file__).parent.parent
+
+
+def main():
+    access_key = "access_key123"
+    secret_key = "secret_key123"
+    print("Starting minio")
+    p = start_minio_server(access_key, secret_key)
+    time.sleep(1)
+
+    # Create a client with the MinIO server playground, its access key
+    # and secret key.
+    client = Minio(
+        "localhost:9000",
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=False,
+    )
+
+    # Make 'data' bucket if it does not exist
+    print("Loading test data to the 'data' bucket")
+    found = client.bucket_exists("data")
+    if not found:
+        client.make_bucket("data")
+    else:
+        print("Bucket 'data' already exists")
+
+    for fname in ["movies.json", "barley.json", "disasters.csv", "github.csv"]:
+        client.fput_object(
+            "data",
+            fname, root / "vegafusion-runtime" / "tests" / "util" / "vegajs_runtime" / "data" / fname,
+        )
+
+    print("Data loaded")
+    print(f"""
+Open dashboard at http://127.0.0.1:9000
+username: {access_key}
+password: {secret_key}
+""")
+    # Block on the server
+    p.wait()
+
+
+def start_minio_server(access_key, secret_key):
+    # Set environment variables for access and secret keys
+    env = os.environ.copy()
+    env["MINIO_ROOT_USER"] = access_key
+    env["MINIO_ROOT_PASSWORD"] = secret_key
+    env["MINIO_REGION"] = "us-east-1"
+
+    # Command to start MinIO server
+    data_dir = root / "minio_data"
+    shutil.rmtree(data_dir, ignore_errors=True)
+    cmd = ["minio", "server", "minio_data"]
+
+    # Start MinIO server in the background
+    process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    return process
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except S3Error as exc:
+        print("error occurred.", exc)

--- a/automation/start_minio.py
+++ b/automation/start_minio.py
@@ -94,7 +94,8 @@ username: {access_key}
 password: {secret_key}
 """)
     # Block on the server
-    p.wait()
+    # p.wait()
+    p.terminate()
 
 
 def start_minio_server(access_key, secret_key):

--- a/automation/start_minio.py
+++ b/automation/start_minio.py
@@ -7,9 +7,9 @@ from pathlib import Path
 import shutil
 from tempfile import NamedTemporaryFile
 import pandas as pd
-from vegafusion.transformer import to_feather
 from csv import QUOTE_ALL
 from io import BytesIO
+import pyarrow as pa
 
 root = Path(__file__).parent.parent
 
@@ -61,13 +61,14 @@ def main():
         )
 
     # Convert to arrow
-    with NamedTemporaryFile("wb") as f:
-        to_feather(df, f)
-        client.fput_object(
-            "data",
-            "movies.arrow",
-            f.name,
-        )
+    tbl = pa.Table.from_pandas(df)
+    b = arrow_table_to_ipc_bytes(tbl)
+    client.put_object(
+        "data",
+        "movies.arrow",
+        BytesIO(b),
+        len(b)
+    )
 
     # Convert to parquet. For some reason, uploading to minio with client.fput_object
     # (as above for arrow) results in a parquet file with corrupt footer.
@@ -109,6 +110,15 @@ def start_minio_server(access_key, secret_key):
     process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     return process
+
+
+def arrow_table_to_ipc_bytes(table):
+    bytes_buffer = BytesIO()
+    max_chunksize=8096
+    with pa.ipc.new_file(bytes_buffer, table.schema) as f:
+        f.write_table(table, max_chunksize=max_chunksize)
+
+    return bytes_buffer.getvalue()
 
 
 if __name__ == "__main__":

--- a/automation/start_minio.py
+++ b/automation/start_minio.py
@@ -94,8 +94,7 @@ username: {access_key}
 password: {secret_key}
 """)
     # Block on the server
-    # p.wait()
-    p.terminate()
+    p.wait()
 
 
 def start_minio_server(access_key, secret_key):

--- a/automation/start_minio.py
+++ b/automation/start_minio.py
@@ -5,7 +5,6 @@ import subprocess
 import time
 from pathlib import Path
 import shutil
-from tempfile import NamedTemporaryFile
 import pandas as pd
 from csv import QUOTE_ALL
 from io import BytesIO
@@ -52,13 +51,17 @@ def main():
     df["Release Date"] = pd.to_datetime(df["Release Date"])
 
     # Convert to csv
-    with NamedTemporaryFile("wb") as f:
-        df.to_csv(f, index=False, quoting=QUOTE_ALL)
-        client.fput_object(
-            "data",
-            "movies.csv",
-            f.name,
-        )
+    f = BytesIO()
+    df.to_csv(f, index=False, quoting=QUOTE_ALL)
+    b = f.getvalue()
+    n = len(b)
+
+    client.put_object(
+        "data",
+        "movies.csv",
+        BytesIO(b),
+        n
+    )
 
     # Convert to arrow
     tbl = pa.Table.from_pandas(df)

--- a/pixi.lock
+++ b/pixi.lock
@@ -4466,6 +4466,90 @@ package:
   noarch: python
   size: 11682
   timestamp: 1691045097208
+- name: configparser
+  version: 5.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: c99fd5916160900dc5ff64204da99c4d
+    sha256: ce6ce9ee08437b46c284d52b076fb091cf6f2a9e12860d4a37546adbd5f53b28
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 22490
+  timestamp: 1660952265700
+- name: configparser
+  version: 5.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: c99fd5916160900dc5ff64204da99c4d
+    sha256: ce6ce9ee08437b46c284d52b076fb091cf6f2a9e12860d4a37546adbd5f53b28
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 22490
+  timestamp: 1660952265700
+- name: configparser
+  version: 5.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: c99fd5916160900dc5ff64204da99c4d
+    sha256: ce6ce9ee08437b46c284d52b076fb091cf6f2a9e12860d4a37546adbd5f53b28
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 22490
+  timestamp: 1660952265700
+- name: configparser
+  version: 5.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: c99fd5916160900dc5ff64204da99c4d
+    sha256: ce6ce9ee08437b46c284d52b076fb091cf6f2a9e12860d4a37546adbd5f53b28
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 22490
+  timestamp: 1660952265700
 - name: coverage
   version: 7.3.2
   manager: conda
@@ -5869,6 +5953,90 @@ package:
   license: LGPL-2.1
   size: 60255
   timestamp: 1604417405528
+- name: future
+  version: 0.18.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: fec8329fc739090f26a7d7803db254f1
+    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 365520
+  timestamp: 1673596757510
+- name: future
+  version: 0.18.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: fec8329fc739090f26a7d7803db254f1
+    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 365520
+  timestamp: 1673596757510
+- name: future
+  version: 0.18.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: fec8329fc739090f26a7d7803db254f1
+    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 365520
+  timestamp: 1673596757510
+- name: future
+  version: 0.18.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: fec8329fc739090f26a7d7803db254f1
+    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 365520
+  timestamp: 1673596757510
 - name: gcc_impl_linux-64
   version: 13.2.0
   manager: conda
@@ -14580,6 +14748,192 @@ package:
   noarch: python
   size: 13707
   timestamp: 1639515992326
+- name: minio
+  version: 7.1.17
+  manager: conda
+  platform: linux-64
+  dependencies:
+    certifi: '*'
+    configparser: '*'
+    future: '*'
+    python: '>=3.6'
+    python-dateutil: '*'
+    pytz: '*'
+    urllib3: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
+  hash:
+    md5: 37a6599b8de3b46f8faff4aeb55b718f
+    sha256: 845cea4347a5b40d08caf013a7ae4aefe0112a66dd3bf0aa334068a3a5db962c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 59925
+  timestamp: 1695627015341
+- name: minio
+  version: 7.1.17
+  manager: conda
+  platform: osx-64
+  dependencies:
+    certifi: '*'
+    configparser: '*'
+    future: '*'
+    python: '>=3.6'
+    python-dateutil: '*'
+    pytz: '*'
+    urllib3: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
+  hash:
+    md5: 37a6599b8de3b46f8faff4aeb55b718f
+    sha256: 845cea4347a5b40d08caf013a7ae4aefe0112a66dd3bf0aa334068a3a5db962c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 59925
+  timestamp: 1695627015341
+- name: minio
+  version: 7.1.17
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    certifi: '*'
+    configparser: '*'
+    future: '*'
+    python: '>=3.6'
+    python-dateutil: '*'
+    pytz: '*'
+    urllib3: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
+  hash:
+    md5: 37a6599b8de3b46f8faff4aeb55b718f
+    sha256: 845cea4347a5b40d08caf013a7ae4aefe0112a66dd3bf0aa334068a3a5db962c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 59925
+  timestamp: 1695627015341
+- name: minio
+  version: 7.1.17
+  manager: conda
+  platform: win-64
+  dependencies:
+    certifi: '*'
+    configparser: '*'
+    future: '*'
+    python: '>=3.6'
+    python-dateutil: '*'
+    pytz: '*'
+    urllib3: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
+  hash:
+    md5: 37a6599b8de3b46f8faff4aeb55b718f
+    sha256: 845cea4347a5b40d08caf013a7ae4aefe0112a66dd3bf0aa334068a3a5db962c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 59925
+  timestamp: 1695627015341
+- name: minio-server
+  version: 2023.09.23.03.47.50
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/minio-server-2023.09.23.03.47.50-hbcca054_0.conda
+  hash:
+    md5: ff773f379a8324cefc3a904a5fcb0c27
+    sha256: 83d01977a656502d67ba01b709bdaa39730d19d4630d0965e3150fc5b76de5b1
+  optional: false
+  category: main
+  build: hbcca054_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: AGPL-3.0-only
+  license_family: AGPL
+  size: 28514641
+  timestamp: 1695661212355
+- name: minio-server
+  version: 2023.09.23.03.47.50
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/minio-server-2023.09.23.03.47.50-h8857fd0_0.conda
+  hash:
+    md5: e5631d220e6361e9945598970cb8cbd3
+    sha256: 5466cf7e24112c70405a1631f3f4fb5e86fa9e93c5beaf5ea72a9839ae75f7bb
+  optional: false
+  category: main
+  build: h8857fd0_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  constrains:
+  - __osx>=10.12
+  license: AGPL-3.0-only
+  license_family: AGPL
+  size: 29438678
+  timestamp: 1695669781862
+- name: minio-server
+  version: 2023.09.23.03.47.50
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/minio-server-2023.09.23.03.47.50-hf0a4a13_0.conda
+  hash:
+    md5: 716354cbeec9ed541b75c4d1398af8e9
+    sha256: e8ecdc8c0943cd01a1ac488f2fdea36ec74161ca1225f47c06b71934dea61ef2
+  optional: false
+  category: main
+  build: hf0a4a13_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: AGPL-3.0-only
+  license_family: AGPL
+  size: 28775220
+  timestamp: 1695661328725
+- name: minio-server
+  version: 2023.09.23.03.47.50
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/minio-server-2023.09.23.03.47.50-h56e8100_0.conda
+  hash:
+    md5: 842697378d8ac142d1dac05a310cb9eb
+    sha256: 1382416ae6dc8c5fcde90f448e03860ef0da591d2aa3e06bde312ccfb8bd5607
+  optional: false
+  category: main
+  build: h56e8100_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: AGPL-3.0-only
+  license_family: AGPL
+  size: 28599729
+  timestamp: 1695661919637
 - name: mistune
   version: 3.0.2
   manager: conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,6 +34,7 @@ test-py-jupyter-headless = { cmd = "export VEGAFUSION_TEST_HEADLESS=1 && cd pyth
 build-vegajs-runtime = { cmd = "cd vegafusion-runtime/tests/util/vegajs_runtime && npm install" }
 test-rs-core = "cargo test -p vegafusion-core $0"
 test-rs-runtime = { cmd="cargo test -p vegafusion-runtime $0",  depends_on = ["build-vegajs-runtime"] }
+test-rs-runtime-s3 = { cmd="VEGAFUSION_S3_TESTS=1 cargo test -p vegafusion-runtime $0",  depends_on = ["build-vegajs-runtime"] }
 test-rs-server = "cargo test -p vegafusion-server $0"
 test-rs-sql = "cargo test -p vegafusion-sql $0"
 test-rs = { cmd = "cargo test --workspace --exclude vegafusion-python-embed --exclude vegafusion-wasm $0", depends_on = ["build-vegajs-runtime"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,6 +50,9 @@ build-js-embed = { cmd = "cd javascript/vegafusion-embed && npm install && npm r
 # VegaFusion Server
 build-rs-vegafusion-server = { cmd = "cargo build -p vegafusion-server --release $0" }
 
+# minio
+start-minio = "python automation/start_minio.py"
+
 # Java
 build-jni = "cargo build -p vegafusion-jni --release $0"
 build-jar = "cd java && ./gradlew jar"
@@ -120,6 +123,8 @@ rust = "1.71.1.*"
 jupytext = "1.15.0.*"
 openjdk = "20.0.0.*"
 build = "0.7.0.*"
+minio-server = "2023.9.23.3.47.50.*"
+minio = "7.1.17.*"
 
 # Dependencies are those required at runtime by the Python packages
 [dependencies]

--- a/vegafusion-common/Cargo.toml
+++ b/vegafusion-common/Cargo.toml
@@ -52,3 +52,7 @@ optional = true
 [dependencies.base64]
 version = "0.21.2"
 optional = true
+
+[dependencies.object_store]
+workspace = true
+optional = true

--- a/vegafusion-dataframe/src/connection.rs
+++ b/vegafusion-dataframe/src/connection.rs
@@ -41,4 +41,11 @@ pub trait Connection: Send + Sync + 'static {
             "scan_arrow_file not supported by connection",
         ))
     }
+
+    /// Scan an Parquet file into a DataFrame
+    async fn scan_parquet(&self, _url: &str) -> Result<Arc<dyn DataFrame>> {
+        Err(VegaFusionError::sql_not_supported(
+            "scan_parquet not supported by connection",
+        ))
+    }
 }

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -35,6 +35,7 @@ env_logger = "0.10.0"
 ordered-float = "3.6.0"
 reqwest-retry = "0.3.0"
 reqwest-middleware = "0.2.0"
+object_store = { workspace=true, features = ["aws"] }
 
 [dev-dependencies]
 futures = "0.3.21"
@@ -64,7 +65,7 @@ workspace = true
 
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
-features = [ "json", "sqlparser", "prettyprint",]
+features = [ "json", "sqlparser", "prettyprint", "object_store"]
 version = "1.4.3"
 
 [dependencies.vegafusion-core]

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -27,6 +27,8 @@ use vegafusion_core::proto::gen::transforms::TransformPipeline;
 use vegafusion_core::task_graph::task::{InputVariable, TaskDependencies};
 use vegafusion_core::task_graph::task_value::TaskValue;
 
+use object_store::aws::AmazonS3Builder;
+use object_store::ObjectStore;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use vegafusion_common::arrow::datatypes::{DataType, Field, Schema};
@@ -634,6 +636,21 @@ async fn read_json(url: &str, conn: Arc<dyn Connection>) -> Result<Arc<dyn DataF
             .external("Failed to convert URL data to text")?;
 
         serde_json::from_str(&body)?
+    } else if let Some(bucket_path) = url.strip_prefix("s3://") {
+        let s3= AmazonS3Builder::from_env().with_url(url).build().with_context(||
+            format!(
+                "Failed to initialize s3 connection from environment variables.\n\
+                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env"
+            )
+        )?;
+        let Some((_, path)) = bucket_path.split_once("/") else {
+            return Err(VegaFusionError::specification(format!("Invalid s3 URL: {url}")));
+        };
+        let path = object_store::path::Path::from_url_path(path)?;
+        let get_result = s3.get(&path).await?;
+        let b = get_result.bytes().await?;
+        let text = String::from_utf8_lossy(b.as_ref());
+        serde_json::from_str(text.as_ref())?
     } else {
         // Assume local file
         let mut file = tokio::fs::File::open(url)

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -144,6 +144,10 @@ impl TaskCall for DataUrlTask {
             || (file_type.is_none() && (url.ends_with(".arrow") || url.ends_with(".feather")))
         {
             read_arrow(&url, conn).await?
+        } else if file_type == Some("parquet")
+            || (file_type.is_none() && (url.ends_with(".parquet")))
+        {
+            read_parquet(&url, conn).await?
         } else {
             return Err(VegaFusionError::internal(format!(
                 "Invalid url file extension {url}"
@@ -672,6 +676,10 @@ async fn read_json(url: &str, conn: Arc<dyn Connection>) -> Result<Arc<dyn DataF
 
 async fn read_arrow(url: &str, conn: Arc<dyn Connection>) -> Result<Arc<dyn DataFrame>> {
     conn.scan_arrow_file(url).await
+}
+
+async fn read_parquet(url: &str, conn: Arc<dyn Connection>) -> Result<Arc<dyn DataFrame>> {
+    conn.scan_parquet(url).await
 }
 
 pub fn make_request_client() -> ClientWithMiddleware {

--- a/vegafusion-runtime/tests/test_pre_transform_values.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_values.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::{crate_dir, setup_s3_environment_vars};
     use serde_json::json;
     use std::collections::HashMap;
+    use std::env;
     use std::fs;
     use std::sync::Arc;
     use vegafusion_common::data::table::VegaFusionTable;
@@ -355,6 +356,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_pre_transform_dataset_s3() {
+        let run_s3_tests = env::var("VEGAFUSION_S3_TESTS").is_ok();
+        if !run_s3_tests {
+            return;
+        }
+
         // Note: s3 tests require the pixi start-minio job
         setup_s3_environment_vars();
 

--- a/vegafusion-runtime/tests/test_pre_transform_values.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_values.rs
@@ -10,7 +10,6 @@ mod tests {
     use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType;
     use vegafusion_core::proto::gen::tasks::Variable;
     use vegafusion_core::spec::chart::ChartSpec;
-    use vegafusion_core::spec::data::{DataFormatParseSpec, DataFormatSpec};
     use vegafusion_core::spec::values::StringOrSignalSpec;
     use vegafusion_runtime::data::dataset::VegaFusionDataset;
     use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
@@ -364,14 +363,12 @@ mod tests {
         let spec_str = fs::read_to_string(spec_path).unwrap();
         let mut spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
-        for file_type in [
-            "json",
-            "csv",
-            "arrow"
-        ] {
+        for file_type in ["json", "csv", "arrow", "parquet"] {
             // Prefix data/movies.json with s3://
             println!("File type: {file_type}");
-            spec.data[0].url = Some(StringOrSignalSpec::String(format!("s3://data/movies.{file_type}")));
+            spec.data[0].url = Some(StringOrSignalSpec::String(format!(
+                "s3://data/movies.{file_type}"
+            )));
 
             // Initialize task graph runtime
             let runtime = VegaFusionRuntime::new(

--- a/vegafusion-sql/Cargo.toml
+++ b/vegafusion-sql/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "VegaFusion SQL dialect generation and connection implementations"
 
 [features]
-datafusion-conn = [ "datafusion", "tempfile", "reqwest", "reqwest-retry", "reqwest-middleware", "vegafusion-datafusion-udfs",]
+datafusion-conn = [ "datafusion", "tempfile", "reqwest", "reqwest-retry", "reqwest-middleware", "vegafusion-datafusion-udfs", "object_store", "url"]
 
 [dependencies]
 async-trait = "0.1.73"
@@ -74,6 +74,15 @@ optional = true
 
 [dependencies.regex]
 version = "^1.5.5"
+optional = true
+
+[dependencies.object_store]
+workspace = true
+optional = true
+features = [ "aws",]
+
+[dependencies.url]
+version = "2.3.1"
 optional = true
 
 [dev-dependencies.async-std]


### PR DESCRIPTION
This PR adds initial support for loading input files from s3, and for parquet support. Includes:

 - Use object_store::aws::AmazonS3Builder to support loading json, csv, arrow, and parquet files from s3. Credentials are pulled from environment variables per https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env.
 - Support loading parquet files from the local file system and from s3 (no support for http/https yet).

For testing, I added a pixi dependency on minio and added the `pixi start minio` task that start's minio with pre-determined credentials and loads sample data.