### PR TITLE
Wrap ChartState in pure Python class with typed API

### DIFF
--- a/python/vegafusion/vegafusion/__init__.py
+++ b/python/vegafusion/vegafusion/__init__.py
@@ -1,9 +1,3 @@
-# VegaFusion
-# Copyright (C) 2022, Jon Mease
-#
-# This program is distributed under multiple licenses.
-# Please consult the license documentation provided alongside
-# this program the details of the active license.
 from .runtime import runtime
 from .transformer import to_feather, get_inline_datasets_for_spec
 from .renderer import RowLimitError

--- a/python/vegafusion/vegafusion/embed.py
+++ b/python/vegafusion/vegafusion/embed.py
@@ -1,9 +1,3 @@
-# VegaFusion
-# Copyright (C) 2022, Jon Mease
-#
-# This program is distributed under multiple licenses.
-# Please consult the license documentation provided alongside
-# this program the details of the active license.
 try:
     from vegafusion_embed import *
 except ImportError:

--- a/python/vegafusion/vegafusion/jupyter.py
+++ b/python/vegafusion/vegafusion/jupyter.py
@@ -1,9 +1,3 @@
-# VegaFusion
-# Copyright (C) 2022, Jon Mease
-#
-# This program is distributed under multiple licenses.
-# Please consult the license documentation provided alongside
-# this program the details of the active license.
 try:
     from vegafusion_jupyter import *
 except ImportError:

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -4,8 +4,6 @@
 # This program is distributed under multiple licenses.
 # Please consult the license documentation provided alongside
 # this program the details of the active license.
-import json
-
 import pandas as pd
 import psutil
 import pyarrow as pa
@@ -26,6 +24,8 @@ try:
 except ImportError:
     pl = None
 
+from typing import TypedDict, List, Literal, Any
+
 
 def _all_datasets_have_type(inline_datasets, types):
     if not inline_datasets:
@@ -37,6 +37,82 @@ def _all_datasets_have_type(inline_datasets, types):
             if not isinstance(dataset, types):
                 return False
         return True
+
+
+class VariableUpdate(TypedDict):
+    name: str
+    namespace: Literal["data", "signal"]
+    scope: List[int]
+    value: Any
+
+
+class Watch(TypedDict):
+    name: str
+    namespace: Literal["data", "signal"]
+    scope: List[int]
+
+
+class WatchPlan(TypedDict):
+    client_to_server: List[Watch]
+    server_to_client: List[Watch]
+
+
+class PreTransformWarning(TypedDict):
+    type: str
+    message: str
+
+
+class ChartState:
+    def __init__(self, chart_state):
+        self._chart_state = chart_state
+
+    def update(self, client_updates: List[VariableUpdate]) -> List[VariableUpdate]:
+        """Update chart state with updates from the client
+
+        :param client_updates: List of VariableUpdate values from the client
+        :return: list of VariableUpdates that should be pushed to the client
+        """
+        return self._chart_state.update(client_updates)
+
+    def get_watch_plan(self) -> WatchPlan:
+        """Get ChartState's watch plan
+
+        The watch plan specifies the signals and datasets that should be communicated
+        between ChartState and client to preserve the input Vega spec's interactivity
+        :return: WatchPlan
+        """
+        return self._chart_state.get_watch_plan()
+
+    def get_transformed_spec(self) -> dict:
+        """Get initial transformed spec
+
+        Get the initial transformed spec. This is equivalent to the spec that would
+        be produced by vf.runtime.pre_transform_spec()
+        """
+        return self._chart_state.get_transformed_spec()
+
+    def get_warnings(self) -> List[PreTransformWarning]:
+        """Get transformed spec warnings
+
+        :return: A list of warnings as dictionaries. Each warning dict has a 'type'
+           key indicating the warning type, and a 'message' key containing
+           a description of the warning. Potential warning types include:
+            'RowLimitExceeded': Some datasets in resulting Vega specification
+                have been truncated to the provided row limit
+            'BrokenInteractivity': Some interactive features may have been
+                broken in the resulting Vega specification
+            'Unsupported': No transforms in the provided Vega specification were
+                eligible for pre-transforming
+        """
+        return self._chart_state.get_warnings()
+
+    def get_server_spec(self) -> dict:
+        """Get server spec"""
+        return self._chart_state.get_server_spec()
+
+    def get_client_spec(self) -> dict:
+        """Get client spec"""
+        return self._chart_state.get_client_spec()
 
 
 class VegaFusionRuntime:
