### PR TITLE
Lift bin and timeunit transforms out of facets

### DIFF
--- a/vegafusion-core/src/planning/lift_facet_aggregations.rs
+++ b/vegafusion-core/src/planning/lift_facet_aggregations.rs
@@ -136,6 +136,14 @@ impl MutChartVisitor for ExtractFacetAggregationsVisitor {
                     lifted_transforms.push(TransformSpec::Filter(tx));
                     child_dataset.transform.remove(0);
                 }
+                Some(TransformSpec::Bin(tx)) => {
+                    lifted_transforms.push(TransformSpec::Bin(tx));
+                    child_dataset.transform.remove(0);
+                }
+                Some(TransformSpec::Timeunit(tx)) => {
+                    lifted_transforms.push(TransformSpec::Timeunit(tx));
+                    child_dataset.transform.remove(0);
+                }
                 _ => {
                     // Reached unsupported transform type without an aggregation
                     break None;


### PR DESCRIPTION
Follow-on to https://github.com/hex-inc/vegafusion/pull/446 that also lifts leading `timeunit` and `bin` transforms in addition to `formula` and `filter`.