### PR TITLE
Add DataFusion datasource implementation in Python for pandas and DataFrame Interchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,7 @@ dependencies = [
  "async-trait",
  "datafusion-common",
  "datafusion-expr",
+ "pyo3",
  "vegafusion-common",
 ]
 
@@ -4577,6 +4578,7 @@ dependencies = [
  "lazy_static",
  "log",
  "object_store",
+ "pyo3",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -4590,6 +4592,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "uuid",
  "vegafusion-common",
  "vegafusion-dataframe",
  "vegafusion-datafusion-udfs",

--- a/python/vegafusion/tests/test_transformed_data.py
+++ b/python/vegafusion/tests/test_transformed_data.py
@@ -221,10 +221,9 @@ def test_transformed_data_exclude():
 
 
 @pytest.mark.skipif(pa_major_minor < (11, 0), reason="pyarrow 11+ required")
-@pytest.mark.parametrize("connection", get_connections())
-def test_gh_286(connection):
+def test_gh_286():
     # https://github.com/hex-inc/vegafusion/issues/286
-    vf.runtime.set_connection(connection)
+    vf.runtime.set_connection("datafusion")
     source = pl.from_pandas(data.seattle_weather())
 
     chart = alt.Chart(source).mark_bar(

--- a/python/vegafusion/vegafusion/datasource/__init__.py
+++ b/python/vegafusion/vegafusion/datasource/__init__.py
@@ -1,2 +1,3 @@
 from .dfi_datasource import DfiDatasource
 from .pandas_datasource import PandasDatasource
+from .datasource import Datasource

--- a/python/vegafusion/vegafusion/datasource/__init__.py
+++ b/python/vegafusion/vegafusion/datasource/__init__.py
@@ -1,0 +1,2 @@
+from .dfi_datasource import DfiDatasource
+from .pandas_datasource import PandasDatasource

--- a/python/vegafusion/vegafusion/datasource/_dfi_types.py
+++ b/python/vegafusion/vegafusion/datasource/_dfi_types.py
@@ -1,0 +1,508 @@
+# DataFrame Interchange Protocol Types
+# Copied from https://data-apis.org/dataframe-protocol/latest/API.html
+#
+# These classes are only for use in type signatures
+from abc import (
+    ABC,
+    abstractmethod,
+)
+import enum
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+)
+
+
+class DlpackDeviceType(enum.IntEnum):
+    """Integer enum for device type codes matching DLPack."""
+
+    CPU = 1
+    CUDA = 2
+    CPU_PINNED = 3
+    OPENCL = 4
+    VULKAN = 7
+    METAL = 8
+    VPI = 9
+    ROCM = 10
+
+
+class DtypeKind(enum.IntEnum):
+    """
+    Integer enum for data types.
+
+    Attributes
+    ----------
+    INT : int
+        Matches to signed integer data type.
+    UINT : int
+        Matches to unsigned integer data type.
+    FLOAT : int
+        Matches to floating point data type.
+    BOOL : int
+        Matches to boolean data type.
+    STRING : int
+        Matches to string data type (UTF-8 encoded).
+    DATETIME : int
+        Matches to datetime data type.
+    CATEGORICAL : int
+        Matches to categorical data type.
+    """
+
+    INT = 0
+    UINT = 1
+    FLOAT = 2
+    BOOL = 20
+    STRING = 21  # UTF-8
+    DATETIME = 22
+    CATEGORICAL = 23
+
+
+Dtype = Tuple[DtypeKind, int, str, str]  # see Column.dtype
+
+
+class ColumnNullType(enum.IntEnum):
+    """
+    Integer enum for null type representation.
+
+    Attributes
+    ----------
+    NON_NULLABLE : int
+        Non-nullable column.
+    USE_NAN : int
+        Use explicit float NaN value.
+    USE_SENTINEL : int
+        Sentinel value besides NaN.
+    USE_BITMASK : int
+        The bit is set/unset representing a null on a certain position.
+    USE_BYTEMASK : int
+        The byte is set/unset representing a null on a certain position.
+    """
+
+    NON_NULLABLE = 0
+    USE_NAN = 1
+    USE_SENTINEL = 2
+    USE_BITMASK = 3
+    USE_BYTEMASK = 4
+
+
+class ColumnBuffers(TypedDict):
+    # first element is a buffer containing the column data;
+    # second element is the data buffer's associated dtype
+    data: Tuple["Buffer", Dtype]
+
+    # first element is a buffer containing mask values indicating missing data;
+    # second element is the mask value buffer's associated dtype.
+    # None if the null representation is not a bit or byte mask
+    validity: Optional[Tuple["Buffer", Dtype]]
+
+    # first element is a buffer containing the offset values for
+    # variable-size binary data (e.g., variable-length strings);
+    # second element is the offsets buffer's associated dtype.
+    # None if the data buffer does not have an associated offsets buffer
+    offsets: Optional[Tuple["Buffer", Dtype]]
+
+
+class CategoricalDescription(TypedDict):
+    # whether the ordering of dictionary indices is semantically meaningful
+    is_ordered: bool
+    # whether a dictionary-style mapping of categorical values to other objects exists
+    is_dictionary: bool
+    # Python-level only (e.g. ``{int: str}``).
+    # None if not a dictionary-style categorical.
+    categories: "Optional[Column]"
+
+
+class Buffer(ABC):
+    """
+    Data in the buffer is guaranteed to be contiguous in memory.
+
+    Note that there is no dtype attribute present, a buffer can be thought of
+    as simply a block of memory. However, if the column that the buffer is
+    attached to has a dtype that's supported by DLPack and ``__dlpack__`` is
+    implemented, then that dtype information will be contained in the return
+    value from ``__dlpack__``.
+
+    This distinction is useful to support both data exchange via DLPack on a
+    buffer and (b) dtypes like variable-length strings which do not have a
+    fixed number of bytes per element.
+    """
+
+    @property
+    @abstractmethod
+    def bufsize(self) -> int:
+        """
+        Buffer size in bytes.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def ptr(self) -> int:
+        """
+        Pointer to start of the buffer as an integer.
+        """
+        pass
+
+    @abstractmethod
+    def __dlpack__(self):
+        """
+        Produce DLPack capsule (see array API standard).
+
+        Raises:
+
+            - TypeError : if the buffer contains unsupported dtypes.
+            - NotImplementedError : if DLPack support is not implemented
+
+        Useful to have to connect to array libraries. Support optional because
+        it's not completely trivial to implement for a Python-only library.
+        """
+        raise NotImplementedError("__dlpack__")
+
+    @abstractmethod
+    def __dlpack_device__(self) -> Tuple[DlpackDeviceType, Optional[int]]:
+        """
+        Device type and device ID for where the data in the buffer resides.
+        Uses device type codes matching DLPack.
+        Note: must be implemented even if ``__dlpack__`` is not.
+        """
+        pass
+
+
+class Column(ABC):
+    """
+    A column object, with only the methods and properties required by the
+    interchange protocol defined.
+
+    A column can contain one or more chunks. Each chunk can contain up to three
+    buffers - a data buffer, a mask buffer (depending on null representation),
+    and an offsets buffer (if variable-size binary; e.g., variable-length
+    strings).
+
+    TBD: Arrow has a separate "null" dtype, and has no separate mask concept.
+         Instead, it seems to use "children" for both columns with a bit mask,
+         and for nested dtypes. Unclear whether this is elegant or confusing.
+         This design requires checking the null representation explicitly.
+
+         The Arrow design requires checking:
+         1. the ARROW_FLAG_NULLABLE (for sentinel values)
+         2. if a column has two children, combined with one of those children
+            having a null dtype.
+
+         Making the mask concept explicit seems useful. One null dtype would
+         not be enough to cover both bit and byte masks, so that would mean
+         even more checking if we did it the Arrow way.
+
+    TBD: there's also the "chunk" concept here, which is implicit in Arrow as
+         multiple buffers per array (= column here). Semantically it may make
+         sense to have both: chunks were meant for example for lazy evaluation
+         of data which doesn't fit in memory, while multiple buffers per column
+         could also come from doing a selection operation on a single
+         contiguous buffer.
+
+         Given these concepts, one would expect chunks to be all of the same
+         size (say a 10,000 row dataframe could have 10 chunks of 1,000 rows),
+         while multiple buffers could have data-dependent lengths. Not an issue
+         in pandas if one column is backed by a single NumPy array, but in
+         Arrow it seems possible.
+         Are multiple chunks *and* multiple buffers per column necessary for
+         the purposes of this interchange protocol, or must producers either
+         reuse the chunk concept for this or copy the data?
+
+    Note: this Column object can only be produced by ``__dataframe__``, so
+          doesn't need its own version or ``__column__`` protocol.
+    """
+
+    @abstractmethod
+    def size(self) -> int:
+        """
+        Size of the column, in elements.
+
+        Corresponds to DataFrame.num_rows() if column is a single chunk;
+        equal to size of this current chunk otherwise.
+
+        Is a method rather than a property because it may cause a (potentially
+        expensive) computation for some dataframe implementations.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def offset(self) -> int:
+        """
+        Offset of first element.
+
+        May be > 0 if using chunks; for example for a column with N chunks of
+        equal size M (only the last chunk may be shorter),
+        ``offset = n * M``, ``n = 0 .. N-1``.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def dtype(self) -> Dtype:
+        """
+        Dtype description as a tuple ``(kind, bit-width, format string, endianness)``.
+
+        Bit-width : the number of bits as an integer
+        Format string : data type description format string in Apache Arrow C
+                        Data Interface format.
+        Endianness : current only native endianness (``=``) is supported
+
+        Notes:
+            - Kind specifiers are aligned with DLPack where possible (hence the
+              jump to 20, leave enough room for future extension)
+            - Masks must be specified as boolean with either bit width 1 (for bit
+              masks) or 8 (for byte masks).
+            - Dtype width in bits was preferred over bytes
+            - Endianness isn't too useful, but included now in case in the future
+              we need to support non-native endianness
+            - Went with Apache Arrow format strings over NumPy format strings
+              because they're more complete from a dataframe perspective
+            - Format strings are mostly useful for datetime specification, and
+              for categoricals.
+            - For categoricals, the format string describes the type of the
+              categorical in the data buffer. In case of a separate encoding of
+              the categorical (e.g. an integer to string mapping), this can
+              be derived from ``self.describe_categorical``.
+            - Data types not included: complex, Arrow-style null, binary, decimal,
+              and nested (list, struct, map, union) dtypes.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def describe_categorical(self) -> CategoricalDescription:
+        """
+        If the dtype is categorical, there are two options:
+        - There are only values in the data buffer.
+        - There is a separate non-categorical Column encoding categorical values.
+
+        Raises TypeError if the dtype is not categorical
+
+        Returns the dictionary with description on how to interpret the data buffer:
+            - "is_ordered" : bool, whether the ordering of dictionary indices is
+                             semantically meaningful.
+            - "is_dictionary" : bool, whether a mapping of
+                                categorical values to other objects exists
+            - "categories" : Column representing the (implicit) mapping of indices to
+                             category values (e.g. an array of cat1, cat2, ...).
+                             None if not a dictionary-style categorical.
+
+        TBD: are there any other in-memory representations that are needed?
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def describe_null(self) -> Tuple[ColumnNullType, Any]:
+        """
+        Return the missing value (or "null") representation the column dtype
+        uses, as a tuple ``(kind, value)``.
+
+        Value : if kind is "sentinel value", the actual value. If kind is a bit
+        mask or a byte mask, the value (0 or 1) indicating a missing value. None
+        otherwise.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def null_count(self) -> Optional[int]:
+        """
+        Number of null elements, if known.
+
+        Note: Arrow uses -1 to indicate "unknown", but None seems cleaner.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Dict[str, Any]:
+        """
+        The metadata for the column. See `DataFrame.metadata` for more details.
+        """
+        pass
+
+    @abstractmethod
+    def num_chunks(self) -> int:
+        """
+        Return the number of chunks the column consists of.
+        """
+        pass
+
+    @abstractmethod
+    def get_chunks(self, n_chunks: Optional[int] = None) -> Iterable["Column"]:
+        """
+        Return an iterator yielding the chunks.
+
+        See `DataFrame.get_chunks` for details on ``n_chunks``.
+        """
+        pass
+
+    @abstractmethod
+    def get_buffers(self) -> ColumnBuffers:
+        """
+        Return a dictionary containing the underlying buffers.
+
+        The returned dictionary has the following contents:
+
+            - "data": a two-element tuple whose first element is a buffer
+                      containing the data and whose second element is the data
+                      buffer's associated dtype.
+            - "validity": a two-element tuple whose first element is a buffer
+                          containing mask values indicating missing data and
+                          whose second element is the mask value buffer's
+                          associated dtype. None if the null representation is
+                          not a bit or byte mask.
+            - "offsets": a two-element tuple whose first element is a buffer
+                         containing the offset values for variable-size binary
+                         data (e.g., variable-length strings) and whose second
+                         element is the offsets buffer's associated dtype. None
+                         if the data buffer does not have an associated offsets
+                         buffer.
+        """
+        pass
+
+
+#    def get_children(self) -> Iterable[Column]:
+#        """
+#        Children columns underneath the column, each object in this iterator
+#        must adhere to the column specification.
+#        """
+#        pass
+
+
+class DataFrame(ABC):
+    """
+    A data frame class, with only the methods required by the interchange
+    protocol defined.
+
+    A "data frame" represents an ordered collection of named columns.
+    A column's "name" must be a unique string.
+    Columns may be accessed by name or by position.
+
+    This could be a public data frame class, or an object with the methods and
+    attributes defined on this DataFrame class could be returned from the
+    ``__dataframe__`` method of a public data frame class in a library adhering
+    to the dataframe interchange protocol specification.
+    """
+
+    version = 0  # version of the protocol
+
+    @abstractmethod
+    def __dataframe__(
+        self, nan_as_null: bool = False, allow_copy: bool = True
+    ) -> "DataFrame":
+        """
+        Construct a new exchange object, potentially changing the parameters.
+
+        ``nan_as_null`` is a keyword intended for the consumer to tell the
+        producer to overwrite null values in the data with ``NaN``.
+        It is intended for cases where the consumer does not support the bit
+        mask or byte mask that is the producer's native representation.
+        ``allow_copy`` is a keyword that defines whether or not the library is
+        allowed to make a copy of the data. For example, copying data would be
+        necessary if a library supports strided buffers, given that this protocol
+        specifies contiguous buffers.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Dict[str, Any]:
+        """
+        The metadata for the data frame, as a dictionary with string keys. The
+        contents of `metadata` may be anything, they are meant for a library
+        to store information that it needs to, e.g., roundtrip losslessly or
+        for two implementations to share data that is not (yet) part of the
+        interchange protocol specification. For avoiding collisions with other
+        entries, please add name the keys with the name of the library
+        followed by a period and the desired name, e.g, ``pandas.indexcol``.
+        """
+        pass
+
+    @abstractmethod
+    def num_columns(self) -> int:
+        """
+        Return the number of columns in the DataFrame.
+        """
+        pass
+
+    @abstractmethod
+    def num_rows(self) -> Optional[int]:
+        # TODO: not happy with Optional, but need to flag it may be expensive
+        #       why include it if it may be None - what do we expect consumers
+        #       to do here?
+        """
+        Return the number of rows in the DataFrame, if available.
+        """
+        pass
+
+    @abstractmethod
+    def num_chunks(self) -> int:
+        """
+        Return the number of chunks the DataFrame consists of.
+        """
+        pass
+
+    @abstractmethod
+    def column_names(self) -> Iterable[str]:
+        """
+        Return an iterator yielding the column names.
+        """
+        pass
+
+    @abstractmethod
+    def get_column(self, i: int) -> Column:
+        """
+        Return the column at the indicated position.
+        """
+        pass
+
+    @abstractmethod
+    def get_column_by_name(self, name: str) -> Column:
+        """
+        Return the column whose name is the indicated name.
+        """
+        pass
+
+    @abstractmethod
+    def get_columns(self) -> Iterable[Column]:
+        """
+        Return an iterator yielding the columns.
+        """
+        pass
+
+    @abstractmethod
+    def select_columns(self, indices: Sequence[int]) -> "DataFrame":
+        """
+        Create a new DataFrame by selecting a subset of columns by index.
+        """
+        pass
+
+    @abstractmethod
+    def select_columns_by_name(self, names: Sequence[str]) -> "DataFrame":
+        """
+        Create a new DataFrame by selecting a subset of columns by name.
+        """
+        pass
+
+    @abstractmethod
+    def get_chunks(self, n_chunks: Optional[int] = None) -> Iterable["DataFrame"]:
+        """
+        Return an iterator yielding the chunks.
+
+        By default (None), yields the chunks that the data is stored as by the
+        producer. If given, ``n_chunks`` must be a multiple of
+        ``self.num_chunks()``, meaning the producer must subdivide each chunk
+        before yielding it.
+
+        Note that the producer must ensure that all columns are chunked the
+        same way.
+        """
+        pass

--- a/python/vegafusion/vegafusion/datasource/datasource.py
+++ b/python/vegafusion/vegafusion/datasource/datasource.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Iterable
+import pyarrow as pa
+
+
+class Datasource(ABC):
+    @abstractmethod
+    def schema(self) -> pa.Schema:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def fetch(self, columns: Iterable[str]) -> pa.Table:
+        raise NotImplementedError()

--- a/python/vegafusion/vegafusion/datasource/dfi_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/dfi_datasource.py
@@ -3,12 +3,12 @@ import re
 import pyarrow as pa
 from pyarrow.interchange import from_dataframe
 
-from typing import Any
+from typing import Any, Dict
 from ._dfi_types import DtypeKind, DataFrame as DfiDataFrame
 from .datasource import Datasource
 
 # Taken from private pyarrow utilities
-_PYARROW_DTYPES: dict[DtypeKind, dict[int, Any]] = {
+_PYARROW_DTYPES: Dict[DtypeKind, Dict[int, Any]] = {
     DtypeKind.INT: {8: pa.int8(),
                     16: pa.int16(),
                     32: pa.int32(),

--- a/python/vegafusion/vegafusion/datasource/dfi_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/dfi_datasource.py
@@ -1,0 +1,82 @@
+from typing import Iterable
+import re
+import pyarrow as pa
+from pyarrow.interchange import from_dataframe
+
+from typing import Any
+from ._dfi_types import DtypeKind, DataFrame as DfiDataFrame
+from .datasource import Datasource
+
+# Taken from private pyarrow utilities
+_PYARROW_DTYPES: dict[DtypeKind, dict[int, Any]] = {
+    DtypeKind.INT: {8: pa.int8(),
+                    16: pa.int16(),
+                    32: pa.int32(),
+                    64: pa.int64()},
+    DtypeKind.UINT: {8: pa.uint8(),
+                     16: pa.uint16(),
+                     32: pa.uint32(),
+                     64: pa.uint64()},
+    DtypeKind.FLOAT: {16: pa.float16(),
+                      32: pa.float32(),
+                      64: pa.float64()},
+    DtypeKind.BOOL: {1: pa.bool_(),
+                     8: pa.uint8()},
+    DtypeKind.STRING: {8: pa.string()},
+}
+
+
+def parse_datetime_format_str(format_str):
+    """Parse datetime `format_str` to interpret the `data`."""
+
+    # timestamp 'ts{unit}:tz'
+    timestamp_meta = re.match(r"ts([smun]):(.*)", format_str)
+    if timestamp_meta:
+        unit, tz = timestamp_meta.group(1), timestamp_meta.group(2)
+        if unit != "s":
+            # the format string describes only a first letter of the unit, so
+            # add one extra letter to convert the unit to numpy-style:
+            # 'm' -> 'ms', 'u' -> 'us', 'n' -> 'ns'
+            unit += "s"
+
+        return unit, tz
+
+    raise NotImplementedError(f"DateTime kind is not supported: {format_str}")
+
+
+def map_date_type(data_type):
+    """Map column date type to pyarrow date type. """
+    kind, bit_width, f_string, _ = data_type
+
+    if kind == DtypeKind.DATETIME:
+        unit, tz = parse_datetime_format_str(f_string)
+        return pa.timestamp(unit, tz=tz)
+    else:
+        pa_dtype = _PYARROW_DTYPES.get(kind, {}).get(bit_width, None)
+
+        # Error if dtype is not supported
+        if pa_dtype:
+            return pa_dtype
+        else:
+            raise NotImplementedError(
+                f"Conversion for {data_type} is not yet supported.")
+
+
+class DfiDatasource(Datasource):
+    def __init__(self, dataframe: DfiDataFrame):
+        if hasattr(dataframe, "__dataframe__"):
+            dataframe = dataframe.__dataframe__()
+        fields = []
+        for col in dataframe.column_names():
+            field = dataframe.get_column_by_name(col)
+            pa_type = map_date_type(field.dtype)
+            fields.append(pa.field(col, pa_type))
+
+        self._dataframe = dataframe
+        self._schema = pa.schema(fields)
+
+    def schema(self) -> pa.Schema:
+        return self._schema
+
+    def fetch(self, columns: Iterable[str]) -> pa.Table:
+        return from_dataframe(self._dataframe.select_columns_by_name(columns))

--- a/python/vegafusion/vegafusion/datasource/dfi_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/dfi_datasource.py
@@ -79,4 +79,7 @@ class DfiDatasource(Datasource):
         return self._schema
 
     def fetch(self, columns: Iterable[str]) -> pa.Table:
-        return from_dataframe(self._dataframe.select_columns_by_name(columns))
+        columns = list(columns)
+        projected_schema = pa.schema([f for f in self._schema if f.name in columns])
+        table = from_dataframe(self._dataframe.select_columns_by_name(columns))
+        return table.cast(projected_schema, safe=False)

--- a/python/vegafusion/vegafusion/datasource/pandas_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/pandas_datasource.py
@@ -1,0 +1,77 @@
+from typing import Iterable
+from math import floor
+import pandas as pd
+import pyarrow as pa
+from .datasource import Datasource
+
+
+class PandasDatasource(Datasource):
+    def __init__(self, df: pd.DataFrame, sample_size: int = 10000, batch_size: int = 8096):
+        fields = []
+        casts = {}
+        sample_stride = floor(len(df) / sample_size)
+
+        # Shallow copy and add named index levels as columns
+        # (this is faster that df.reset_index, which seems to perform a deep copy)
+        df = df.copy(deep=False)
+        for i, index_name in enumerate(getattr(df.index, "names", [])):
+            if isinstance(index_name, str):
+                df[index_name] = df.index.get_level_values(i)
+        df.reset_index(drop=True, inplace=True)
+
+        for col, pd_type in df.dtypes.items():
+            if not isinstance(col, str):
+                continue
+            try:
+                # We will expand categoricals (not yet supported in VegaFusion)
+                if isinstance(pd_type, pd.CategoricalDtype):
+                    cat = df[col].cat
+                    field = pa.Schema.from_pandas(pd.DataFrame({"cat": cat.categories})).field("cat")
+                else:
+                    candidate_schema = pa.Schema.from_pandas(df.iloc[::sample_stride][[col]])
+                    field = candidate_schema.field(col)
+
+                # Convert Decimal columns to float
+                if isinstance(field.type, (pa.Decimal128Type, pa.Decimal256Type)):
+                    field = pa.field(col, pa.float64())
+                    casts[col] = "float64"
+
+                # Get inferred pyarrow type
+                fields.append(field)
+
+            except pa.ArrowTypeError:
+                if pd_type.kind == "O":
+                    fields.append(pa.field(col, pa.string()))
+                    casts[col] = str
+                else:
+                    raise
+        self._df = df
+        self._schema = pa.schema(fields)
+        self._casts = casts
+        self._batch_size = batch_size
+
+    def schema(self) -> pa.Schema:
+        return self._schema
+
+    def fetch(self, columns: Iterable[str]) -> pa.Table:
+        projected = self._df[columns].copy(deep=False)
+
+        for col, pd_type in projected.dtypes.items():
+            # Handle cases that need to happen before conversion to pyarrow
+            if col in self._casts:
+                projected[col] = projected[col].astype(self._casts[col])
+
+            # Handle expanding categoricals
+            if isinstance(pd_type, pd.CategoricalDtype):
+                cat = projected[col].cat
+                projected[col] = cat.categories[cat.codes]
+
+        table = pa.Table.from_pandas(projected, preserve_index=False)
+
+        # Split into batches of desired size
+        if self._batch_size is None:
+            return table
+        else:
+            # Resize batches
+            batches = table.to_batches(self._batch_size)
+            return pa.Table.from_batches(batches, table.schema)

--- a/python/vegafusion/vegafusion/datasource/pandas_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/pandas_datasource.py
@@ -6,10 +6,10 @@ from .datasource import Datasource
 
 
 class PandasDatasource(Datasource):
-    def __init__(self, df: pd.DataFrame, sample_size: int = 10000, batch_size: int = 8096):
+    def __init__(self, df: pd.DataFrame, sample_size: int = 1000, batch_size: int = 8096):
         fields = []
         casts = {}
-        sample_stride = floor(len(df) / sample_size)
+        sample_stride = max(1, floor(len(df) / sample_size))
 
         # Shallow copy and add named index levels as columns
         # (this is faster that df.reset_index, which seems to perform a deep copy)
@@ -26,7 +26,7 @@ class PandasDatasource(Datasource):
                 # We will expand categoricals (not yet supported in VegaFusion)
                 if isinstance(pd_type, pd.CategoricalDtype):
                     cat = df[col].cat
-                    field = pa.Schema.from_pandas(pd.DataFrame({"cat": cat.categories})).field("cat")
+                    field = pa.Schema.from_pandas(pd.DataFrame({col: cat.categories})).field(col)
                 else:
                     candidate_schema = pa.Schema.from_pandas(df.iloc[::sample_stride][[col]])
                     field = candidate_schema.field(col)

--- a/vegafusion-dataframe/Cargo.toml
+++ b/vegafusion-dataframe/Cargo.toml
@@ -5,6 +5,9 @@ version = "1.5.1"
 edition = "2021"
 description = "VegaFusion's DataFrame and Connection traits"
 
+[features]
+pyarrow = [ "pyo3", "datafusion-common/pyarrow", "vegafusion-common/pyarrow",]
+
 [dependencies]
 async-trait = "0.1.73"
 
@@ -21,3 +24,7 @@ workspace = true
 [dependencies.arrow]
 workspace = true
 default_features = false
+
+[dependencies.pyo3]
+workspace = true
+optional = true

--- a/vegafusion-dataframe/src/connection.rs
+++ b/vegafusion-dataframe/src/connection.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_common::error::{Result, VegaFusionError};
 
+#[cfg(feature = "pyarrow")]
+use pyo3::PyObject;
+
 #[async_trait]
 pub trait Connection: Send + Sync + 'static {
     fn id(&self) -> String;
@@ -46,6 +49,13 @@ pub trait Connection: Send + Sync + 'static {
     async fn scan_parquet(&self, _url: &str) -> Result<Arc<dyn DataFrame>> {
         Err(VegaFusionError::sql_not_supported(
             "scan_parquet not supported by connection",
+        ))
+    }
+
+    #[cfg(feature = "pyarrow")]
+    async fn scan_py_datasource(&self, _datasource: PyObject) -> Result<Arc<dyn DataFrame>> {
+        Err(VegaFusionError::sql_not_supported(
+            "scan_py_datasource not supported by connection",
         ))
     }
 }

--- a/vegafusion-python-embed/Cargo.toml
+++ b/vegafusion-python-embed/Cargo.toml
@@ -54,7 +54,7 @@ version = "1.5.1"
 [dependencies.vegafusion-sql]
 path = "../vegafusion-sql"
 version = "1.5.1"
-features = [ "datafusion-conn",]
+features = [ "datafusion-conn", "pyarrow"]
 
 [dependencies.vegafusion-dataframe]
 path = "../vegafusion-dataframe"

--- a/vegafusion-sql/Cargo.toml
+++ b/vegafusion-sql/Cargo.toml
@@ -7,11 +7,13 @@ description = "VegaFusion SQL dialect generation and connection implementations"
 
 [features]
 datafusion-conn = [ "datafusion", "tempfile", "reqwest", "reqwest-retry", "reqwest-middleware", "vegafusion-datafusion-udfs", "object_store", "url", "vegafusion-common/object_store",]
+pyarrow = [ "pyo3", "datafusion-common/pyarrow", "vegafusion-common/pyarrow", "vegafusion-dataframe/pyarrow"]
 
 [dependencies]
 async-trait = "0.1.73"
 deterministic-hash = "1.0.1"
 log = "0.4.17"
+uuid = "1.4.1"
 
 [dev-dependencies]
 rstest = "0.18.2"
@@ -83,6 +85,10 @@ features = [ "aws",]
 
 [dependencies.url]
 version = "2.3.1"
+optional = true
+
+[dependencies.pyo3]
+workspace = true
 optional = true
 
 [dev-dependencies.async-std]

--- a/vegafusion-sql/src/connection/datafusion_py_datasource.rs
+++ b/vegafusion-sql/src/connection/datafusion_py_datasource.rs
@@ -1,0 +1,154 @@
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::pyarrow::FromPyArrow;
+use async_trait::async_trait;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionState;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{Partitioning, PhysicalSortExpr};
+use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
+use datafusion_common::{project_schema, DataFusionError, Statistics};
+use datafusion_expr::{Expr, TableType};
+use pyo3::types::PyTuple;
+use pyo3::{IntoPy, PyErr, PyObject, Python};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::Arc;
+use vegafusion_common::data::table::VegaFusionTable;
+
+#[derive(Debug, Clone)]
+pub struct PyDatasource {
+    py_datasource: PyObject,
+    schema: SchemaRef,
+}
+
+impl PyDatasource {
+    pub fn try_new(py_datasource: PyObject) -> Result<Self, PyErr> {
+        Python::with_gil(|py| -> Result<_, PyErr> {
+            let table_schema_obj = py_datasource.call_method0(py, "schema")?;
+            let schema = Arc::new(Schema::from_pyarrow(table_schema_obj.as_ref(py))?);
+            Ok(Self {
+                py_datasource,
+                schema,
+            })
+        })
+    }
+
+    pub(crate) async fn create_physical_plan(
+        &self,
+        projections: Option<&Vec<usize>>,
+        schema: SchemaRef,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(PyDatasourceExec::new(
+            projections,
+            schema,
+            self.clone(),
+        )))
+    }
+}
+
+#[async_trait]
+impl TableProvider for PyDatasource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        return self.create_physical_plan(projection, self.schema()).await;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PyDatasourceExec {
+    db: PyDatasource,
+    projected_schema: SchemaRef,
+}
+
+impl PyDatasourceExec {
+    fn new(projections: Option<&Vec<usize>>, schema: SchemaRef, db: PyDatasource) -> Self {
+        let projected_schema = project_schema(&schema, projections).unwrap();
+        Self {
+            db,
+            projected_schema,
+        }
+    }
+}
+
+impl DisplayAs for PyDatasourceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "PyDatasourceExec")
+    }
+}
+
+impl ExecutionPlan for PyDatasourceExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.projected_schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion_common::Result<SendableRecordBatchStream> {
+        let table = Python::with_gil(|py| -> Result<_, PyErr> {
+            let column_names = self
+                .projected_schema
+                .fields
+                .iter()
+                .map(|field| field.name().clone())
+                .collect::<Vec<_>>();
+            let args = PyTuple::new(py, vec![column_names.into_py(py)]);
+            let pa_table = self.db.py_datasource.call_method1(py, "fetch", args)?;
+            let table = VegaFusionTable::from_pyarrow(py, &pa_table.as_ref(py))?;
+            Ok(table)
+        })
+        .map_err(|err| DataFusionError::Execution(err.to_string()))?;
+
+        Ok(Box::pin(MemoryStream::try_new(
+            table.batches,
+            table.schema,
+            None,
+        )?))
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}

--- a/vegafusion-sql/src/connection/mod.rs
+++ b/vegafusion-sql/src/connection/mod.rs
@@ -1,6 +1,3 @@
-// pub mod datafusion_conn;
-// pub mod sqlite_conn;
-
 use crate::dialect::Dialect;
 use arrow::datatypes::Schema;
 use async_trait::async_trait;
@@ -14,6 +11,10 @@ pub use vegafusion_dataframe::connection::Connection;
 
 #[cfg(feature = "datafusion-conn")]
 pub mod datafusion_conn;
+
+#[cfg(feature = "datafusion-conn")]
+#[cfg(feature = "pyarrow")]
+pub mod datafusion_py_datasource;
 
 #[async_trait]
 pub trait SqlConnection: Connection {


### PR DESCRIPTION
Closes https://github.com/hex-inc/vegafusion/issues/386

This PR adds custom DataFusion datasources, written in Python, for pandas DataFrames and objects that adhere to the DataFrame Interchange Protocol (i.e. have a `__dataframe__` method). Using this approach, we no longer convert these objects directly to arrow before passing them into VegaFusion. Instead, they are converted to arrow dynamically during the DataFusion query. This makes it possible to down select to the required columns before converting to Arrow, which can be much much faster for DataFrames that include lots of columns.

Example of 10 million row histogram with pandas:

```python
import altair as alt
import pandas as pd
alt.data_transformers.enable("vegafusion")

movies = pd.read_json("https://raw.githubusercontent.com/vega/vega-datasets/main/data/movies.json")
movies = pd.concat([movies]*3200, axis=0).reset_index(drop=False)
print(len(movies))
source = movies
chart = alt.Chart(source).mark_bar().encode(
    alt.X("IMDB Rating:Q", bin=True),
    y='count()',
)
chart
```
10243200

![visualization](https://github.com/hex-inc/vegafusion/assets/15064365/062ace7d-2669-4ead-a5b8-f0f336ebf67a)

Test performing with chart.to_dict()

```python
%%timeit
d = chart.to_dict(format="vega")
```

Before: 7.04 s ± 81.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
After:  336 ms ± 11.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

That's 20x faster!

This is because we're only converting 1 out of 17 columns to arrow, and skipping several string columns which are particularly slow to convert.

The duckdb connection against pandas is still a bit faster, but the DataFusion connection is now within a factor of 2 for this example.

DuckDB: 199 ms ± 2.92 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

The performance results for DataFrame Interchange Protocol objects will vary depending on how expensive it is to convert their contents to arrow using PyArrow. In this case we're using `dfi.select_columns_by_name(columns)` to filter down the source columns before converting to Arrow.

cc @ivirshup