@@ -344,7 +420,7 @@ class VegaFusionRuntime:
 
     def new_chart_state(
         self, spec, local_tz=None, default_input_tz=None, row_limit=None, inline_datasets=None
-    ):
+    ) -> ChartState:
         """
         Construct new ChartState object
 
@@ -368,7 +444,9 @@ class VegaFusionRuntime:
         else:
             local_tz = local_tz or get_local_tz()
             inline_arrow_dataset = self._import_or_register_inline_datasets(inline_datasets)
-            return self.embedded_runtime.new_chart_state(spec, local_tz, default_input_tz, row_limit, inline_arrow_dataset)
+            return ChartState(
+                self.embedded_runtime.new_chart_state(spec, local_tz, default_input_tz, row_limit, inline_arrow_dataset)
+            )
 
     def pre_transform_datasets(
         self,

--- a/python/vegafusion/vegafusion/runtime.py
+++ b/python/vegafusion/vegafusion/runtime.py
@@ -1,9 +1,3 @@
-# VegaFusion
-# Copyright (C) 2022, Jon Mease
-#
-# This program is distributed under multiple licenses.
-# Please consult the license documentation provided alongside
-# this program the details of the active license.
 import pandas as pd
 import psutil
 import pyarrow as pa

--- a/python/vegafusion/vegafusion/transformer.py
+++ b/python/vegafusion/vegafusion/transformer.py
@@ -1,10 +1,3 @@
-# VegaFusion
-# Copyright (C) 2022, Jon Mease
-#
-# This program is distributed under multiple licenses.
-# Please consult the license documentation provided alongside
-# this program the details of the active license.
-
 import io
 import os
 import pathlib

--- a/vegafusion-python-embed/src/lib.rs
+++ b/vegafusion-python-embed/src/lib.rs
@@ -42,13 +42,13 @@ pub fn initialize_logging() {
 }
 
 #[pyclass]
-struct ChartState {
+struct PyChartState {
     runtime: Arc<VegaFusionRuntime>,
     state: RsChartState,
     tokio_runtime: Arc<Runtime>,
 }
 
-impl ChartState {
+impl PyChartState {
     pub fn try_new(
         runtime: Arc<VegaFusionRuntime>,
         tokio_runtime: Arc<Runtime>,
@@ -73,7 +73,7 @@ impl ChartState {
 }
 
 #[pymethods]
-impl ChartState {
+impl PyChartState {
     /// Update chart state with updates from the client
     pub fn update(&self, py: Python, updates: Vec<PyObject>) -> PyResult<Vec<PyObject>> {
         let updates = updates
@@ -248,7 +248,7 @@ impl PyVegaFusionRuntime {
         default_input_tz: Option<String>,
         row_limit: Option<u32>,
         inline_datasets: Option<&PyDict>,
-    ) -> PyResult<ChartState> {
+    ) -> PyResult<PyChartState> {
         let spec = parse_json_spec(spec)?;
         let tz_config = TzConfig {
             local_tz: local_tz.to_string(),
@@ -266,7 +266,7 @@ impl PyVegaFusionRuntime {
             &self.tokio_runtime_connection
         };
 
-        ChartState::try_new(
+        PyChartState::try_new(
             self.runtime.clone(),
             tokio_runtime.clone(),
             spec,
@@ -602,7 +602,7 @@ impl PyVegaFusionRuntime {
 fn vegafusion_embed(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyVegaFusionRuntime>()?;
     m.add_class::<PySqlConnection>()?;
-    m.add_class::<ChartState>()?;
+    m.add_class::<PyChartState>()?;
     Ok(())
 }
 


### PR DESCRIPTION
Wraps the Rust ChartState pyo3 class in a pure Python wrapper that has a typed API.

Also removes some legacy (pre-1.0) copyright headers.