### PR TITLE
Restore pyarrow 10 support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -350,8 +350,8 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
-          python -m pip install pyarrow==10.0
+          python -m pip install pytest vega-datasets polars duckdb vl-convert-python scikit-image pandas==2.0
+          python -m pip install pyarrow==10.0 altair==5.1.2
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -351,6 +351,7 @@ jobs:
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_7_x86_64.whl
           python -m pip install pytest vega-datasets polars duckdb altair vl-convert-python scikit-image pandas==2.0
+          python -m pip install pyarrow==10.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/python/vegafusion/vegafusion/datasource/dfi_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/dfi_datasource.py
@@ -1,7 +1,6 @@
 from typing import Iterable
 import re
 import pyarrow as pa
-from pyarrow.interchange import from_dataframe
 
 from typing import Any, Dict
 from ._dfi_types import DtypeKind, DataFrame as DfiDataFrame
@@ -79,6 +78,7 @@ class DfiDatasource(Datasource):
         return self._schema
 
     def fetch(self, columns: Iterable[str]) -> pa.Table:
+        from pyarrow.interchange import from_dataframe
         columns = list(columns)
         projected_schema = pa.schema([f for f in self._schema if f.name in columns])
         table = from_dataframe(self._dataframe.select_columns_by_name(columns))


### PR DESCRIPTION
Version 1.6.0 inadvertently caused a hard dependency on pyarrow 11's dataframe interchange support.  This PR removes that hard dependency by delaying the import of dataframe interchange support until needed.