### PR TITLE
Add ChartState for managing interactive chart state in Python

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -351,9 +351,6 @@ jobs:
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
           python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-
-          # Downgrade pyarrow to 10.0.1
-          python -m pip install pyarrow==10.0.1
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/vegafusion-core/src/expression/visitors.rs
+++ b/vegafusion-core/src/expression/visitors.rs
@@ -212,7 +212,7 @@ impl ExpressionVisitor for CheckSupportedExprVisitor {
                 ..
             })) = &args[1].expr
             {
-                if v != "" {
+                if !v.is_empty() {
                     self.supported = false;
                 }
             } else {

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -126,7 +126,7 @@ impl PlannerConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SpecPlan {
     pub server_spec: ChartSpec,
     pub client_spec: ChartSpec,

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -6,7 +6,7 @@ import "tasks.proto";
 /// Pre transform spec messages
 message PreTransformSpecOpts {
   optional uint32 row_limit = 1;
-  repeated PreTransformInlineDataset inline_datasets = 2;
+  repeated tasks.InlineDataset inline_datasets = 2;
   bool preserve_interactivity = 3;
   repeated PreTransformVariable keep_variables = 4;
 }
@@ -50,7 +50,7 @@ message PreTransformVariable {
 
 message PreTransformValuesOpts {
   repeated PreTransformVariable variables = 1;
-  repeated PreTransformInlineDataset inline_datasets = 2;
+  repeated tasks.InlineDataset inline_datasets = 2;
   optional uint32 row_limit = 3;
 }
 
@@ -74,13 +74,6 @@ message PreTransformValuesWarning {
 }
 
 /// Common pre-transform messages
-message PreTransformInlineDataset {
-  // Inline dataset name
-  string name = 1;
-  // Serialized Arrow record batch in Arrow IPC format
-  bytes table = 2;
-}
-
 message PlannerWarning {
   string message = 1;
 }
@@ -115,6 +108,6 @@ message PreTransformExtractRequest {
   optional string default_input_tz = 3;
   bool preserve_interactivity = 4;
   int32 extract_threshold = 5;
-  repeated PreTransformInlineDataset inline_datasets = 6;
+  repeated tasks.InlineDataset inline_datasets = 6;
   repeated PreTransformVariable keep_variables = 7;
 }

--- a/vegafusion-core/src/proto/prost_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/prost_gen/pretransform.rs
@@ -5,7 +5,7 @@ pub struct PreTransformSpecOpts {
     #[prost(uint32, optional, tag = "1")]
     pub row_limit: ::core::option::Option<u32>,
     #[prost(message, repeated, tag = "2")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(bool, tag = "3")]
     pub preserve_interactivity: bool,
     #[prost(message, repeated, tag = "4")]
@@ -82,7 +82,7 @@ pub struct PreTransformValuesOpts {
     #[prost(message, repeated, tag = "1")]
     pub variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
     #[prost(message, repeated, tag = "2")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(uint32, optional, tag = "3")]
     pub row_limit: ::core::option::Option<u32>,
 }
@@ -124,16 +124,6 @@ pub mod pre_transform_values_warning {
     }
 }
 /// / Common pre-transform messages
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PreTransformInlineDataset {
-    /// Inline dataset name
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Serialized Arrow record batch in Arrow IPC format
-    #[prost(bytes = "vec", tag = "2")]
-    pub table: ::prost::alloc::vec::Vec<u8>,
-}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlannerWarning {
@@ -193,7 +183,7 @@ pub struct PreTransformExtractRequest {
     #[prost(int32, tag = "5")]
     pub extract_threshold: i32,
     #[prost(message, repeated, tag = "6")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(message, repeated, tag = "7")]
     pub keep_variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
 }

--- a/vegafusion-core/src/proto/prost_gen/tasks.rs
+++ b/vegafusion-core/src/proto/prost_gen/tasks.rs
@@ -233,6 +233,8 @@ pub struct TaskGraphValueRequest {
     pub task_graph: ::core::option::Option<TaskGraph>,
     #[prost(message, repeated, tag = "2")]
     pub indices: ::prost::alloc::vec::Vec<NodeValueIndex>,
+    #[prost(message, repeated, tag = "3")]
+    pub inline_datasets: ::prost::alloc::vec::Vec<InlineDataset>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -249,6 +251,16 @@ pub struct ResponseTaskValue {
 pub struct TaskGraphValueResponse {
     #[prost(message, repeated, tag = "1")]
     pub response_values: ::prost::alloc::vec::Vec<ResponseTaskValue>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InlineDataset {
+    /// Inline dataset name
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Serialized Arrow record batch in Arrow IPC format
+    #[prost(bytes = "vec", tag = "2")]
+    pub table: ::prost::alloc::vec::Vec<u8>,
 }
 /// ## Variable
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/vegafusion-core/src/proto/tasks.proto
+++ b/vegafusion-core/src/proto/tasks.proto
@@ -150,6 +150,7 @@ message NodeValueIndex {
 message TaskGraphValueRequest {
   TaskGraph task_graph = 1;
   repeated NodeValueIndex indices = 2;
+  repeated InlineDataset inline_datasets = 3;
 }
 
 message ResponseTaskValue {
@@ -160,4 +161,11 @@ message ResponseTaskValue {
 
 message TaskGraphValueResponse {
   repeated ResponseTaskValue response_values = 1;
+}
+
+message InlineDataset {
+  // Inline dataset name
+  string name = 1;
+  // Serialized Arrow record batch in Arrow IPC format
+  bytes table = 2;
 }

--- a/vegafusion-core/src/proto/tonic_gen/pretransform.rs
+++ b/vegafusion-core/src/proto/tonic_gen/pretransform.rs
@@ -5,7 +5,7 @@ pub struct PreTransformSpecOpts {
     #[prost(uint32, optional, tag = "1")]
     pub row_limit: ::core::option::Option<u32>,
     #[prost(message, repeated, tag = "2")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(bool, tag = "3")]
     pub preserve_interactivity: bool,
     #[prost(message, repeated, tag = "4")]
@@ -82,7 +82,7 @@ pub struct PreTransformValuesOpts {
     #[prost(message, repeated, tag = "1")]
     pub variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
     #[prost(message, repeated, tag = "2")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(uint32, optional, tag = "3")]
     pub row_limit: ::core::option::Option<u32>,
 }
@@ -124,16 +124,6 @@ pub mod pre_transform_values_warning {
     }
 }
 /// / Common pre-transform messages
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PreTransformInlineDataset {
-    /// Inline dataset name
-    #[prost(string, tag = "1")]
-    pub name: ::prost::alloc::string::String,
-    /// Serialized Arrow record batch in Arrow IPC format
-    #[prost(bytes = "vec", tag = "2")]
-    pub table: ::prost::alloc::vec::Vec<u8>,
-}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlannerWarning {
@@ -193,7 +183,7 @@ pub struct PreTransformExtractRequest {
     #[prost(int32, tag = "5")]
     pub extract_threshold: i32,
     #[prost(message, repeated, tag = "6")]
-    pub inline_datasets: ::prost::alloc::vec::Vec<PreTransformInlineDataset>,
+    pub inline_datasets: ::prost::alloc::vec::Vec<super::tasks::InlineDataset>,
     #[prost(message, repeated, tag = "7")]
     pub keep_variables: ::prost::alloc::vec::Vec<PreTransformVariable>,
 }

--- a/vegafusion-core/src/proto/tonic_gen/tasks.rs
+++ b/vegafusion-core/src/proto/tonic_gen/tasks.rs
@@ -233,6 +233,8 @@ pub struct TaskGraphValueRequest {
     pub task_graph: ::core::option::Option<TaskGraph>,
     #[prost(message, repeated, tag = "2")]
     pub indices: ::prost::alloc::vec::Vec<NodeValueIndex>,
+    #[prost(message, repeated, tag = "3")]
+    pub inline_datasets: ::prost::alloc::vec::Vec<InlineDataset>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -249,6 +251,16 @@ pub struct ResponseTaskValue {
 pub struct TaskGraphValueResponse {
     #[prost(message, repeated, tag = "1")]
     pub response_values: ::prost::alloc::vec::Vec<ResponseTaskValue>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InlineDataset {
+    /// Inline dataset name
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Serialized Arrow record batch in Arrow IPC format
+    #[prost(bytes = "vec", tag = "2")]
+    pub table: ::prost::alloc::vec::Vec<u8>,
 }
 /// ## Variable
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/vegafusion-core/src/spec/values.rs
+++ b/vegafusion-core/src/spec/values.rs
@@ -141,8 +141,9 @@ impl SortOrderOrList {
 }
 
 /// Helper struct that will not drop null values on round trip (de)serialization
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum MissingNullOrValue {
+    #[default]
     Missing,
     Null,
     Value(serde_json::Value),
@@ -159,12 +160,6 @@ impl MissingNullOrValue {
             MissingNullOrValue::Null => Some(serde_json::Value::Null),
             MissingNullOrValue::Value(v) => Some(v.clone()),
         }
-    }
-}
-
-impl Default for MissingNullOrValue {
-    fn default() -> Self {
-        MissingNullOrValue::Missing
     }
 }
 

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -74,6 +74,7 @@ impl ChartState {
 
 #[pymethods]
 impl ChartState {
+    /// Update chart state with updates from the client
     pub fn update(&self, py: Python, updates: Vec<PyObject>) -> PyResult<Vec<PyObject>> {
         let updates = updates
             .into_iter()
@@ -91,15 +92,23 @@ impl ChartState {
         Ok(a)
     }
 
+    /// Get ChartState's initial input spec
+    pub fn get_input_spec(&self, py: Python) -> PyResult<PyObject> {
+        Ok(pythonize(py, self.state.get_input_spec())?)
+    }
+
+    /// Get ChartState's initial transformed spec
     pub fn get_transformed_spec(&self, py: Python) -> PyResult<PyObject> {
         Ok(pythonize(py, self.state.get_transformed_spec())?)
     }
 
+    /// Get ChartState's watch plan
     pub fn get_watch_plan(&self, py: Python) -> PyResult<PyObject> {
         let watch_plan = WatchPlan::from(self.state.get_comm_plan().clone());
         Ok(pythonize(py, &watch_plan)?)
     }
 
+    /// Get list of transform warnings
     pub fn get_warnings(&self, py: Python) -> PyResult<PyObject> {
         let warnings: Vec<_> = self
             .state

--- a/vegafusion-runtime/benches/spec_benchmarks.rs
+++ b/vegafusion-runtime/benches/spec_benchmarks.rs
@@ -67,10 +67,11 @@ async fn eval_spec_get_variable(full_spec: ChartSpec, var: &ScopedVariable) -> Q
         request: Some(Request::TaskGraphValues(TaskGraphValueRequest {
             task_graph: Some(task_graph.clone()),
             indices: vec![node_index.clone()],
+            inline_datasets: vec![],
         })),
     };
 
-    runtime.query_request(request).await.unwrap()
+    runtime.query_request_message(request).await.unwrap()
 }
 
 async fn eval_spec_sequence(full_spec: ChartSpec, full_updates: Vec<ExportUpdateBatch>) {
@@ -118,9 +119,10 @@ async fn eval_spec_sequence(full_spec: ChartSpec, full_updates: Vec<ExportUpdate
         request: Some(Request::TaskGraphValues(TaskGraphValueRequest {
             task_graph: Some(task_graph.clone()),
             indices: query_indices,
+            inline_datasets: vec![],
         })),
     };
-    let _response = runtime.query_request(request).await.unwrap();
+    let _response = runtime.query_request_message(request).await.unwrap();
 
     // Get update values
     for update_batch in full_updates {
@@ -137,9 +139,10 @@ async fn eval_spec_sequence(full_spec: ChartSpec, full_updates: Vec<ExportUpdate
             request: Some(Request::TaskGraphValues(TaskGraphValueRequest {
                 task_graph: Some(task_graph.clone()),
                 indices: query_indices,
+                inline_datasets: vec![],
             })),
         };
-        let _response = runtime.query_request(request).await.unwrap();
+        let _response = runtime.query_request_message(request).await.unwrap();
     }
 }
 

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -642,12 +642,10 @@ async fn read_json(url: &str, conn: Arc<dyn Connection>) -> Result<Arc<dyn DataF
         serde_json::from_str(&body)?
     } else if let Some(bucket_path) = url.strip_prefix("s3://") {
         let s3= AmazonS3Builder::from_env().with_url(url).build().with_context(||
-            format!(
-                "Failed to initialize s3 connection from environment variables.\n\
-                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env"
-            )
+            "Failed to initialize s3 connection from environment variables.\n\
+                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env".to_string()
         )?;
-        let Some((_, path)) = bucket_path.split_once("/") else {
+        let Some((_, path)) = bucket_path.split_once('/') else {
             return Err(VegaFusionError::specification(format!("Invalid s3 URL: {url}")));
         };
         let path = object_store::path::Path::from_url_path(path)?;

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/format.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/format.rs
@@ -17,7 +17,7 @@ use vegafusion_core::error::{Result, VegaFusionError};
 pub fn format_transform(args: &[Expr], schema: &DFSchema) -> Result<Expr> {
     if args.len() == 2 {
         match &args[1] {
-            Expr::Literal(ScalarValue::Utf8(Some(s))) if s == "" => {
+            Expr::Literal(ScalarValue::Utf8(Some(s))) if s.is_empty() => {
                 let arg = to_numeric(args[0].clone(), schema)?;
                 if is_integer_datatype(&arg.get_type(schema)?) {
                     // Integer type, just cast to string

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -1035,7 +1035,7 @@ impl ChartState {
             )
             .await?;
 
-        let response_updates = response_task_values
+        let mut response_updates = response_task_values
             .into_iter()
             .map(|response_value| {
                 let variable = response_value
@@ -1065,6 +1065,9 @@ impl ChartState {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+
+        // Sort for deterministic ordering
+        response_updates.sort_by_key(|update| update.name.clone());
 
         Ok(response_updates)
     }

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -20,7 +20,7 @@ use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
 use vegafusion_core::planning::stitch::CommPlan;
 use vegafusion_core::planning::watch::{
-    ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace, WatchPlan,
+    ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace,
 };
 use vegafusion_core::proto::gen::errors::error::Errorkind;
 use vegafusion_core::proto::gen::errors::{Error, TaskGraphValueError};
@@ -1067,6 +1067,10 @@ impl ChartState {
             .collect::<Result<Vec<_>>>()?;
 
         Ok(response_updates)
+    }
+
+    pub fn get_input_spec(&self) -> &ChartSpec {
+        &self.input_spec
     }
 
     pub fn get_transformed_spec(&self) -> &ChartSpec {

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -8,18 +8,20 @@ use crate::pre_transform::destringify_selection_datetimes::destringify_selection
 use crate::task_graph::cache::VegaFusionCache;
 use crate::task_graph::task::TaskCall;
 use crate::task_graph::timezone::RuntimeTzConfig;
+use datafusion_common::ScalarValue;
 use futures_util::{future, FutureExt};
 use prost::Message as ProstMessage;
 use serde_json::Value;
 use std::convert::{TryFrom, TryInto};
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
-use datafusion_common::ScalarValue;
 use vegafusion_common::data::scalar::ScalarValueHelpers;
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
 use vegafusion_core::planning::stitch::CommPlan;
-use vegafusion_core::planning::watch::{ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace, WatchPlan};
+use vegafusion_core::planning::watch::{
+    ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace, WatchPlan,
+};
 use vegafusion_core::proto::gen::errors::error::Errorkind;
 use vegafusion_core::proto::gen::errors::{Error, TaskGraphValueError};
 use vegafusion_core::proto::gen::pretransform::pre_transform_spec_warning::WarningType;
@@ -39,8 +41,10 @@ use vegafusion_core::proto::gen::services::{
     query_request, query_result, PreTransformExtractResult, PreTransformSpecResult,
     PreTransformValuesResult, QueryRequest, QueryResult,
 };
-use vegafusion_core::proto::gen::services::query_result::Response;
-use vegafusion_core::proto::gen::tasks::{task::TaskKind, NodeValueIndex, ResponseTaskValue, TaskGraph, TaskGraphValueResponse, TaskValue as ProtoTaskValue, TzConfig, Variable, VariableNamespace, TaskGraphValueRequest};
+use vegafusion_core::proto::gen::tasks::{
+    task::TaskKind, InlineDataset, NodeValueIndex, ResponseTaskValue, TaskGraph,
+    TaskGraphValueResponse, TaskValue as ProtoTaskValue, TzConfig, Variable, VariableNamespace,
+};
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::spec::values::MissingNullOrValue;
 use vegafusion_core::task_graph::graph::ScopedVariable;
@@ -95,57 +99,69 @@ impl VegaFusionRuntime {
         })
     }
 
-    pub async fn query_request(&self, request: QueryRequest) -> Result<QueryResult> {
+    pub async fn query_request(
+        &self,
+        task_graph: Arc<TaskGraph>,
+        indices: &[NodeValueIndex],
+        inline_datasets: &HashMap<String, VegaFusionDataset>,
+    ) -> Result<Vec<ResponseTaskValue>> {
+        // Clone task_graph and task_graph_runtime for use in closure
+        let task_graph_runtime = self.clone();
+        let response_value_futures: Vec<_> = indices
+            .iter()
+            .map(|node_value_index| {
+                let node = task_graph
+                    .nodes
+                    .get(node_value_index.node_index as usize)
+                    .with_context(|| {
+                        format!(
+                            "Node index {} out of bounds for graph with size {}",
+                            node_value_index.node_index,
+                            task_graph.nodes.len()
+                        )
+                    })?;
+                let task = node.task();
+                let var = match node_value_index.output_index {
+                    None => task.variable().clone(),
+                    Some(output_index) => task.output_vars()[output_index as usize].clone(),
+                };
+
+                let scope = node.task().scope.clone();
+
+                // Clone task_graph and task_graph_runtime for use in closure
+                let task_graph_runtime = task_graph_runtime.clone();
+                let task_graph = task_graph.clone();
+
+                Ok(async move {
+                    let value = task_graph_runtime
+                        .clone()
+                        .get_node_value(task_graph, node_value_index, inline_datasets.clone())
+                        .await?;
+
+                    Ok::<_, VegaFusionError>(ResponseTaskValue {
+                        variable: Some(var),
+                        scope,
+                        value: Some(ProtoTaskValue::try_from(&value).unwrap()),
+                    })
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        future::try_join_all(response_value_futures).await
+    }
+
+    pub async fn query_request_message(&self, request: QueryRequest) -> Result<QueryResult> {
         match request.request {
             Some(query_request::Request::TaskGraphValues(task_graph_values)) => {
                 let task_graph = Arc::new(task_graph_values.task_graph.unwrap());
+                let indices = &task_graph_values.indices;
+                let inline_datasets =
+                    Self::decode_inline_datasets(task_graph_values.inline_datasets)?;
 
-                // Clone task_graph and task_graph_runtime for use in closure
-                let task_graph_runtime = self.clone();
-                let task_graph = task_graph.clone();
-
-                let response_value_futures: Vec<_> = task_graph_values
-                    .indices
-                    .iter()
-                    .map(|node_value_index| {
-                        let node = task_graph
-                            .nodes
-                            .get(node_value_index.node_index as usize)
-                            .with_context(|| {
-                                format!(
-                                    "Node index {} out of bounds for graph with size {}",
-                                    node_value_index.node_index,
-                                    task_graph.nodes.len()
-                                )
-                            })?;
-                        let task = node.task();
-                        let var = match node_value_index.output_index {
-                            None => task.variable().clone(),
-                            Some(output_index) => task.output_vars()[output_index as usize].clone(),
-                        };
-
-                        let scope = node.task().scope.clone();
-
-                        // Clone task_graph and task_graph_runtime for use in closure
-                        let task_graph_runtime = task_graph_runtime.clone();
-                        let task_graph = task_graph.clone();
-
-                        Ok(async move {
-                            let value = task_graph_runtime
-                                .clone()
-                                .get_node_value(task_graph, node_value_index, Default::default())
-                                .await?;
-
-                            Ok::<_, VegaFusionError>(ResponseTaskValue {
-                                variable: Some(var),
-                                scope,
-                                value: Some(ProtoTaskValue::try_from(&value).unwrap()),
-                            })
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                match future::try_join_all(response_value_futures).await {
+                match self
+                    .query_request(task_graph, indices.as_slice(), &inline_datasets)
+                    .await
+                {
                     Ok(response_values) => {
                         let response_msg = QueryResult {
                             response: Some(query_result::Response::TaskGraphValues(
@@ -177,7 +193,7 @@ impl VegaFusionRuntime {
     pub async fn query_request_bytes(&self, request_bytes: &[u8]) -> Result<Vec<u8>> {
         // Decode request
         let request = QueryRequest::decode(request_bytes).unwrap();
-        let response_msg = self.query_request(request).await?;
+        let response_msg = self.query_request_message(request).await?;
 
         let mut buf: Vec<u8> = Vec::new();
         buf.reserve(response_msg.encoded_len());
@@ -210,13 +226,7 @@ impl VegaFusionRuntime {
                 (None, true, Default::default(), Default::default())
             };
 
-        let inline_datasets = inline_pretransform_datasets
-            .iter()
-            .map(|inline_dataset| {
-                let dataset = VegaFusionDataset::from_table_ipc_bytes(&inline_dataset.table)?;
-                Ok((inline_dataset.name.clone(), dataset))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
+        let inline_datasets = Self::decode_inline_datasets(inline_pretransform_datasets)?;
 
         // Parse spec
         let spec: ChartSpec = serde_json::from_str(&request.spec)?;
@@ -247,6 +257,19 @@ impl VegaFusionRuntime {
         };
 
         Ok(response)
+    }
+
+    fn decode_inline_datasets(
+        inline_pretransform_datasets: Vec<InlineDataset>,
+    ) -> Result<HashMap<String, VegaFusionDataset>> {
+        let inline_datasets = inline_pretransform_datasets
+            .iter()
+            .map(|inline_dataset| {
+                let dataset = VegaFusionDataset::from_table_ipc_bytes(&inline_dataset.table)?;
+                Ok((inline_dataset.name.clone(), dataset))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+        Ok(inline_datasets)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -290,13 +313,7 @@ impl VegaFusionRuntime {
             .map(|opts| opts.inline_datasets)
             .unwrap_or_default();
 
-        let inline_datasets = inline_pretransform_datasets
-            .iter()
-            .map(|inline_dataset| {
-                let dataset = VegaFusionDataset::from_table_ipc_bytes(&inline_dataset.table)?;
-                Ok((inline_dataset.name.clone(), dataset))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
+        let inline_datasets = Self::decode_inline_datasets(inline_pretransform_datasets)?;
 
         // Extract requested variables
         let variables: Vec<ScopedVariable> = request
@@ -481,14 +498,7 @@ impl VegaFusionRuntime {
     ) -> Result<PreTransformExtractResult> {
         // Extract and deserialize inline datasets
         let inline_pretransform_datasets = request.inline_datasets;
-
-        let inline_datasets = inline_pretransform_datasets
-            .iter()
-            .map(|inline_dataset| {
-                let dataset = VegaFusionDataset::from_table_ipc_bytes(&inline_dataset.table)?;
-                Ok((inline_dataset.name.clone(), dataset))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
+        let inline_datasets = Self::decode_inline_datasets(inline_pretransform_datasets)?;
 
         // Parse spec
         let spec_string = request.spec;
@@ -782,7 +792,12 @@ async fn get_or_compute_node_value(
     }
 }
 
-fn apply_pre_transform_datasets(input_spec: &ChartSpec, plan: &SpecPlan, init: Vec<ExportUpdateArrow>, row_limit: Option<u32>) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
+fn apply_pre_transform_datasets(
+    input_spec: &ChartSpec,
+    plan: &SpecPlan,
+    init: Vec<ExportUpdateArrow>,
+    row_limit: Option<u32>,
+) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
     // Update client spec with server values
     let mut spec = plan.client_spec.clone();
     let mut limited_datasets: Vec<Variable> = Vec::new();
@@ -802,17 +817,16 @@ fn apply_pre_transform_datasets(input_spec: &ChartSpec, plan: &SpecPlan, init: V
                 // copy the input JSON directly to avoid the case where round-tripping
                 // through Arrow homogenizes mixed type arrays.
                 // E.g. round tripping may turn [1, "two"] into ["1", "two"]
-                let input_values =
-                    input_spec
-                        .get_nested_data(&scope, name)
-                        .ok()
-                        .and_then(|data| {
-                            if data.transform.is_empty() {
-                                data.values.clone()
-                            } else {
-                                None
-                            }
-                        });
+                let input_values = input_spec
+                    .get_nested_data(&scope, name)
+                    .ok()
+                    .and_then(|data| {
+                        if data.transform.is_empty() {
+                            data.values.clone()
+                        } else {
+                            None
+                        }
+                    });
                 let value = if let Some(input_values) = input_values {
                     input_values
                 } else if let Value::Array(values) = &export_update.value {
@@ -902,7 +916,13 @@ pub struct ChartState {
 }
 
 impl ChartState {
-    pub async fn try_new(runtime: &VegaFusionRuntime, spec: ChartSpec, inline_datasets: HashMap<String, VegaFusionDataset>, tz_config: TzConfig, row_limit: Option<u32>) -> Result<Self> {
+    pub async fn try_new(
+        runtime: &VegaFusionRuntime,
+        spec: ChartSpec,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
+        tz_config: TzConfig,
+        row_limit: Option<u32>,
+    ) -> Result<Self> {
         let dataset_fingerprints = inline_datasets
             .iter()
             .map(|(k, ds)| (k.clone(), ds.fingerprint()))
@@ -921,8 +941,7 @@ impl ChartState {
         let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
         let task_graph_mapping = task_graph.build_mapping();
         let server_to_client_value_indices: Arc<HashSet<_>> = Arc::new(
-            plan
-                .comm_plan
+            plan.comm_plan
                 .server_to_client
                 .iter()
                 .map(|scoped_var| task_graph_mapping.get(scoped_var).unwrap().clone())
@@ -952,9 +971,8 @@ impl ChartState {
             });
         }
 
-        let (transformed_spec, warnings) = apply_pre_transform_datasets(
-            &spec, &plan, init, row_limit
-        )?;
+        let (transformed_spec, warnings) =
+            apply_pre_transform_datasets(&spec, &plan, init, row_limit)?;
 
         Ok(Self {
             input_spec: spec,
@@ -968,73 +986,85 @@ impl ChartState {
         })
     }
 
-    pub async fn update(&self, runtime: &VegaFusionRuntime, updates: Vec<ExportUpdateJSON>) -> Result<Vec<ExportUpdateJSON>> {
-        let mut task_graph = self.task_graph.lock().map_err(
-            |err| VegaFusionError::internal(format!("Failed to acquire task graph lock: {:?}", err))
-        )?;
+    pub async fn update(
+        &self,
+        runtime: &VegaFusionRuntime,
+        updates: Vec<ExportUpdateJSON>,
+    ) -> Result<Vec<ExportUpdateJSON>> {
+        let mut task_graph = self.task_graph.lock().map_err(|err| {
+            VegaFusionError::internal(format!("Failed to acquire task graph lock: {:?}", err))
+        })?;
         let server_to_client = self.server_to_client_value_indices.clone();
-        let mut updated_nodes: Vec<NodeValueIndex> = Vec::new();
+        let mut indices: Vec<NodeValueIndex> = Vec::new();
         for export_update in &updates {
             let var = match export_update.namespace {
                 ExportUpdateNamespace::Signal => Variable::new_signal(&export_update.name),
                 ExportUpdateNamespace::Data => Variable::new_data(&export_update.name),
             };
             let scoped_var: ScopedVariable = (var, export_update.scope.clone());
-            let node_value_index = self.task_graph_mapping.get(&scoped_var).with_context(
-                || format!("No task graph node found for {scoped_var:?}")
-            )?.clone();
+            let node_value_index = self
+                .task_graph_mapping
+                .get(&scoped_var)
+                .with_context(|| format!("No task graph node found for {scoped_var:?}"))?
+                .clone();
 
             let value = match export_update.namespace {
-                ExportUpdateNamespace::Signal => TaskValue::Scalar(ScalarValue::from_json(&export_update.value)?),
-                ExportUpdateNamespace::Data => TaskValue::Table(VegaFusionTable::from_json(&export_update.value)?)
+                ExportUpdateNamespace::Signal => {
+                    TaskValue::Scalar(ScalarValue::from_json(&export_update.value)?)
+                }
+                ExportUpdateNamespace::Data => {
+                    TaskValue::Table(VegaFusionTable::from_json(&export_update.value)?)
+                }
             };
 
-            updated_nodes.extend(
-                task_graph.update_value(node_value_index.node_index as usize, value)?
-            );
+            indices.extend(task_graph.update_value(node_value_index.node_index as usize, value)?);
         }
 
         // Filter to update nodes in the comm plan
-        let updated_nodes: Vec<_> = updated_nodes
+        let indices: Vec<_> = indices
             .iter()
             .cloned()
             .filter(|node| server_to_client.contains(node))
             .collect();
 
-        let request_msg = QueryRequest {
-            request: Some(query_request::Request::TaskGraphValues(
-                TaskGraphValueRequest {
-                    task_graph: Some(task_graph.clone()),
-                    indices: updated_nodes,
-                },
-            )),
-        };
+        let response_task_values = runtime
+            .query_request(
+                Arc::new(task_graph.clone()),
+                indices.as_slice(),
+                &self.inline_datasets,
+            )
+            .await?;
 
-        // TODO: route inline datasets through query_request
-        let a = runtime.query_request(request_msg).await?;
-        let response = a.response.with_context(|| "Query response is None")?;
+        let response_updates = response_task_values
+            .into_iter()
+            .map(|response_value| {
+                let variable = response_value
+                    .variable
+                    .with_context(|| "Missing variable for response value".to_string())?;
 
-        let response_updates: Vec<_> = match response {
-            Response::Error(err) => return Err(VegaFusionError::internal(format!("{err:?}"))),
-            Response::TaskGraphValues(task_graph_vals) => {
-                task_graph_vals.deserialize()
-                    .with_context(|| "Failed to deserialize response")?.iter().map(|(var, scope, value)| {
+                let scope = response_value.scope;
+                let proto_value = response_value
+                    .value
+                    .with_context(|| "missing value for response value: {:?}".to_string())?;
 
-                    Ok(ExportUpdateJSON {
-                        namespace: match var.ns() {
-                            VariableNamespace::Signal => ExportUpdateNamespace::Signal,
-                            VariableNamespace::Data => ExportUpdateNamespace::Data,
-                            VariableNamespace::Scale => {
-                                return Err(VegaFusionError::internal("Unexpected scale variable"))
-                            }
-                        },
-                        name: var.name.clone(),
-                        scope: scope.clone(),
-                        value: value.to_json()?,
-                    })
-                }).collect::<Result<Vec<_>>>()?
-            }
-        };
+                let value = TaskValue::try_from(&proto_value).with_context(|| {
+                    "Deserialization failed for value of response value: {:?}".to_string()
+                })?;
+
+                Ok(ExportUpdateJSON {
+                    namespace: match variable.ns() {
+                        VariableNamespace::Signal => ExportUpdateNamespace::Signal,
+                        VariableNamespace::Data => ExportUpdateNamespace::Data,
+                        VariableNamespace::Scale => {
+                            return Err(VegaFusionError::internal("Unexpected scale variable"))
+                        }
+                    },
+                    name: variable.name.clone(),
+                    scope: scope.clone(),
+                    value: value.to_json()?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(response_updates)
     }
@@ -1046,5 +1076,8 @@ impl ChartState {
     pub fn get_comm_plan(&self) -> &CommPlan {
         &self.plan.comm_plan
     }
-}
 
+    pub fn get_warnings(&self) -> &Vec<PreTransformSpecWarning> {
+        &self.warnings
+    }
+}

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -2,18 +2,11 @@
 mod tests {
     use crate::crate_dir;
     use serde_json::json;
-    use std::collections::HashMap;
-    use std::env;
     use std::fs;
     use std::sync::Arc;
-    use vegafusion_common::data::table::VegaFusionTable;
-    use vegafusion_common::error::VegaFusionError;
     use vegafusion_core::planning::watch::{ExportUpdateJSON, ExportUpdateNamespace};
-    use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType;
-    use vegafusion_core::proto::gen::tasks::{TzConfig, Variable};
+    use vegafusion_core::proto::gen::tasks::TzConfig;
     use vegafusion_core::spec::chart::ChartSpec;
-    use vegafusion_core::spec::values::StringOrSignalSpec;
-    use vegafusion_runtime::data::dataset::VegaFusionDataset;
     use vegafusion_runtime::task_graph::runtime::{ChartState, VegaFusionRuntime};
     use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -1,0 +1,77 @@
+#[cfg(test)]
+mod tests {
+    use crate::{crate_dir};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::env;
+    use std::fs;
+    use std::sync::Arc;
+    use vegafusion_common::data::table::VegaFusionTable;
+    use vegafusion_common::error::VegaFusionError;
+    use vegafusion_core::planning::watch::{ExportUpdateJSON, ExportUpdateNamespace};
+    use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType;
+    use vegafusion_core::proto::gen::tasks::{TzConfig, Variable};
+    use vegafusion_core::spec::chart::ChartSpec;
+    use vegafusion_core::spec::values::StringOrSignalSpec;
+    use vegafusion_runtime::data::dataset::VegaFusionDataset;
+    use vegafusion_runtime::task_graph::runtime::{ChartState, VegaFusionRuntime};
+    use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
+
+    #[tokio::test]
+    async fn test_pre_transform_dataset() {
+        // Load spec
+        let spec_path = format!("{}/tests/specs/custom/flights_crossfilter_a.vg.json", crate_dir());
+        let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
+
+        // Initialize task graph runtime
+        let runtime = VegaFusionRuntime::new(
+            Arc::new(DataFusionConnection::default()),
+            Some(16),
+            Some(1024_i32.pow(3) as usize),
+        );
+
+        let chart_state = ChartState::try_new(
+            &runtime,
+            spec,
+            Default::default(),
+            TzConfig { local_tz: "UTC".to_string(), default_input_tz: None },
+            None
+        ).await.unwrap();
+
+        let updates = vec![ExportUpdateJSON {
+            namespace: ExportUpdateNamespace::Data,
+            name: "brush_store".to_string(),
+            scope: vec![],
+            value:json!([
+              {
+                "unit": "child__column_distance_layer_0",
+                "fields": [
+                  {
+                    "field": "distance",
+                    "channel": "x",
+                    "type": "R"
+                  }
+                ],
+                "values": [
+                  [
+                    1161.5625,
+                    1449.5625
+                  ]
+                ]
+              }
+            ]),
+        }];
+
+        let response_updates = chart_state.update(&runtime, updates).await.unwrap();
+        println!("{response_updates:?}");
+
+    }
+}
+
+
+fn crate_dir() -> String {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .display()
+        .to_string()
+}

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -73,95 +73,96 @@ mod tests {
 
         let response_updates = chart_state.update(&runtime, updates).await.unwrap();
         let expected_updates: Vec<ExportUpdateJSON> = serde_json::from_value(json!(
-            [
+        [
+          {
+            "namespace": "data",
+            "name": "data_2",
+            "scope": [],
+            "value": [
               {
-                "namespace": "data",
-                "name": "data_2",
-                "scope": [],
-                "value": [
-                  {
-                    "__count": 23,
-                    "bin_maxbins_20_distance": 1400.0,
-                    "bin_maxbins_20_distance_end": 1600.0
-                  },
-                  {
-                    "__count": 30,
-                    "bin_maxbins_20_distance": 1000.0,
-                    "bin_maxbins_20_distance_end": 1200.0
-                  },
-                  {
-                    "__count": 34,
-                    "bin_maxbins_20_distance": 1200.0,
-                    "bin_maxbins_20_distance_end": 1400.0
-                  }
-                ]
+                "__count": 23,
+                "bin_maxbins_20_distance": 1400.0,
+                "bin_maxbins_20_distance_end": 1600.0
               },
               {
-                "namespace": "data",
-                "name": "data_1",
-                "scope": [],
-                "value": [
-                  {
-                    "__count": 44,
-                    "bin_maxbins_20_delay": -20.0,
-                    "bin_maxbins_20_delay_end": 0.0
-                  },
-                  {
-                    "__count": 27,
-                    "bin_maxbins_20_delay": 0.0,
-                    "bin_maxbins_20_delay_end": 20.0
-                  },
-                  {
-                    "__count": 8,
-                    "bin_maxbins_20_delay": 20.0,
-                    "bin_maxbins_20_delay_end": 40.0
-                  },
-                  {
-                    "__count": 5,
-                    "bin_maxbins_20_delay": -40.0,
-                    "bin_maxbins_20_delay_end": -20.0
-                  },
-                  {
-                    "__count": 1,
-                    "bin_maxbins_20_delay": 40.0,
-                    "bin_maxbins_20_delay_end": 60.0
-                  },
-                  {
-                    "__count": 2,
-                    "bin_maxbins_20_delay": 60.0,
-                    "bin_maxbins_20_delay_end": 80.0
-                  }
-                ]
+                "__count": 30,
+                "bin_maxbins_20_distance": 1000.0,
+                "bin_maxbins_20_distance_end": 1200.0
               },
               {
-                "namespace": "signal",
-                "name": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
-                "scope": [],
-                "value": {
-                  "fields": [
-                    "delay"
-                  ],
-                  "fname": "bin_delay",
-                  "start": -40.0,
-                  "step": 20.0,
-                  "stop": 260.0
-                }
-              },
-              {
-                "namespace": "signal",
-                "name": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
-                "scope": [],
-                "value": {
-                  "fields": [
-                    "distance"
-                  ],
-                  "fname": "bin_distance",
-                  "start": 0.0,
-                  "step": 200.0,
-                  "stop": 2400.0
-                }
+                "__count": 34,
+                "bin_maxbins_20_distance": 1200.0,
+                "bin_maxbins_20_distance_end": 1400.0
               }
-            ])).unwrap();
+            ]
+          },
+          {
+            "namespace": "data",
+            "name": "data_1",
+            "scope": [],
+            "value": [
+              {
+                "__count": 44,
+                "bin_maxbins_20_delay": -20.0,
+                "bin_maxbins_20_delay_end": 0.0
+              },
+              {
+                "__count": 27,
+                "bin_maxbins_20_delay": 0.0,
+                "bin_maxbins_20_delay_end": 20.0
+              },
+              {
+                "__count": 8,
+                "bin_maxbins_20_delay": 20.0,
+                "bin_maxbins_20_delay_end": 40.0
+              },
+              {
+                "__count": 5,
+                "bin_maxbins_20_delay": -40.0,
+                "bin_maxbins_20_delay_end": -20.0
+              },
+              {
+                "__count": 1,
+                "bin_maxbins_20_delay": 40.0,
+                "bin_maxbins_20_delay_end": 60.0
+              },
+              {
+                "__count": 2,
+                "bin_maxbins_20_delay": 60.0,
+                "bin_maxbins_20_delay_end": 80.0
+              }
+            ]
+          },
+          {
+            "namespace": "signal",
+            "name": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
+            "scope": [],
+            "value": {
+              "fields": [
+                "delay"
+              ],
+              "fname": "bin_delay",
+              "start": -40.0,
+              "step": 20.0,
+              "stop": 260.0
+            }
+          },
+          {
+            "namespace": "signal",
+            "name": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
+            "scope": [],
+            "value": {
+              "fields": [
+                "distance"
+              ],
+              "fname": "bin_distance",
+              "start": 0.0,
+              "step": 200.0,
+              "stop": 2400.0
+            }
+          }
+        ]))
+        .unwrap();
 
         assert_eq!(response_updates, expected_updates)
     }

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -63,8 +63,8 @@ mod tests {
                 ],
                 "values": [
                   [
-                    1161.5625,
-                    1449.5625
+                    1100,
+                    1500
                   ]
                 ]
               }
@@ -72,7 +72,98 @@ mod tests {
         }];
 
         let response_updates = chart_state.update(&runtime, updates).await.unwrap();
-        println!("{response_updates:?}");
+        let expected_updates: Vec<ExportUpdateJSON> = serde_json::from_value(json!(
+            [
+              {
+                "namespace": "data",
+                "name": "data_2",
+                "scope": [],
+                "value": [
+                  {
+                    "__count": 23,
+                    "bin_maxbins_20_distance": 1400.0,
+                    "bin_maxbins_20_distance_end": 1600.0
+                  },
+                  {
+                    "__count": 30,
+                    "bin_maxbins_20_distance": 1000.0,
+                    "bin_maxbins_20_distance_end": 1200.0
+                  },
+                  {
+                    "__count": 34,
+                    "bin_maxbins_20_distance": 1200.0,
+                    "bin_maxbins_20_distance_end": 1400.0
+                  }
+                ]
+              },
+              {
+                "namespace": "data",
+                "name": "data_1",
+                "scope": [],
+                "value": [
+                  {
+                    "__count": 44,
+                    "bin_maxbins_20_delay": -20.0,
+                    "bin_maxbins_20_delay_end": 0.0
+                  },
+                  {
+                    "__count": 27,
+                    "bin_maxbins_20_delay": 0.0,
+                    "bin_maxbins_20_delay_end": 20.0
+                  },
+                  {
+                    "__count": 8,
+                    "bin_maxbins_20_delay": 20.0,
+                    "bin_maxbins_20_delay_end": 40.0
+                  },
+                  {
+                    "__count": 5,
+                    "bin_maxbins_20_delay": -40.0,
+                    "bin_maxbins_20_delay_end": -20.0
+                  },
+                  {
+                    "__count": 1,
+                    "bin_maxbins_20_delay": 40.0,
+                    "bin_maxbins_20_delay_end": 60.0
+                  },
+                  {
+                    "__count": 2,
+                    "bin_maxbins_20_delay": 60.0,
+                    "bin_maxbins_20_delay_end": 80.0
+                  }
+                ]
+              },
+              {
+                "namespace": "signal",
+                "name": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
+                "scope": [],
+                "value": {
+                  "fields": [
+                    "delay"
+                  ],
+                  "fname": "bin_delay",
+                  "start": -40.0,
+                  "step": 20.0,
+                  "stop": 260.0
+                }
+              },
+              {
+                "namespace": "signal",
+                "name": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
+                "scope": [],
+                "value": {
+                  "fields": [
+                    "distance"
+                  ],
+                  "fname": "bin_distance",
+                  "start": 0.0,
+                  "step": 200.0,
+                  "stop": 2400.0
+                }
+              }
+            ])).unwrap();
+
+        assert_eq!(response_updates, expected_updates)
     }
 }
 

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -11,7 +11,7 @@ mod tests {
     use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 
     #[tokio::test]
-    async fn test_pre_transform_dataset() {
+    async fn test_chart_state() {
         // Load spec
         let spec_path = format!(
             "{}/tests/specs/custom/flights_crossfilter_a.vg.json",
@@ -68,26 +68,32 @@ mod tests {
         let expected_updates: Vec<ExportUpdateJSON> = serde_json::from_value(json!(
         [
           {
-            "namespace": "data",
-            "name": "data_2",
+            "namespace": "signal",
+            "name": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
             "scope": [],
-            "value": [
-              {
-                "__count": 23,
-                "bin_maxbins_20_distance": 1400.0,
-                "bin_maxbins_20_distance_end": 1600.0
-              },
-              {
-                "__count": 30,
-                "bin_maxbins_20_distance": 1000.0,
-                "bin_maxbins_20_distance_end": 1200.0
-              },
-              {
-                "__count": 34,
-                "bin_maxbins_20_distance": 1200.0,
-                "bin_maxbins_20_distance_end": 1400.0
-              }
-            ]
+            "value": {
+              "fields": [
+                "delay"
+              ],
+              "fname": "bin_delay",
+              "start": -40.0,
+              "step": 20.0,
+              "stop": 260.0
+            }
+          },
+          {
+            "namespace": "signal",
+            "name": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
+            "scope": [],
+            "value": {
+              "fields": [
+                "distance"
+              ],
+              "fname": "bin_distance",
+              "start": 0.0,
+              "step": 200.0,
+              "stop": 2400.0
+            }
           },
           {
             "namespace": "data",
@@ -127,33 +133,27 @@ mod tests {
             ]
           },
           {
-            "namespace": "signal",
-            "name": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
+            "namespace": "data",
+            "name": "data_2",
             "scope": [],
-            "value": {
-              "fields": [
-                "delay"
-              ],
-              "fname": "bin_delay",
-              "start": -40.0,
-              "step": 20.0,
-              "stop": 260.0
-            }
+            "value": [
+              {
+                "__count": 23,
+                "bin_maxbins_20_distance": 1400.0,
+                "bin_maxbins_20_distance_end": 1600.0
+              },
+              {
+                "__count": 30,
+                "bin_maxbins_20_distance": 1000.0,
+                "bin_maxbins_20_distance_end": 1200.0
+              },
+              {
+                "__count": 34,
+                "bin_maxbins_20_distance": 1200.0,
+                "bin_maxbins_20_distance_end": 1400.0
+              }
+            ]
           },
-          {
-            "namespace": "signal",
-            "name": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
-            "scope": [],
-            "value": {
-              "fields": [
-                "distance"
-              ],
-              "fname": "bin_distance",
-              "start": 0.0,
-              "step": 200.0,
-              "stop": 2400.0
-            }
-          }
         ]))
         .unwrap();
 

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{crate_dir};
+    use crate::crate_dir;
     use serde_json::json;
     use std::collections::HashMap;
     use std::env;
@@ -20,7 +20,10 @@ mod tests {
     #[tokio::test]
     async fn test_pre_transform_dataset() {
         // Load spec
-        let spec_path = format!("{}/tests/specs/custom/flights_crossfilter_a.vg.json", crate_dir());
+        let spec_path = format!(
+            "{}/tests/specs/custom/flights_crossfilter_a.vg.json",
+            crate_dir()
+        );
         let spec_str = fs::read_to_string(spec_path).unwrap();
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
@@ -35,15 +38,20 @@ mod tests {
             &runtime,
             spec,
             Default::default(),
-            TzConfig { local_tz: "UTC".to_string(), default_input_tz: None },
-            None
-        ).await.unwrap();
+            TzConfig {
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
         let updates = vec![ExportUpdateJSON {
             namespace: ExportUpdateNamespace::Data,
             name: "brush_store".to_string(),
             scope: vec![],
-            value:json!([
+            value: json!([
               {
                 "unit": "child__column_distance_layer_0",
                 "fields": [
@@ -65,10 +73,8 @@ mod tests {
 
         let response_updates = chart_state.update(&runtime, updates).await.unwrap();
         println!("{response_updates:?}");
-
     }
 }
-
 
 fn crate_dir() -> String {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -1161,7 +1161,7 @@ mod test_image_comparison_window {
 mod test_pre_transform_inline {
     use super::*;
     use crate::util::datasets::vega_json_dataset_async;
-    use vegafusion_core::proto::gen::pretransform::PreTransformInlineDataset;
+    use vegafusion_core::proto::gen::tasks::InlineDataset;
     use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 
     #[tokio::test]
@@ -1186,7 +1186,7 @@ mod test_pre_transform_inline {
 
         // Load csv file as inline dataset
         let movies_table = vega_json_dataset_async("movies").await;
-        let inline_datasets = vec![PreTransformInlineDataset {
+        let inline_datasets = vec![InlineDataset {
             name: "movies".to_string(),
             table: movies_table.to_ipc_bytes().unwrap(),
         }];

--- a/vegafusion-server/src/main.rs
+++ b/vegafusion-server/src/main.rs
@@ -35,7 +35,10 @@ impl TonicVegaFusionRuntime for VegaFusionRuntimeGrpc {
         &self,
         request: Request<QueryRequest>,
     ) -> Result<Response<QueryResult>, Status> {
-        let result = self.runtime.query_request(request.into_inner()).await;
+        let result = self
+            .runtime
+            .query_request_message(request.into_inner())
+            .await;
         match result {
             Ok(result) => Ok(Response::new(result)),
             Err(err) => Err(Status::unknown(err.to_string())),

--- a/vegafusion-server/tests/test_task_graph_runtime.rs
+++ b/vegafusion-server/tests/test_task_graph_runtime.rs
@@ -59,6 +59,7 @@ async fn try_it_from_spec() {
             TaskGraphValueRequest {
                 task_graph: Some(graph),
                 indices: vec![NodeValueIndex::new(2, Some(0))],
+                inline_datasets: vec![],
             },
         )),
     };

--- a/vegafusion-sql/src/connection/datafusion_conn.rs
+++ b/vegafusion-sql/src/connection/datafusion_conn.rs
@@ -69,12 +69,10 @@ impl DataFusionConnection {
         bucket_path: &str,
     ) -> Result<SessionContext> {
         let s3 = AmazonS3Builder::from_env().with_url(url).build().with_context(||
-            format!(
-                "Failed to initialize s3 connection from environment variables.\n\
-                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env"
-            )
+            "Failed to initialize s3 connection from environment variables.\n\
+                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env".to_string()
         )?;
-        let Some((bucket, _)) = bucket_path.split_once("/") else {
+        let Some((bucket, _)) = bucket_path.split_once('/') else {
             return Err(VegaFusionError::specification(format!("Invalid s3 URL: {url}")));
         };
         let base_url = Url::parse(&format!("s3://{bucket}/")).expect("Should be valid URL");
@@ -214,12 +212,10 @@ impl Connection for DataFusionConnection {
             self.scan_arrow(table).await
         } else if let Some(bucket_path) = url.strip_prefix("s3://") {
             let s3 = AmazonS3Builder::from_env().with_url(url).build().with_context(||
-                format!(
-                    "Failed to initialize s3 connection from environment variables.\n\
-                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env"
-                )
+                "Failed to initialize s3 connection from environment variables.\n\
+                See https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env".to_string()
             )?;
-            let Some((bucket, _)) = bucket_path.split_once("/") else {
+            let Some((bucket, _)) = bucket_path.split_once('/') else {
                 return Err(VegaFusionError::specification(format!("Invalid s3 URL: {url}")));
             };
             let base_url = Url::parse(&format!("s3://{bucket}/")).expect("Should be valid URL");

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -277,6 +277,7 @@ impl MsgReceiver {
                                 TaskGraphValueRequest {
                                     task_graph: Some(task_graph.clone()),
                                     indices: updated_nodes,
+                                    inline_datasets: vec![],
                                 },
                             )),
                         };
@@ -323,6 +324,7 @@ impl MsgReceiver {
                                     TaskGraphValueRequest {
                                         task_graph: Some(task_graph.clone()),
                                         indices: updated_nodes,
+                                        inline_datasets: vec![],
                                     },
                                 )),
                             };
@@ -431,6 +433,7 @@ pub fn render_vegafusion(
             TaskGraphValueRequest {
                 task_graph: Some(task_graph),
                 indices: updated_node_indices,
+                inline_datasets: vec![],
             },
         )),
     };


### PR DESCRIPTION
This PR adds a new `vf.runtime.new_chart_state` Python method which returns an instance of a `ChartState` Python class. The ChartState stores a copy of the TaskGraph that corresponds to the chart and provides an `update` method that can be used to update the task graph and return updates that should be made to the displayed visualization.

This is a step toward replacing `VegaFusionWidget` with Altair's own `JupyterChart`. My goal is that eventually the built-in Altair JuptyerChart will be able to optionally support VegaFusionWidget's current functionality. To accomplish this, JupyterChart will construct a ChartState and use it to determine what callbacks to install in the displayed Vega visualization, and will determine what properties to update in response to interactions.

A big advantage of this approach is that the chart state maintains references to any inline datasets, so it's not necessary to write inline datasets to arrow files on disk. Everything can stay in memory. This also means that non-pandas Datasets (Like SqlDataset) will be compatible with the widget configuration.

Another advantage over VegaFusionWidget is that it will be possible to use JupyterChart's support for accessing selections and params while enjoying VegaFusion's serverside scaling.