### PR TITLE
Fix parent dataset resolution in facet lift planner stage

### DIFF
--- a/vegafusion-core/src/planning/lift_facet_aggregations.rs
+++ b/vegafusion-core/src/planning/lift_facet_aggregations.rs
@@ -213,7 +213,7 @@ impl MutChartVisitor for ExtractFacetAggregationsVisitor {
         // Save new dataset at the same scope as the original input dataset
         let Ok(resolved) = self
             .task_scope
-            .resolve_scope(&Variable::new_data(&facet.data), scope)
+            .resolve_scope(&Variable::new_data(&facet.data), &scope[..scope.len() - 1])
         else {
             return Ok(());
         };

--- a/vegafusion-runtime/tests/specs/custom/facet_with_selections.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/facet_with_selections.comm_plan.json
@@ -1,0 +1,30 @@
+{
+  "server_to_client": [
+    {
+      "name": "column_domain",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_0_color_domain_MPAA Rating",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_0_facet_facet0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "data_3_x_domain_Creative Type",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/facet_with_selections.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/facet_with_selections.vg.json
@@ -1,0 +1,1105 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": {
+    "bottom": 20,
+    "right": 20
+  },
+  "data": [
+    {
+      "name": "interval_intervalselection_0_store"
+    },
+    {
+      "name": "click_pointselection_0_store"
+    },
+    {
+      "name": "legend_pointselection_0_store"
+    },
+    {
+      "name": "legend_pointhover_0_store"
+    },
+    {
+      "name": "movies_clean",
+      "url": "data/movies.json"
+    },
+    {
+      "name": "data_0",
+      "source": "movies_clean",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "if(datum[\"MPAA Rating\"] === \"G\", 0, if(datum[\"MPAA Rating\"] === \"NC-17\", 1, if(datum[\"MPAA Rating\"] === \"Not Rated\", 2, if(datum[\"MPAA Rating\"] === \"Open\", 3, if(datum[\"MPAA Rating\"] === \"PG\", 4, if(datum[\"MPAA Rating\"] === \"PG-13\", 5, if(datum[\"MPAA Rating\"] === \"R\", 6, 7)))))))",
+          "as": "d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order"
+        },
+        {
+          "type": "formula",
+          "expr": "datum[\"MPAA Rating\"]===\"G\" ? 0 : datum[\"MPAA Rating\"]===\"NC-17\" ? 1 : datum[\"MPAA Rating\"]===\"Not Rated\" ? 2 : datum[\"MPAA Rating\"]===\"Open\" ? 3 : datum[\"MPAA Rating\"]===\"PG\" ? 4 : datum[\"MPAA Rating\"]===\"PG-13\" ? 5 : datum[\"MPAA Rating\"]===\"R\" ? 6 : 7",
+          "as": "color_MPAA Rating_sort_index"
+        }
+      ]
+    },
+    {
+      "name": "column_domain",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": [
+            "MPAA Rating"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "data_3",
+      "source": "data_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": [
+            "Creative Type",
+            "MPAA Rating",
+            "d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order"
+          ],
+          "ops": [
+            "sum"
+          ],
+          "fields": [
+            "Worldwide Gross"
+          ],
+          "as": [
+            "sum_Worldwide Gross"
+          ]
+        },
+        {
+          "type": "stack",
+          "groupby": [
+            "Creative Type",
+            "MPAA Rating"
+          ],
+          "field": "sum_Worldwide Gross",
+          "sort": {
+            "field": [
+              "d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order"
+            ],
+            "order": [
+              "descending"
+            ]
+          },
+          "as": [
+            "sum_Worldwide Gross_start",
+            "sum_Worldwide Gross_end"
+          ],
+          "offset": "zero"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"sum_Worldwide Gross\"]) && isFinite(+datum[\"sum_Worldwide Gross\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {
+          "events": "pointermove",
+          "update": "isTuple(group()) ? group() : unit"
+        }
+      ]
+    },
+    {
+      "name": "legend_pointhover_0_MPAA_Rating_legend",
+      "value": null,
+      "on": [
+        {
+          "events": [
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_symbols"
+            },
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_labels"
+            },
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_entries"
+            }
+          ],
+          "update": "isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value",
+          "force": true
+        },
+        {
+          "events": [
+            {
+              "source": "view",
+              "type": "click"
+            }
+          ],
+          "update": "!event.item || !datum ? null : legend_pointhover_0_MPAA_Rating_legend",
+          "force": true
+        }
+      ]
+    },
+    {
+      "name": "legend_pointselection_0_MPAA_Rating_legend",
+      "value": null,
+      "on": [
+        {
+          "events": [
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_symbols"
+            },
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_labels"
+            },
+            {
+              "source": "view",
+              "type": "click",
+              "markname": "MPAA_Rating_legend_entries"
+            }
+          ],
+          "update": "isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value",
+          "force": true
+        },
+        {
+          "events": [
+            {
+              "source": "view",
+              "type": "click"
+            }
+          ],
+          "update": "!event.item || !datum ? null : legend_pointselection_0_MPAA_Rating_legend",
+          "force": true
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0",
+      "update": "vlSelectionResolve(\"interval_intervalselection_0_store\", \"union\")"
+    },
+    {
+      "name": "click_pointselection_0",
+      "update": "vlSelectionResolve(\"click_pointselection_0_store\", \"union\", true, true)"
+    },
+    {
+      "name": "legend_pointselection_0",
+      "update": "vlSelectionResolve(\"legend_pointselection_0_store\", \"union\", true, true)"
+    },
+    {
+      "name": "legend_pointhover_0",
+      "update": "vlSelectionResolve(\"legend_pointhover_0_store\", \"union\", true, true)"
+    },
+    {
+      "name": "cursor",
+      "value": "default",
+      "on": [
+        {
+          "events": "mousemove",
+          "update": "if(isDefined((group()).bounds), if(item().mark.marktype != 'group', 'default', 'crosshair'), 'default')"
+        }
+      ]
+    },
+    {
+      "name": "width",
+      "init": "isFinite(containerSize()[0]) ? containerSize()[0] : 120",
+      "on": [
+        {
+          "update": "isFinite(containerSize()[0]) ? containerSize()[0] : 120",
+          "events": "window:resize"
+        }
+      ]
+    },
+    {
+      "name": "height",
+      "init": "isFinite(containerSize()[1]) ? containerSize()[1] : 120",
+      "on": [
+        {
+          "update": "isFinite(containerSize()[1]) ? containerSize()[1] : 120",
+          "events": "window:resize"
+        }
+      ]
+    },
+    {
+      "name": "child_width",
+      "update": "length(data('column_domain')) > 0? width / length(data('column_domain')) - 1: 120"
+    },
+    {
+      "name": "min_width",
+      "update": "120 * length(data('column_domain'))"
+    },
+    {
+      "name": "child_height",
+      "update": "height"
+    },
+    {
+      "name": "min_height",
+      "update": "240"
+    }
+  ],
+  "layout": {
+    "padding": 20,
+    "offset": {
+      "columnTitle": 10
+    },
+    "columns": {
+      "signal": "length(data('column_domain'))"
+    },
+    "bounds": "full",
+    "align": "all"
+  },
+  "marks": [
+    {
+      "name": "column-title",
+      "type": "group",
+      "role": "column-title",
+      "title": {
+        "text": "MPAA Rating",
+        "style": "guide-title",
+        "offset": 10
+      }
+    },
+    {
+      "name": "row_header",
+      "type": "group",
+      "role": "row-header",
+      "encode": {
+        "update": {
+          "height": {
+            "signal": "child_height"
+          }
+        }
+      },
+      "axes": [
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": false,
+          "title": "Sum of Worldwide Gross",
+          "labelFlush": false,
+          "labels": true,
+          "ticks": true,
+          "labelOverlap": true,
+          "tickCount": {
+            "signal": "ceil(child_height/40)"
+          },
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "column_header",
+      "type": "group",
+      "role": "column-header",
+      "from": {
+        "data": "column_domain"
+      },
+      "sort": {
+        "field": "datum[\"MPAA Rating\"]",
+        "order": "ascending"
+      },
+      "title": {
+        "text": {
+          "signal": "isValid(parent[\"MPAA Rating\"]) ? parent[\"MPAA Rating\"] : \"\"+parent[\"MPAA Rating\"]"
+        },
+        "style": "guide-label",
+        "frame": "group",
+        "offset": 10
+      },
+      "encode": {
+        "update": {
+          "width": {
+            "signal": "child_width"
+          }
+        }
+      }
+    },
+    {
+      "name": "column_footer",
+      "type": "group",
+      "role": "column-footer",
+      "from": {
+        "data": "column_domain"
+      },
+      "sort": {
+        "field": "datum[\"MPAA Rating\"]",
+        "order": "ascending"
+      },
+      "encode": {
+        "update": {
+          "width": {
+            "signal": "child_width"
+          }
+        }
+      },
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": false,
+          "title": "Creative Type",
+          "labelFlush": false,
+          "labelOverlap": "greedy",
+          "labels": true,
+          "ticks": true,
+          "labelAlign": "right",
+          "labelAngle": 270,
+          "labelBaseline": "middle",
+          "zindex": 0
+        }
+      ]
+    },
+    {
+      "name": "cell",
+      "type": "group",
+      "style": "cell",
+      "from": {
+        "facet": {
+          "name": "facet",
+          "data": "data_0",
+          "groupby": [
+            "MPAA Rating"
+          ]
+        }
+      },
+      "sort": {
+        "field": [
+          "datum[\"MPAA Rating\"]"
+        ],
+        "order": [
+          "ascending"
+        ]
+      },
+      "data": [
+        {
+          "source": "facet",
+          "name": "data_0",
+          "transform": [
+            {
+              "type": "aggregate",
+              "groupby": [
+                "Creative Type",
+                "MPAA Rating",
+                "d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order"
+              ],
+              "ops": [
+                "sum"
+              ],
+              "fields": [
+                "Worldwide Gross"
+              ],
+              "as": [
+                "sum_Worldwide Gross"
+              ]
+            },
+            {
+              "type": "stack",
+              "groupby": [
+                "Creative Type"
+              ],
+              "field": "sum_Worldwide Gross",
+              "sort": {
+                "field": [
+                  "d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order"
+                ],
+                "order": [
+                  "descending"
+                ]
+              },
+              "as": [
+                "sum_Worldwide Gross_start",
+                "sum_Worldwide Gross_end"
+              ],
+              "offset": "zero"
+            },
+            {
+              "type": "filter",
+              "expr": "isValid(datum[\"sum_Worldwide Gross\"]) && isFinite(+datum[\"sum_Worldwide Gross\"])"
+            }
+          ]
+        }
+      ],
+      "encode": {
+        "update": {
+          "width": {
+            "signal": "child_width"
+          },
+          "height": {
+            "signal": "child_height"
+          }
+        }
+      },
+      "signals": [
+        {
+          "name": "facet",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "pointermove"
+                }
+              ],
+              "update": "isTuple(facet) ? facet : group(\"cell\").datum"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_x",
+          "value": [],
+          "on": [
+            {
+              "events": {
+                "source": "scope",
+                "type": "pointerdown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"interval_intervalselection_0_brush\""
+                ]
+              },
+              "update": "[x(unit), x(unit)]"
+            },
+            {
+              "events": {
+                "source": "window",
+                "type": "pointermove",
+                "consume": true,
+                "between": [
+                  {
+                    "source": "scope",
+                    "type": "pointerdown",
+                    "filter": [
+                      "!event.item || event.item.mark.name !== \"interval_intervalselection_0_brush\""
+                    ]
+                  },
+                  {
+                    "source": "window",
+                    "type": "pointerup"
+                  }
+                ]
+              },
+              "update": "[interval_intervalselection_0_x[0], clamp(x(unit), 0, child_width)]"
+            },
+            {
+              "events": {
+                "signal": "interval_intervalselection_0_scale_trigger"
+              },
+              "update": "[0, 0]"
+            },
+            {
+              "events": [
+                {
+                  "source": "view",
+                  "type": "dblclick"
+                }
+              ],
+              "update": "[0, 0]"
+            },
+            {
+              "events": {
+                "signal": "interval_intervalselection_0_translate_delta"
+              },
+              "update": "clampRange(panLinear(interval_intervalselection_0_translate_anchor.extent_x, interval_intervalselection_0_translate_delta.x / span(interval_intervalselection_0_translate_anchor.extent_x)), 0, child_width)"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_Creative_Type",
+          "on": [
+            {
+              "events": {
+                "signal": "interval_intervalselection_0_x"
+              },
+              "update": "interval_intervalselection_0_x[0] === interval_intervalselection_0_x[1] ? null : invert(\"x\", interval_intervalselection_0_x)"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_scale_trigger",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "x"
+                }
+              ],
+              "update": "(!isArray(interval_intervalselection_0_Creative_Type) || (invert(\"x\", interval_intervalselection_0_x)[0] === interval_intervalselection_0_Creative_Type[0] && invert(\"x\", interval_intervalselection_0_x)[1] === interval_intervalselection_0_Creative_Type[1])) ? interval_intervalselection_0_scale_trigger : {}"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_tuple",
+          "on": [
+            {
+              "events": [
+                {
+                  "signal": "interval_intervalselection_0_Creative_Type"
+                }
+              ],
+              "update": "interval_intervalselection_0_Creative_Type ? {unit: \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"]), fields: interval_intervalselection_0_tuple_fields, values: [interval_intervalselection_0_Creative_Type]} : null"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_tuple_fields",
+          "value": [
+            {
+              "field": "Creative Type",
+              "channel": "x",
+              "type": "E"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_translate_anchor",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "pointerdown",
+                  "markname": "interval_intervalselection_0_brush"
+                }
+              ],
+              "update": "{x: x(unit), y: y(unit), extent_x: slice(interval_intervalselection_0_x)}"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_translate_delta",
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "window",
+                  "type": "pointermove",
+                  "consume": true,
+                  "between": [
+                    {
+                      "source": "scope",
+                      "type": "pointerdown",
+                      "markname": "interval_intervalselection_0_brush"
+                    },
+                    {
+                      "source": "window",
+                      "type": "pointerup"
+                    }
+                  ]
+                }
+              ],
+              "update": "{x: interval_intervalselection_0_translate_anchor.x - x(unit), y: interval_intervalselection_0_translate_anchor.y - y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "interval_intervalselection_0_modify",
+          "on": [
+            {
+              "events": {
+                "signal": "interval_intervalselection_0_tuple"
+              },
+              "update": "modify(\"interval_intervalselection_0_store\", interval_intervalselection_0_tuple, true)"
+            }
+          ]
+        },
+        {
+          "name": "click_pointselection_0_tuple",
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "click"
+                }
+              ],
+              "update": "datum && item().mark.marktype !== 'group' && indexof(item().mark.role, 'legend') < 0 && indexof(item().mark.name, 'interval_intervalselection_0_brush') < 0 ? {unit: \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"]), fields: click_pointselection_0_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"Creative Type\"], (item().isVoronoi ? datum.datum : datum)[\"MPAA Rating\"]]} : null",
+              "force": true
+            },
+            {
+              "events": [
+                {
+                  "source": "view",
+                  "type": "dblclick"
+                }
+              ],
+              "update": "null"
+            }
+          ]
+        },
+        {
+          "name": "click_pointselection_0_tuple_fields",
+          "value": [
+            {
+              "field": "Creative Type",
+              "channel": "x",
+              "type": "E"
+            },
+            {
+              "field": "MPAA Rating",
+              "channel": "color",
+              "type": "E"
+            }
+          ]
+        },
+        {
+          "name": "click_pointselection_0_toggle",
+          "value": false,
+          "on": [
+            {
+              "events": [
+                {
+                  "source": "scope",
+                  "type": "click"
+                }
+              ],
+              "update": "false"
+            },
+            {
+              "events": [
+                {
+                  "source": "view",
+                  "type": "dblclick"
+                }
+              ],
+              "update": "false"
+            }
+          ]
+        },
+        {
+          "name": "click_pointselection_0_modify",
+          "on": [
+            {
+              "events": {
+                "signal": "click_pointselection_0_tuple"
+              },
+              "update": "modify(\"click_pointselection_0_store\", click_pointselection_0_toggle ? null : click_pointselection_0_tuple, click_pointselection_0_toggle ? null : true, click_pointselection_0_toggle ? click_pointselection_0_tuple : null)"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointselection_0_tuple",
+          "update": "legend_pointselection_0_MPAA_Rating_legend !== null ? {fields: legend_pointselection_0_tuple_fields, values: [legend_pointselection_0_MPAA_Rating_legend]} : null"
+        },
+        {
+          "name": "legend_pointselection_0_tuple_fields",
+          "value": [
+            {
+              "field": "MPAA Rating",
+              "channel": "color",
+              "type": "E"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointselection_0_toggle",
+          "value": false,
+          "on": [
+            {
+              "events": {
+                "merge": [
+                  {
+                    "source": "view",
+                    "type": "click"
+                  }
+                ]
+              },
+              "update": "event.shiftKey"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointselection_0_modify",
+          "on": [
+            {
+              "events": {
+                "signal": "legend_pointselection_0_tuple"
+              },
+              "update": "modify(\"legend_pointselection_0_store\", legend_pointselection_0_toggle ? null : legend_pointselection_0_tuple, legend_pointselection_0_toggle ? null : true, legend_pointselection_0_toggle ? legend_pointselection_0_tuple : null)"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointhover_0_tuple",
+          "update": "legend_pointhover_0_MPAA_Rating_legend !== null ? {fields: legend_pointhover_0_tuple_fields, values: [legend_pointhover_0_MPAA_Rating_legend]} : null"
+        },
+        {
+          "name": "legend_pointhover_0_tuple_fields",
+          "value": [
+            {
+              "field": "MPAA Rating",
+              "channel": "color",
+              "type": "E"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointhover_0_toggle",
+          "value": false,
+          "on": [
+            {
+              "events": {
+                "merge": [
+                  {
+                    "source": "view",
+                    "type": "click"
+                  }
+                ]
+              },
+              "update": "event.shiftKey"
+            }
+          ]
+        },
+        {
+          "name": "legend_pointhover_0_modify",
+          "on": [
+            {
+              "events": {
+                "signal": "legend_pointhover_0_tuple"
+              },
+              "update": "modify(\"legend_pointhover_0_store\", legend_pointhover_0_toggle ? null : legend_pointhover_0_tuple, legend_pointhover_0_toggle ? null : true, legend_pointhover_0_toggle ? legend_pointhover_0_tuple : null)"
+            }
+          ]
+        }
+      ],
+      "marks": [
+        {
+          "name": "interval_intervalselection_0_brush_bg",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {
+              "fill": {
+                "value": "#669EFF"
+              },
+              "fillOpacity": {
+                "value": 0.07
+              }
+            },
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "signal": "interval_intervalselection_0_x[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "value": 0
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "x2": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "signal": "interval_intervalselection_0_x[1]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y2": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "field": {
+                    "group": "height"
+                  }
+                },
+                {
+                  "value": 0
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "child_layer_0_layer_0_layer_0_marks",
+          "type": "rect",
+          "clip": true,
+          "style": [
+            "bar"
+          ],
+          "interactive": true,
+          "from": {
+            "data": "data_0"
+          },
+          "encode": {
+            "update": {
+              "cursor": {
+                "value": "pointer"
+              },
+              "fill": {
+                "scale": "color",
+                "field": "MPAA Rating"
+              },
+              "opacity": [
+                {
+                  "test": "!((!length(data(\"interval_intervalselection_0_store\")) || vlSelectionTest(\"interval_intervalselection_0_store\", datum)) && (!length(data(\"click_pointselection_0_store\")) || vlSelectionTest(\"click_pointselection_0_store\", datum)) && ((length(data(\"legend_pointselection_0_store\")) && vlSelectionTest(\"legend_pointselection_0_store\", datum)) || (!length(data(\"legend_pointhover_0_store\")) || vlSelectionTest(\"legend_pointhover_0_store\", datum))))",
+                  "value": 0.3
+                },
+                {
+                  "value": 1
+                }
+              ],
+              "tooltip": {
+                "signal": "{\"Creative Type\": isValid(datum[\"Creative Type\"]) ? datum[\"Creative Type\"] : \"\"+datum[\"Creative Type\"], \"Sum of Worldwide Gross\": format(datum[\"sum_Worldwide Gross\"], \"\"), \"MPAA Rating\": isValid(datum[\"MPAA Rating\"]) ? datum[\"MPAA Rating\"] : \"\"+datum[\"MPAA Rating\"]}"
+              },
+              "ariaRoleDescription": {
+                "value": "bar"
+              },
+              "description": {
+                "signal": "\"Creative Type: \" + (isValid(datum[\"Creative Type\"]) ? datum[\"Creative Type\"] : \"\"+datum[\"Creative Type\"]) + \"; Sum of Worldwide Gross: \" + (format(datum[\"sum_Worldwide Gross\"], \"\")) + \"; MPAA Rating: \" + (isValid(datum[\"MPAA Rating\"]) ? datum[\"MPAA Rating\"] : \"\"+datum[\"MPAA Rating\"]) + \"; d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order: \" + (isValid(datum[\"d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order\"]) ? datum[\"d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order\"] : \"\"+datum[\"d00e1fdb-6cb1-40c6-8276-2f7f58875f69-custom-stack-order\"])"
+              },
+              "x": {
+                "scale": "x",
+                "field": "Creative Type"
+              },
+              "width": {
+                "signal": "max(0.25, bandwidth('x'))"
+              },
+              "y": {
+                "scale": "y",
+                "field": "sum_Worldwide Gross_end"
+              },
+              "y2": {
+                "scale": "y",
+                "field": "sum_Worldwide Gross_start"
+              }
+            }
+          }
+        },
+        {
+          "name": "interval_intervalselection_0_brush",
+          "type": "rect",
+          "clip": true,
+          "encode": {
+            "enter": {
+              "fill": {
+                "value": "transparent"
+              }
+            },
+            "update": {
+              "x": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "signal": "interval_intervalselection_0_x[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "value": 0
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "x2": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "signal": "interval_intervalselection_0_x[1]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y2": [
+                {
+                  "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"child_layer_0_layer_0_layer_0\" + '__facet_column_' + (facet[\"MPAA Rating\"])",
+                  "field": {
+                    "group": "height"
+                  }
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "stroke": [
+                {
+                  "test": "interval_intervalselection_0_x[0] !== interval_intervalselection_0_x[1]",
+                  "value": "#669EFF"
+                },
+                {
+                  "value": null
+                }
+              ],
+              "strokeOpacity": [
+                {
+                  "test": "interval_intervalselection_0_x[0] !== interval_intervalselection_0_x[1]",
+                  "value": 0.4
+                },
+                {
+                  "value": null
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "axes": [
+        {
+          "scale": "x",
+          "orient": "bottom",
+          "grid": true,
+          "gridScale": "y",
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        },
+        {
+          "scale": "y",
+          "orient": "left",
+          "grid": true,
+          "gridScale": "x",
+          "tickCount": {
+            "signal": "ceil(child_height/40)"
+          },
+          "domain": false,
+          "labels": false,
+          "aria": false,
+          "maxExtent": 0,
+          "minExtent": 0,
+          "ticks": false,
+          "zindex": 0
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {
+        "data": "data_3",
+        "field": "Creative Type",
+        "sort": true
+      },
+      "range": [
+        0,
+        {
+          "signal": "child_width"
+        }
+      ],
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "data": "data_3",
+        "fields": [
+          "sum_Worldwide Gross_start",
+          "sum_Worldwide Gross_end"
+        ]
+      },
+      "range": [
+        {
+          "signal": "child_height"
+        },
+        0
+      ],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {
+        "data": "data_0",
+        "field": "MPAA Rating",
+        "sort": {
+          "op": "min",
+          "field": "color_MPAA Rating_sort_index"
+        }
+      },
+      "range": [
+        "#4C78A8",
+        "#F58518",
+        "#E45756",
+        "#72B7B2",
+        "#54A24B",
+        "#EECA3B",
+        "#B279A2",
+        "#FF9DA6",
+        "#9D755D",
+        "#BAB0AC"
+      ],
+      "interpolate": "hcl"
+    }
+  ],
+  "legends": [
+    {
+      "symbolOpacity": 1,
+      "title": "MPAA Rating",
+      "fill": "color",
+      "symbolType": "square",
+      "encode": {
+        "labels": {
+          "name": "MPAA_Rating_legend_labels",
+          "interactive": true,
+          "update": {
+            "opacity": [
+              {
+                "test": "(!length(data(\"legend_pointselection_0_store\")) || (legend_pointselection_0[\"MPAA Rating\"] && indexof(legend_pointselection_0[\"MPAA Rating\"], datum.value) >= 0)) || (!length(data(\"legend_pointhover_0_store\")) || (legend_pointhover_0[\"MPAA Rating\"] && indexof(legend_pointhover_0[\"MPAA Rating\"], datum.value) >= 0))",
+                "value": 1
+              },
+              {
+                "value": 0.35
+              }
+            ]
+          }
+        },
+        "symbols": {
+          "name": "MPAA_Rating_legend_symbols",
+          "interactive": true,
+          "update": {
+            "opacity": [
+              {
+                "test": "(!length(data(\"legend_pointselection_0_store\")) || (legend_pointselection_0[\"MPAA Rating\"] && indexof(legend_pointselection_0[\"MPAA Rating\"], datum.value) >= 0)) || (!length(data(\"legend_pointhover_0_store\")) || (legend_pointhover_0[\"MPAA Rating\"] && indexof(legend_pointhover_0[\"MPAA Rating\"], datum.value) >= 0))",
+                "value": 1
+              },
+              {
+                "value": 0.35
+              }
+            ]
+          }
+        },
+        "entries": {
+          "name": "MPAA_Rating_legend_entries",
+          "interactive": true,
+          "update": {
+            "fill": {
+              "value": "transparent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -147,7 +147,8 @@ mod test_custom_specs {
         case("custom/binned_ordinal", 0.001, true),
         case("custom/timeOffset_stocks", 0.001, true),
         case("custom/quakes_initial_selection", 0.001, true),
-        case("custom/aggregate_with_threshold", 0.001, true)
+        case("custom/aggregate_with_threshold", 0.001, true),
+        case("custom/facet_with_selections", 0.001, true)
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");


### PR DESCRIPTION
Consider a facet group mark like this:

```json
    {
      "name": "cell",
      "type": "group",
      "style": "cell",
      "from": {
        "facet": {
          "name": "facet",
          "data": "data_0",
          "groupby": [
            "MPAA Rating"
          ]
        }
      },
      "sort": {
        "field": [
          "datum[\"MPAA Rating\"]"
        ],
        "order": [
          "ascending"
        ]
      },
      "data": [
        {
          "source": "facet",
          "name": "data_0",
...
```

The facet lift optimization introduces a new dataset (named `data_0_facet_facet0`) and intends to insert this new dataset alongside the facet mark's input dataset (`data_0` in this case). Notice that in this case, the facet group mark has a nested dataset also named `data_0`. The error we were making is that we would mistakenly resolve `data_0` to be the nested dataset and place the new `data_0_facet_facet0` nested inside the facet group mark, where it is not visible from the facet definition.

The fix is to only resolve the source dataset in the scope above the facet definition.

A previously failing test is added