### PR TITLE
Fix local datetime stringification for columns that need escaping

### DIFF
--- a/vegafusion-core/src/planning/stringify_local_datetimes.rs
+++ b/vegafusion-core/src/planning/stringify_local_datetimes.rs
@@ -15,6 +15,7 @@ use crate::task_graph::scope::TaskScope;
 use itertools::sorted;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use vegafusion_common::escape::unescape_field;
 
 /// This planning phase converts select datetime columns from the default millisecond UTC
 /// representation to naive datetime strings in an "output timezone". This is only done for datetime
@@ -385,13 +386,14 @@ impl<'a> MutChartVisitor for StringifyLocalDatetimeFieldsVisitor<'a> {
         );
 
         for field in sorted(fields) {
+            let field = unescape_field(&field);
             let expr_str =
                 format!("timeFormat(toDate(datum['{field}'], 'local'), '%Y-%m-%dT%H:%M:%S.%L')");
 
             let transforms = &mut data.transform;
             let transform = FormulaTransformSpec {
                 expr: expr_str,
-                as_: field.to_string(),
+                as_: field,
                 extra: Default::default(),
             };
             transforms.push(TransformSpec::Formula(transform))
@@ -405,6 +407,7 @@ impl<'a> MutChartVisitor for StringifyLocalDatetimeFieldsVisitor<'a> {
             let source_resolved_var = (source_resolved.var, source_resolved.scope);
             if let Some(fields) = self.local_datetime_fields.get(&source_resolved_var) {
                 for field in sorted(fields) {
+                    let field = unescape_field(&field);
                     let expr_str = format!("toDate(datum['{field}'], 'local')");
                     let transforms = &mut data.transform;
                     let transform = FormulaTransformSpec {
@@ -448,6 +451,7 @@ impl<'a> MutChartVisitor for FormatLocalDatetimeFieldsVisitor<'a> {
             self.domain_dataset_fields,
         );
         for field in sorted(fields) {
+            let field = unescape_field(&field);
             let transforms = &mut data.transform;
             let transform = FormulaTransformSpec {
                 expr: format!("toDate(datum['{field}'])"),

--- a/vegafusion-runtime/tests/specs/custom/local_timezone_with_dot.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/local_timezone_with_dot.comm_plan.json
@@ -1,0 +1,15 @@
+{
+  "server_to_client": [
+    {
+      "namespace": "data",
+      "name": "data_0",
+      "scope": []
+    },
+    {
+      "namespace": "data",
+      "name": "data_0_y_domain_sum_price",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/local_timezone_with_dot.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/local_timezone_with_dot.vg.json
@@ -1,0 +1,1037 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "autosize": {"type": "fit", "contains": "padding"},
+  "background": "white",
+  "padding": 5,
+  "style": "cell",
+  "data": [
+    {"name": "interval_intervalselection_0_store"},
+    {"name": "click_pointselection_0_store"},
+    {
+      "name": "df",
+      "values": [
+        {"symbol": "MSFT", "da.te": "Jan 1 2000", "price": 39.81},
+        {"symbol": "MSFT", "da.te": "Feb 1 2000", "price": 36.35},
+        {"symbol": "MSFT", "da.te": "Mar 1 2000", "price": 43.22},
+        {"symbol": "MSFT", "da.te": "Apr 1 2000", "price": 28.37},
+        {"symbol": "MSFT", "da.te": "May 1 2000", "price": 25.45},
+        {"symbol": "MSFT", "da.te": "Jun 1 2000", "price": 32.54},
+        {"symbol": "MSFT", "da.te": "Jul 1 2000", "price": 28.4},
+        {"symbol": "MSFT", "da.te": "Aug 1 2000", "price": 28.4},
+        {"symbol": "MSFT", "da.te": "Sep 1 2000", "price": 24.53},
+        {"symbol": "MSFT", "da.te": "Oct 1 2000", "price": 28.02},
+        {"symbol": "MSFT", "da.te": "Nov 1 2000", "price": 23.34},
+        {"symbol": "MSFT", "da.te": "Dec 1 2000", "price": 17.65},
+        {"symbol": "MSFT", "da.te": "Jan 1 2001", "price": 24.84},
+        {"symbol": "MSFT", "da.te": "Feb 1 2001", "price": 24},
+        {"symbol": "MSFT", "da.te": "Mar 1 2001", "price": 22.25},
+        {"symbol": "MSFT", "da.te": "Apr 1 2001", "price": 27.56},
+        {"symbol": "MSFT", "da.te": "May 1 2001", "price": 28.14},
+        {"symbol": "MSFT", "da.te": "Jun 1 2001", "price": 29.7},
+        {"symbol": "MSFT", "da.te": "Jul 1 2001", "price": 26.93},
+        {"symbol": "MSFT", "da.te": "Aug 1 2001", "price": 23.21},
+        {"symbol": "MSFT", "da.te": "Sep 1 2001", "price": 20.82},
+        {"symbol": "MSFT", "da.te": "Oct 1 2001", "price": 23.65},
+        {"symbol": "MSFT", "da.te": "Nov 1 2001", "price": 26.12},
+        {"symbol": "MSFT", "da.te": "Dec 1 2001", "price": 26.95},
+        {"symbol": "MSFT", "da.te": "Jan 1 2002", "price": 25.92},
+        {"symbol": "MSFT", "da.te": "Feb 1 2002", "price": 23.73},
+        {"symbol": "MSFT", "da.te": "Mar 1 2002", "price": 24.53},
+        {"symbol": "MSFT", "da.te": "Apr 1 2002", "price": 21.26},
+        {"symbol": "MSFT", "da.te": "May 1 2002", "price": 20.71},
+        {"symbol": "MSFT", "da.te": "Jun 1 2002", "price": 22.25},
+        {"symbol": "MSFT", "da.te": "Jul 1 2002", "price": 19.52},
+        {"symbol": "MSFT", "da.te": "Aug 1 2002", "price": 19.97},
+        {"symbol": "MSFT", "da.te": "Sep 1 2002", "price": 17.79},
+        {"symbol": "MSFT", "da.te": "Oct 1 2002", "price": 21.75},
+        {"symbol": "MSFT", "da.te": "Nov 1 2002", "price": 23.46},
+        {"symbol": "MSFT", "da.te": "Dec 1 2002", "price": 21.03},
+        {"symbol": "MSFT", "da.te": "Jan 1 2003", "price": 19.31},
+        {"symbol": "MSFT", "da.te": "Feb 1 2003", "price": 19.34},
+        {"symbol": "MSFT", "da.te": "Mar 1 2003", "price": 19.76},
+        {"symbol": "MSFT", "da.te": "Apr 1 2003", "price": 20.87},
+        {"symbol": "MSFT", "da.te": "May 1 2003", "price": 20.09},
+        {"symbol": "MSFT", "da.te": "Jun 1 2003", "price": 20.93},
+        {"symbol": "MSFT", "da.te": "Jul 1 2003", "price": 21.56},
+        {"symbol": "MSFT", "da.te": "Aug 1 2003", "price": 21.65},
+        {"symbol": "MSFT", "da.te": "Sep 1 2003", "price": 22.69},
+        {"symbol": "MSFT", "da.te": "Oct 1 2003", "price": 21.45},
+        {"symbol": "MSFT", "da.te": "Nov 1 2003", "price": 21.1},
+        {"symbol": "MSFT", "da.te": "Dec 1 2003", "price": 22.46},
+        {"symbol": "MSFT", "da.te": "Jan 1 2004", "price": 22.69},
+        {"symbol": "MSFT", "da.te": "Feb 1 2004", "price": 21.77},
+        {"symbol": "MSFT", "da.te": "Mar 1 2004", "price": 20.46},
+        {"symbol": "MSFT", "da.te": "Apr 1 2004", "price": 21.45},
+        {"symbol": "MSFT", "da.te": "May 1 2004", "price": 21.53},
+        {"symbol": "MSFT", "da.te": "Jun 1 2004", "price": 23.44},
+        {"symbol": "MSFT", "da.te": "Jul 1 2004", "price": 23.38},
+        {"symbol": "MSFT", "da.te": "Aug 1 2004", "price": 22.47},
+        {"symbol": "MSFT", "da.te": "Sep 1 2004", "price": 22.76},
+        {"symbol": "MSFT", "da.te": "Oct 1 2004", "price": 23.02},
+        {"symbol": "MSFT", "da.te": "Nov 1 2004", "price": 24.6},
+        {"symbol": "MSFT", "da.te": "Dec 1 2004", "price": 24.52},
+        {"symbol": "MSFT", "da.te": "Jan 1 2005", "price": 24.11},
+        {"symbol": "MSFT", "da.te": "Feb 1 2005", "price": 23.15},
+        {"symbol": "MSFT", "da.te": "Mar 1 2005", "price": 22.24},
+        {"symbol": "MSFT", "da.te": "Apr 1 2005", "price": 23.28},
+        {"symbol": "MSFT", "da.te": "May 1 2005", "price": 23.82},
+        {"symbol": "MSFT", "da.te": "Jun 1 2005", "price": 22.93},
+        {"symbol": "MSFT", "da.te": "Jul 1 2005", "price": 23.64},
+        {"symbol": "MSFT", "da.te": "Aug 1 2005", "price": 25.35},
+        {"symbol": "MSFT", "da.te": "Sep 1 2005", "price": 23.83},
+        {"symbol": "MSFT", "da.te": "Oct 1 2005", "price": 23.8},
+        {"symbol": "MSFT", "da.te": "Nov 1 2005", "price": 25.71},
+        {"symbol": "MSFT", "da.te": "Dec 1 2005", "price": 24.29},
+        {"symbol": "MSFT", "da.te": "Jan 1 2006", "price": 26.14},
+        {"symbol": "MSFT", "da.te": "Feb 1 2006", "price": 25.04},
+        {"symbol": "MSFT", "da.te": "Mar 1 2006", "price": 25.36},
+        {"symbol": "MSFT", "da.te": "Apr 1 2006", "price": 22.5},
+        {"symbol": "MSFT", "da.te": "May 1 2006", "price": 21.19},
+        {"symbol": "MSFT", "da.te": "Jun 1 2006", "price": 21.8},
+        {"symbol": "MSFT", "da.te": "Jul 1 2006", "price": 22.51},
+        {"symbol": "MSFT", "da.te": "Aug 1 2006", "price": 24.13},
+        {"symbol": "MSFT", "da.te": "Sep 1 2006", "price": 25.68},
+        {"symbol": "MSFT", "da.te": "Oct 1 2006", "price": 26.96},
+        {"symbol": "MSFT", "da.te": "Nov 1 2006", "price": 27.66},
+        {"symbol": "MSFT", "da.te": "Dec 1 2006", "price": 28.13},
+        {"symbol": "MSFT", "da.te": "Jan 1 2007", "price": 29.07},
+        {"symbol": "MSFT", "da.te": "Feb 1 2007", "price": 26.63},
+        {"symbol": "MSFT", "da.te": "Mar 1 2007", "price": 26.35},
+        {"symbol": "MSFT", "da.te": "Apr 1 2007", "price": 28.3},
+        {"symbol": "MSFT", "da.te": "May 1 2007", "price": 29.11},
+        {"symbol": "MSFT", "da.te": "Jun 1 2007", "price": 27.95},
+        {"symbol": "MSFT", "da.te": "Jul 1 2007", "price": 27.5},
+        {"symbol": "MSFT", "da.te": "Aug 1 2007", "price": 27.34},
+        {"symbol": "MSFT", "da.te": "Sep 1 2007", "price": 28.04},
+        {"symbol": "MSFT", "da.te": "Oct 1 2007", "price": 35.03},
+        {"symbol": "MSFT", "da.te": "Nov 1 2007", "price": 32.09},
+        {"symbol": "MSFT", "da.te": "Dec 1 2007", "price": 34},
+        {"symbol": "MSFT", "da.te": "Jan 1 2008", "price": 31.13},
+        {"symbol": "MSFT", "da.te": "Feb 1 2008", "price": 26.07},
+        {"symbol": "MSFT", "da.te": "Mar 1 2008", "price": 27.21},
+        {"symbol": "MSFT", "da.te": "Apr 1 2008", "price": 27.34},
+        {"symbol": "MSFT", "da.te": "May 1 2008", "price": 27.25},
+        {"symbol": "MSFT", "da.te": "Jun 1 2008", "price": 26.47},
+        {"symbol": "MSFT", "da.te": "Jul 1 2008", "price": 24.75},
+        {"symbol": "MSFT", "da.te": "Aug 1 2008", "price": 26.36},
+        {"symbol": "MSFT", "da.te": "Sep 1 2008", "price": 25.78},
+        {"symbol": "MSFT", "da.te": "Oct 1 2008", "price": 21.57},
+        {"symbol": "MSFT", "da.te": "Nov 1 2008", "price": 19.66},
+        {"symbol": "MSFT", "da.te": "Dec 1 2008", "price": 18.91},
+        {"symbol": "MSFT", "da.te": "Jan 1 2009", "price": 16.63},
+        {"symbol": "MSFT", "da.te": "Feb 1 2009", "price": 15.81},
+        {"symbol": "MSFT", "da.te": "Mar 1 2009", "price": 17.99},
+        {"symbol": "MSFT", "da.te": "Apr 1 2009", "price": 19.84},
+        {"symbol": "MSFT", "da.te": "May 1 2009", "price": 20.59},
+        {"symbol": "MSFT", "da.te": "Jun 1 2009", "price": 23.42},
+        {"symbol": "MSFT", "da.te": "Jul 1 2009", "price": 23.18},
+        {"symbol": "MSFT", "da.te": "Aug 1 2009", "price": 24.43},
+        {"symbol": "MSFT", "da.te": "Sep 1 2009", "price": 25.49},
+        {"symbol": "MSFT", "da.te": "Oct 1 2009", "price": 27.48},
+        {"symbol": "MSFT", "da.te": "Nov 1 2009", "price": 29.27},
+        {"symbol": "MSFT", "da.te": "Dec 1 2009", "price": 30.34},
+        {"symbol": "MSFT", "da.te": "Jan 1 2010", "price": 28.05},
+        {"symbol": "MSFT", "da.te": "Feb 1 2010", "price": 28.67},
+        {"symbol": "MSFT", "da.te": "Mar 1 2010", "price": 28.8},
+        {"symbol": "AMZN", "da.te": "Jan 1 2000", "price": 64.56},
+        {"symbol": "AMZN", "da.te": "Feb 1 2000", "price": 68.87},
+        {"symbol": "AMZN", "da.te": "Mar 1 2000", "price": 67},
+        {"symbol": "AMZN", "da.te": "Apr 1 2000", "price": 55.19},
+        {"symbol": "AMZN", "da.te": "May 1 2000", "price": 48.31},
+        {"symbol": "AMZN", "da.te": "Jun 1 2000", "price": 36.31},
+        {"symbol": "AMZN", "da.te": "Jul 1 2000", "price": 30.12},
+        {"symbol": "AMZN", "da.te": "Aug 1 2000", "price": 41.5},
+        {"symbol": "AMZN", "da.te": "Sep 1 2000", "price": 38.44},
+        {"symbol": "AMZN", "da.te": "Oct 1 2000", "price": 36.62},
+        {"symbol": "AMZN", "da.te": "Nov 1 2000", "price": 24.69},
+        {"symbol": "AMZN", "da.te": "Dec 1 2000", "price": 15.56},
+        {"symbol": "AMZN", "da.te": "Jan 1 2001", "price": 17.31},
+        {"symbol": "AMZN", "da.te": "Feb 1 2001", "price": 10.19},
+        {"symbol": "AMZN", "da.te": "Mar 1 2001", "price": 10.23},
+        {"symbol": "AMZN", "da.te": "Apr 1 2001", "price": 15.78},
+        {"symbol": "AMZN", "da.te": "May 1 2001", "price": 16.69},
+        {"symbol": "AMZN", "da.te": "Jun 1 2001", "price": 14.15},
+        {"symbol": "AMZN", "da.te": "Jul 1 2001", "price": 12.49},
+        {"symbol": "AMZN", "da.te": "Aug 1 2001", "price": 8.94},
+        {"symbol": "AMZN", "da.te": "Sep 1 2001", "price": 5.97},
+        {"symbol": "AMZN", "da.te": "Oct 1 2001", "price": 6.98},
+        {"symbol": "AMZN", "da.te": "Nov 1 2001", "price": 11.32},
+        {"symbol": "AMZN", "da.te": "Dec 1 2001", "price": 10.82},
+        {"symbol": "AMZN", "da.te": "Jan 1 2002", "price": 14.19},
+        {"symbol": "AMZN", "da.te": "Feb 1 2002", "price": 14.1},
+        {"symbol": "AMZN", "da.te": "Mar 1 2002", "price": 14.3},
+        {"symbol": "AMZN", "da.te": "Apr 1 2002", "price": 16.69},
+        {"symbol": "AMZN", "da.te": "May 1 2002", "price": 18.23},
+        {"symbol": "AMZN", "da.te": "Jun 1 2002", "price": 16.25},
+        {"symbol": "AMZN", "da.te": "Jul 1 2002", "price": 14.45},
+        {"symbol": "AMZN", "da.te": "Aug 1 2002", "price": 14.94},
+        {"symbol": "AMZN", "da.te": "Sep 1 2002", "price": 15.93},
+        {"symbol": "AMZN", "da.te": "Oct 1 2002", "price": 19.36},
+        {"symbol": "AMZN", "da.te": "Nov 1 2002", "price": 23.35},
+        {"symbol": "AMZN", "da.te": "Dec 1 2002", "price": 18.89},
+        {"symbol": "AMZN", "da.te": "Jan 1 2003", "price": 21.85},
+        {"symbol": "AMZN", "da.te": "Feb 1 2003", "price": 22.01},
+        {"symbol": "AMZN", "da.te": "Mar 1 2003", "price": 26.03},
+        {"symbol": "AMZN", "da.te": "Apr 1 2003", "price": 28.69},
+        {"symbol": "AMZN", "da.te": "May 1 2003", "price": 35.89},
+        {"symbol": "AMZN", "da.te": "Jun 1 2003", "price": 36.32},
+        {"symbol": "AMZN", "da.te": "Jul 1 2003", "price": 41.64},
+        {"symbol": "AMZN", "da.te": "Aug 1 2003", "price": 46.32},
+        {"symbol": "AMZN", "da.te": "Sep 1 2003", "price": 48.43},
+        {"symbol": "AMZN", "da.te": "Oct 1 2003", "price": 54.43},
+        {"symbol": "AMZN", "da.te": "Nov 1 2003", "price": 53.97},
+        {"symbol": "AMZN", "da.te": "Dec 1 2003", "price": 52.62},
+        {"symbol": "AMZN", "da.te": "Jan 1 2004", "price": 50.4},
+        {"symbol": "AMZN", "da.te": "Feb 1 2004", "price": 43.01},
+        {"symbol": "AMZN", "da.te": "Mar 1 2004", "price": 43.28},
+        {"symbol": "AMZN", "da.te": "Apr 1 2004", "price": 43.6},
+        {"symbol": "AMZN", "da.te": "May 1 2004", "price": 48.5},
+        {"symbol": "AMZN", "da.te": "Jun 1 2004", "price": 54.4},
+        {"symbol": "AMZN", "da.te": "Jul 1 2004", "price": 38.92},
+        {"symbol": "AMZN", "da.te": "Aug 1 2004", "price": 38.14},
+        {"symbol": "AMZN", "da.te": "Sep 1 2004", "price": 40.86},
+        {"symbol": "AMZN", "da.te": "Oct 1 2004", "price": 34.13},
+        {"symbol": "AMZN", "da.te": "Nov 1 2004", "price": 39.68},
+        {"symbol": "AMZN", "da.te": "Dec 1 2004", "price": 44.29},
+        {"symbol": "AMZN", "da.te": "Jan 1 2005", "price": 43.22},
+        {"symbol": "AMZN", "da.te": "Feb 1 2005", "price": 35.18},
+        {"symbol": "AMZN", "da.te": "Mar 1 2005", "price": 34.27},
+        {"symbol": "AMZN", "da.te": "Apr 1 2005", "price": 32.36},
+        {"symbol": "AMZN", "da.te": "May 1 2005", "price": 35.51},
+        {"symbol": "AMZN", "da.te": "Jun 1 2005", "price": 33.09},
+        {"symbol": "AMZN", "da.te": "Jul 1 2005", "price": 45.15},
+        {"symbol": "AMZN", "da.te": "Aug 1 2005", "price": 42.7},
+        {"symbol": "AMZN", "da.te": "Sep 1 2005", "price": 45.3},
+        {"symbol": "AMZN", "da.te": "Oct 1 2005", "price": 39.86},
+        {"symbol": "AMZN", "da.te": "Nov 1 2005", "price": 48.46},
+        {"symbol": "AMZN", "da.te": "Dec 1 2005", "price": 47.15},
+        {"symbol": "AMZN", "da.te": "Jan 1 2006", "price": 44.82},
+        {"symbol": "AMZN", "da.te": "Feb 1 2006", "price": 37.44},
+        {"symbol": "AMZN", "da.te": "Mar 1 2006", "price": 36.53},
+        {"symbol": "AMZN", "da.te": "Apr 1 2006", "price": 35.21},
+        {"symbol": "AMZN", "da.te": "May 1 2006", "price": 34.61},
+        {"symbol": "AMZN", "da.te": "Jun 1 2006", "price": 38.68},
+        {"symbol": "AMZN", "da.te": "Jul 1 2006", "price": 26.89},
+        {"symbol": "AMZN", "da.te": "Aug 1 2006", "price": 30.83},
+        {"symbol": "AMZN", "da.te": "Sep 1 2006", "price": 32.12},
+        {"symbol": "AMZN", "da.te": "Oct 1 2006", "price": 38.09},
+        {"symbol": "AMZN", "da.te": "Nov 1 2006", "price": 40.34},
+        {"symbol": "AMZN", "da.te": "Dec 1 2006", "price": 39.46},
+        {"symbol": "AMZN", "da.te": "Jan 1 2007", "price": 37.67},
+        {"symbol": "AMZN", "da.te": "Feb 1 2007", "price": 39.14},
+        {"symbol": "AMZN", "da.te": "Mar 1 2007", "price": 39.79},
+        {"symbol": "AMZN", "da.te": "Apr 1 2007", "price": 61.33},
+        {"symbol": "AMZN", "da.te": "May 1 2007", "price": 69.14},
+        {"symbol": "AMZN", "da.te": "Jun 1 2007", "price": 68.41},
+        {"symbol": "AMZN", "da.te": "Jul 1 2007", "price": 78.54},
+        {"symbol": "AMZN", "da.te": "Aug 1 2007", "price": 79.91},
+        {"symbol": "AMZN", "da.te": "Sep 1 2007", "price": 93.15},
+        {"symbol": "AMZN", "da.te": "Oct 1 2007", "price": 89.15},
+        {"symbol": "AMZN", "da.te": "Nov 1 2007", "price": 90.56},
+        {"symbol": "AMZN", "da.te": "Dec 1 2007", "price": 92.64},
+        {"symbol": "AMZN", "da.te": "Jan 1 2008", "price": 77.7},
+        {"symbol": "AMZN", "da.te": "Feb 1 2008", "price": 64.47},
+        {"symbol": "AMZN", "da.te": "Mar 1 2008", "price": 71.3},
+        {"symbol": "AMZN", "da.te": "Apr 1 2008", "price": 78.63},
+        {"symbol": "AMZN", "da.te": "May 1 2008", "price": 81.62},
+        {"symbol": "AMZN", "da.te": "Jun 1 2008", "price": 73.33},
+        {"symbol": "AMZN", "da.te": "Jul 1 2008", "price": 76.34},
+        {"symbol": "AMZN", "da.te": "Aug 1 2008", "price": 80.81},
+        {"symbol": "AMZN", "da.te": "Sep 1 2008", "price": 72.76},
+        {"symbol": "AMZN", "da.te": "Oct 1 2008", "price": 57.24},
+        {"symbol": "AMZN", "da.te": "Nov 1 2008", "price": 42.7},
+        {"symbol": "AMZN", "da.te": "Dec 1 2008", "price": 51.28},
+        {"symbol": "AMZN", "da.te": "Jan 1 2009", "price": 58.82},
+        {"symbol": "AMZN", "da.te": "Feb 1 2009", "price": 64.79},
+        {"symbol": "AMZN", "da.te": "Mar 1 2009", "price": 73.44},
+        {"symbol": "AMZN", "da.te": "Apr 1 2009", "price": 80.52},
+        {"symbol": "AMZN", "da.te": "May 1 2009", "price": 77.99},
+        {"symbol": "AMZN", "da.te": "Jun 1 2009", "price": 83.66},
+        {"symbol": "AMZN", "da.te": "Jul 1 2009", "price": 85.76},
+        {"symbol": "AMZN", "da.te": "Aug 1 2009", "price": 81.19},
+        {"symbol": "AMZN", "da.te": "Sep 1 2009", "price": 93.36},
+        {"symbol": "AMZN", "da.te": "Oct 1 2009", "price": 118.81},
+        {"symbol": "AMZN", "da.te": "Nov 1 2009", "price": 135.91},
+        {"symbol": "AMZN", "da.te": "Dec 1 2009", "price": 134.52},
+        {"symbol": "AMZN", "da.te": "Jan 1 2010", "price": 125.41},
+        {"symbol": "AMZN", "da.te": "Feb 1 2010", "price": 118.4},
+        {"symbol": "AMZN", "da.te": "Mar 1 2010", "price": 128.82},
+        {"symbol": "IBM", "da.te": "Jan 1 2000", "price": 100.52},
+        {"symbol": "IBM", "da.te": "Feb 1 2000", "price": 92.11},
+        {"symbol": "IBM", "da.te": "Mar 1 2000", "price": 106.11},
+        {"symbol": "IBM", "da.te": "Apr 1 2000", "price": 99.95},
+        {"symbol": "IBM", "da.te": "May 1 2000", "price": 96.31},
+        {"symbol": "IBM", "da.te": "Jun 1 2000", "price": 98.33},
+        {"symbol": "IBM", "da.te": "Jul 1 2000", "price": 100.74},
+        {"symbol": "IBM", "da.te": "Aug 1 2000", "price": 118.62},
+        {"symbol": "IBM", "da.te": "Sep 1 2000", "price": 101.19},
+        {"symbol": "IBM", "da.te": "Oct 1 2000", "price": 88.5},
+        {"symbol": "IBM", "da.te": "Nov 1 2000", "price": 84.12},
+        {"symbol": "IBM", "da.te": "Dec 1 2000", "price": 76.47},
+        {"symbol": "IBM", "da.te": "Jan 1 2001", "price": 100.76},
+        {"symbol": "IBM", "da.te": "Feb 1 2001", "price": 89.98},
+        {"symbol": "IBM", "da.te": "Mar 1 2001", "price": 86.63},
+        {"symbol": "IBM", "da.te": "Apr 1 2001", "price": 103.7},
+        {"symbol": "IBM", "da.te": "May 1 2001", "price": 100.82},
+        {"symbol": "IBM", "da.te": "Jun 1 2001", "price": 102.35},
+        {"symbol": "IBM", "da.te": "Jul 1 2001", "price": 94.87},
+        {"symbol": "IBM", "da.te": "Aug 1 2001", "price": 90.25},
+        {"symbol": "IBM", "da.te": "Sep 1 2001", "price": 82.82},
+        {"symbol": "IBM", "da.te": "Oct 1 2001", "price": 97.58},
+        {"symbol": "IBM", "da.te": "Nov 1 2001", "price": 104.5},
+        {"symbol": "IBM", "da.te": "Dec 1 2001", "price": 109.36},
+        {"symbol": "IBM", "da.te": "Jan 1 2002", "price": 97.54},
+        {"symbol": "IBM", "da.te": "Feb 1 2002", "price": 88.82},
+        {"symbol": "IBM", "da.te": "Mar 1 2002", "price": 94.15},
+        {"symbol": "IBM", "da.te": "Apr 1 2002", "price": 75.82},
+        {"symbol": "IBM", "da.te": "May 1 2002", "price": 72.97},
+        {"symbol": "IBM", "da.te": "Jun 1 2002", "price": 65.31},
+        {"symbol": "IBM", "da.te": "Jul 1 2002", "price": 63.86},
+        {"symbol": "IBM", "da.te": "Aug 1 2002", "price": 68.52},
+        {"symbol": "IBM", "da.te": "Sep 1 2002", "price": 53.01},
+        {"symbol": "IBM", "da.te": "Oct 1 2002", "price": 71.76},
+        {"symbol": "IBM", "da.te": "Nov 1 2002", "price": 79.16},
+        {"symbol": "IBM", "da.te": "Dec 1 2002", "price": 70.58},
+        {"symbol": "IBM", "da.te": "Jan 1 2003", "price": 71.22},
+        {"symbol": "IBM", "da.te": "Feb 1 2003", "price": 71.13},
+        {"symbol": "IBM", "da.te": "Mar 1 2003", "price": 71.57},
+        {"symbol": "IBM", "da.te": "Apr 1 2003", "price": 77.47},
+        {"symbol": "IBM", "da.te": "May 1 2003", "price": 80.48},
+        {"symbol": "IBM", "da.te": "Jun 1 2003", "price": 75.42},
+        {"symbol": "IBM", "da.te": "Jul 1 2003", "price": 74.28},
+        {"symbol": "IBM", "da.te": "Aug 1 2003", "price": 75.12},
+        {"symbol": "IBM", "da.te": "Sep 1 2003", "price": 80.91},
+        {"symbol": "IBM", "da.te": "Oct 1 2003", "price": 81.96},
+        {"symbol": "IBM", "da.te": "Nov 1 2003", "price": 83.08},
+        {"symbol": "IBM", "da.te": "Dec 1 2003", "price": 85.05},
+        {"symbol": "IBM", "da.te": "Jan 1 2004", "price": 91.06},
+        {"symbol": "IBM", "da.te": "Feb 1 2004", "price": 88.7},
+        {"symbol": "IBM", "da.te": "Mar 1 2004", "price": 84.41},
+        {"symbol": "IBM", "da.te": "Apr 1 2004", "price": 81.04},
+        {"symbol": "IBM", "da.te": "May 1 2004", "price": 81.59},
+        {"symbol": "IBM", "da.te": "Jun 1 2004", "price": 81.19},
+        {"symbol": "IBM", "da.te": "Jul 1 2004", "price": 80.19},
+        {"symbol": "IBM", "da.te": "Aug 1 2004", "price": 78.17},
+        {"symbol": "IBM", "da.te": "Sep 1 2004", "price": 79.13},
+        {"symbol": "IBM", "da.te": "Oct 1 2004", "price": 82.84},
+        {"symbol": "IBM", "da.te": "Nov 1 2004", "price": 87.15},
+        {"symbol": "IBM", "da.te": "Dec 1 2004", "price": 91.16},
+        {"symbol": "IBM", "da.te": "Jan 1 2005", "price": 86.39},
+        {"symbol": "IBM", "da.te": "Feb 1 2005", "price": 85.78},
+        {"symbol": "IBM", "da.te": "Mar 1 2005", "price": 84.66},
+        {"symbol": "IBM", "da.te": "Apr 1 2005", "price": 70.77},
+        {"symbol": "IBM", "da.te": "May 1 2005", "price": 70.18},
+        {"symbol": "IBM", "da.te": "Jun 1 2005", "price": 68.93},
+        {"symbol": "IBM", "da.te": "Jul 1 2005", "price": 77.53},
+        {"symbol": "IBM", "da.te": "Aug 1 2005", "price": 75.07},
+        {"symbol": "IBM", "da.te": "Sep 1 2005", "price": 74.7},
+        {"symbol": "IBM", "da.te": "Oct 1 2005", "price": 76.25},
+        {"symbol": "IBM", "da.te": "Nov 1 2005", "price": 82.98},
+        {"symbol": "IBM", "da.te": "Dec 1 2005", "price": 76.73},
+        {"symbol": "IBM", "da.te": "Jan 1 2006", "price": 75.89},
+        {"symbol": "IBM", "da.te": "Feb 1 2006", "price": 75.09},
+        {"symbol": "IBM", "da.te": "Mar 1 2006", "price": 77.17},
+        {"symbol": "IBM", "da.te": "Apr 1 2006", "price": 77.05},
+        {"symbol": "IBM", "da.te": "May 1 2006", "price": 75.04},
+        {"symbol": "IBM", "da.te": "Jun 1 2006", "price": 72.15},
+        {"symbol": "IBM", "da.te": "Jul 1 2006", "price": 72.7},
+        {"symbol": "IBM", "da.te": "Aug 1 2006", "price": 76.35},
+        {"symbol": "IBM", "da.te": "Sep 1 2006", "price": 77.26},
+        {"symbol": "IBM", "da.te": "Oct 1 2006", "price": 87.06},
+        {"symbol": "IBM", "da.te": "Nov 1 2006", "price": 86.95},
+        {"symbol": "IBM", "da.te": "Dec 1 2006", "price": 91.9},
+        {"symbol": "IBM", "da.te": "Jan 1 2007", "price": 93.79},
+        {"symbol": "IBM", "da.te": "Feb 1 2007", "price": 88.18},
+        {"symbol": "IBM", "da.te": "Mar 1 2007", "price": 89.44},
+        {"symbol": "IBM", "da.te": "Apr 1 2007", "price": 96.98},
+        {"symbol": "IBM", "da.te": "May 1 2007", "price": 101.54},
+        {"symbol": "IBM", "da.te": "Jun 1 2007", "price": 100.25},
+        {"symbol": "IBM", "da.te": "Jul 1 2007", "price": 105.4},
+        {"symbol": "IBM", "da.te": "Aug 1 2007", "price": 111.54},
+        {"symbol": "IBM", "da.te": "Sep 1 2007", "price": 112.6},
+        {"symbol": "IBM", "da.te": "Oct 1 2007", "price": 111},
+        {"symbol": "IBM", "da.te": "Nov 1 2007", "price": 100.9},
+        {"symbol": "IBM", "da.te": "Dec 1 2007", "price": 103.7},
+        {"symbol": "IBM", "da.te": "Jan 1 2008", "price": 102.75},
+        {"symbol": "IBM", "da.te": "Feb 1 2008", "price": 109.64},
+        {"symbol": "IBM", "da.te": "Mar 1 2008", "price": 110.87},
+        {"symbol": "IBM", "da.te": "Apr 1 2008", "price": 116.23},
+        {"symbol": "IBM", "da.te": "May 1 2008", "price": 125.14},
+        {"symbol": "IBM", "da.te": "Jun 1 2008", "price": 114.6},
+        {"symbol": "IBM", "da.te": "Jul 1 2008", "price": 123.74},
+        {"symbol": "IBM", "da.te": "Aug 1 2008", "price": 118.16},
+        {"symbol": "IBM", "da.te": "Sep 1 2008", "price": 113.53},
+        {"symbol": "IBM", "da.te": "Oct 1 2008", "price": 90.24},
+        {"symbol": "IBM", "da.te": "Nov 1 2008", "price": 79.65},
+        {"symbol": "IBM", "da.te": "Dec 1 2008", "price": 82.15},
+        {"symbol": "IBM", "da.te": "Jan 1 2009", "price": 89.46},
+        {"symbol": "IBM", "da.te": "Feb 1 2009", "price": 90.32},
+        {"symbol": "IBM", "da.te": "Mar 1 2009", "price": 95.09},
+        {"symbol": "IBM", "da.te": "Apr 1 2009", "price": 101.29},
+        {"symbol": "IBM", "da.te": "May 1 2009", "price": 104.85},
+        {"symbol": "IBM", "da.te": "Jun 1 2009", "price": 103.01},
+        {"symbol": "IBM", "da.te": "Jul 1 2009", "price": 116.34},
+        {"symbol": "IBM", "da.te": "Aug 1 2009", "price": 117},
+        {"symbol": "IBM", "da.te": "Sep 1 2009", "price": 118.55},
+        {"symbol": "IBM", "da.te": "Oct 1 2009", "price": 119.54},
+        {"symbol": "IBM", "da.te": "Nov 1 2009", "price": 125.79},
+        {"symbol": "IBM", "da.te": "Dec 1 2009", "price": 130.32},
+        {"symbol": "IBM", "da.te": "Jan 1 2010", "price": 121.85},
+        {"symbol": "IBM", "da.te": "Feb 1 2010", "price": 127.16},
+        {"symbol": "IBM", "da.te": "Mar 1 2010", "price": 125.55},
+        {"symbol": "GOOG", "da.te": "Aug 1 2004", "price": 102.37},
+        {"symbol": "GOOG", "da.te": "Sep 1 2004", "price": 129.6},
+        {"symbol": "GOOG", "da.te": "Oct 1 2004", "price": 190.64},
+        {"symbol": "GOOG", "da.te": "Nov 1 2004", "price": 181.98},
+        {"symbol": "GOOG", "da.te": "Dec 1 2004", "price": 192.79},
+        {"symbol": "GOOG", "da.te": "Jan 1 2005", "price": 195.62},
+        {"symbol": "GOOG", "da.te": "Feb 1 2005", "price": 187.99},
+        {"symbol": "GOOG", "da.te": "Mar 1 2005", "price": 180.51},
+        {"symbol": "GOOG", "da.te": "Apr 1 2005", "price": 220},
+        {"symbol": "GOOG", "da.te": "May 1 2005", "price": 277.27},
+        {"symbol": "GOOG", "da.te": "Jun 1 2005", "price": 294.15},
+        {"symbol": "GOOG", "da.te": "Jul 1 2005", "price": 287.76},
+        {"symbol": "GOOG", "da.te": "Aug 1 2005", "price": 286},
+        {"symbol": "GOOG", "da.te": "Sep 1 2005", "price": 316.46},
+        {"symbol": "GOOG", "da.te": "Oct 1 2005", "price": 372.14},
+        {"symbol": "GOOG", "da.te": "Nov 1 2005", "price": 404.91},
+        {"symbol": "GOOG", "da.te": "Dec 1 2005", "price": 414.86},
+        {"symbol": "GOOG", "da.te": "Jan 1 2006", "price": 432.66},
+        {"symbol": "GOOG", "da.te": "Feb 1 2006", "price": 362.62},
+        {"symbol": "GOOG", "da.te": "Mar 1 2006", "price": 390},
+        {"symbol": "GOOG", "da.te": "Apr 1 2006", "price": 417.94},
+        {"symbol": "GOOG", "da.te": "May 1 2006", "price": 371.82},
+        {"symbol": "GOOG", "da.te": "Jun 1 2006", "price": 419.33},
+        {"symbol": "GOOG", "da.te": "Jul 1 2006", "price": 386.6},
+        {"symbol": "GOOG", "da.te": "Aug 1 2006", "price": 378.53},
+        {"symbol": "GOOG", "da.te": "Sep 1 2006", "price": 401.9},
+        {"symbol": "GOOG", "da.te": "Oct 1 2006", "price": 476.39},
+        {"symbol": "GOOG", "da.te": "Nov 1 2006", "price": 484.81},
+        {"symbol": "GOOG", "da.te": "Dec 1 2006", "price": 460.48},
+        {"symbol": "GOOG", "da.te": "Jan 1 2007", "price": 501.5},
+        {"symbol": "GOOG", "da.te": "Feb 1 2007", "price": 449.45},
+        {"symbol": "GOOG", "da.te": "Mar 1 2007", "price": 458.16},
+        {"symbol": "GOOG", "da.te": "Apr 1 2007", "price": 471.38},
+        {"symbol": "GOOG", "da.te": "May 1 2007", "price": 497.91},
+        {"symbol": "GOOG", "da.te": "Jun 1 2007", "price": 522.7},
+        {"symbol": "GOOG", "da.te": "Jul 1 2007", "price": 510},
+        {"symbol": "GOOG", "da.te": "Aug 1 2007", "price": 515.25},
+        {"symbol": "GOOG", "da.te": "Sep 1 2007", "price": 567.27},
+        {"symbol": "GOOG", "da.te": "Oct 1 2007", "price": 707},
+        {"symbol": "GOOG", "da.te": "Nov 1 2007", "price": 693},
+        {"symbol": "GOOG", "da.te": "Dec 1 2007", "price": 691.48},
+        {"symbol": "GOOG", "da.te": "Jan 1 2008", "price": 564.3},
+        {"symbol": "GOOG", "da.te": "Feb 1 2008", "price": 471.18},
+        {"symbol": "GOOG", "da.te": "Mar 1 2008", "price": 440.47},
+        {"symbol": "GOOG", "da.te": "Apr 1 2008", "price": 574.29},
+        {"symbol": "GOOG", "da.te": "May 1 2008", "price": 585.8},
+        {"symbol": "GOOG", "da.te": "Jun 1 2008", "price": 526.42},
+        {"symbol": "GOOG", "da.te": "Jul 1 2008", "price": 473.75},
+        {"symbol": "GOOG", "da.te": "Aug 1 2008", "price": 463.29},
+        {"symbol": "GOOG", "da.te": "Sep 1 2008", "price": 400.52},
+        {"symbol": "GOOG", "da.te": "Oct 1 2008", "price": 359.36},
+        {"symbol": "GOOG", "da.te": "Nov 1 2008", "price": 292.96},
+        {"symbol": "GOOG", "da.te": "Dec 1 2008", "price": 307.65},
+        {"symbol": "GOOG", "da.te": "Jan 1 2009", "price": 338.53},
+        {"symbol": "GOOG", "da.te": "Feb 1 2009", "price": 337.99},
+        {"symbol": "GOOG", "da.te": "Mar 1 2009", "price": 348.06},
+        {"symbol": "GOOG", "da.te": "Apr 1 2009", "price": 395.97},
+        {"symbol": "GOOG", "da.te": "May 1 2009", "price": 417.23},
+        {"symbol": "GOOG", "da.te": "Jun 1 2009", "price": 421.59},
+        {"symbol": "GOOG", "da.te": "Jul 1 2009", "price": 443.05},
+        {"symbol": "GOOG", "da.te": "Aug 1 2009", "price": 461.67},
+        {"symbol": "GOOG", "da.te": "Sep 1 2009", "price": 495.85},
+        {"symbol": "GOOG", "da.te": "Oct 1 2009", "price": 536.12},
+        {"symbol": "GOOG", "da.te": "Nov 1 2009", "price": 583},
+        {"symbol": "GOOG", "da.te": "Dec 1 2009", "price": 619.98},
+        {"symbol": "GOOG", "da.te": "Jan 1 2010", "price": 529.94},
+        {"symbol": "GOOG", "da.te": "Feb 1 2010", "price": 526.8},
+        {"symbol": "GOOG", "da.te": "Mar 1 2010", "price": 560.19},
+        {"symbol": "AAPL", "da.te": "Jan 1 2000", "price": 25.94},
+        {"symbol": "AAPL", "da.te": "Feb 1 2000", "price": 28.66},
+        {"symbol": "AAPL", "da.te": "Mar 1 2000", "price": 33.95},
+        {"symbol": "AAPL", "da.te": "Apr 1 2000", "price": 31.01},
+        {"symbol": "AAPL", "da.te": "May 1 2000", "price": 21},
+        {"symbol": "AAPL", "da.te": "Jun 1 2000", "price": 26.19},
+        {"symbol": "AAPL", "da.te": "Jul 1 2000", "price": 25.41},
+        {"symbol": "AAPL", "da.te": "Aug 1 2000", "price": 30.47},
+        {"symbol": "AAPL", "da.te": "Sep 1 2000", "price": 12.88},
+        {"symbol": "AAPL", "da.te": "Oct 1 2000", "price": 9.78},
+        {"symbol": "AAPL", "da.te": "Nov 1 2000", "price": 8.25},
+        {"symbol": "AAPL", "da.te": "Dec 1 2000", "price": 7.44},
+        {"symbol": "AAPL", "da.te": "Jan 1 2001", "price": 10.81},
+        {"symbol": "AAPL", "da.te": "Feb 1 2001", "price": 9.12},
+        {"symbol": "AAPL", "da.te": "Mar 1 2001", "price": 11.03},
+        {"symbol": "AAPL", "da.te": "Apr 1 2001", "price": 12.74},
+        {"symbol": "AAPL", "da.te": "May 1 2001", "price": 9.98},
+        {"symbol": "AAPL", "da.te": "Jun 1 2001", "price": 11.62},
+        {"symbol": "AAPL", "da.te": "Jul 1 2001", "price": 9.4},
+        {"symbol": "AAPL", "da.te": "Aug 1 2001", "price": 9.27},
+        {"symbol": "AAPL", "da.te": "Sep 1 2001", "price": 7.76},
+        {"symbol": "AAPL", "da.te": "Oct 1 2001", "price": 8.78},
+        {"symbol": "AAPL", "da.te": "Nov 1 2001", "price": 10.65},
+        {"symbol": "AAPL", "da.te": "Dec 1 2001", "price": 10.95},
+        {"symbol": "AAPL", "da.te": "Jan 1 2002", "price": 12.36},
+        {"symbol": "AAPL", "da.te": "Feb 1 2002", "price": 10.85},
+        {"symbol": "AAPL", "da.te": "Mar 1 2002", "price": 11.84},
+        {"symbol": "AAPL", "da.te": "Apr 1 2002", "price": 12.14},
+        {"symbol": "AAPL", "da.te": "May 1 2002", "price": 11.65},
+        {"symbol": "AAPL", "da.te": "Jun 1 2002", "price": 8.86},
+        {"symbol": "AAPL", "da.te": "Jul 1 2002", "price": 7.63},
+        {"symbol": "AAPL", "da.te": "Aug 1 2002", "price": 7.38},
+        {"symbol": "AAPL", "da.te": "Sep 1 2002", "price": 7.25},
+        {"symbol": "AAPL", "da.te": "Oct 1 2002", "price": 8.03},
+        {"symbol": "AAPL", "da.te": "Nov 1 2002", "price": 7.75},
+        {"symbol": "AAPL", "da.te": "Dec 1 2002", "price": 7.16},
+        {"symbol": "AAPL", "da.te": "Jan 1 2003", "price": 7.18},
+        {"symbol": "AAPL", "da.te": "Feb 1 2003", "price": 7.51},
+        {"symbol": "AAPL", "da.te": "Mar 1 2003", "price": 7.07},
+        {"symbol": "AAPL", "da.te": "Apr 1 2003", "price": 7.11},
+        {"symbol": "AAPL", "da.te": "May 1 2003", "price": 8.98},
+        {"symbol": "AAPL", "da.te": "Jun 1 2003", "price": 9.53},
+        {"symbol": "AAPL", "da.te": "Jul 1 2003", "price": 10.54},
+        {"symbol": "AAPL", "da.te": "Aug 1 2003", "price": 11.31},
+        {"symbol": "AAPL", "da.te": "Sep 1 2003", "price": 10.36},
+        {"symbol": "AAPL", "da.te": "Oct 1 2003", "price": 11.44},
+        {"symbol": "AAPL", "da.te": "Nov 1 2003", "price": 10.45},
+        {"symbol": "AAPL", "da.te": "Dec 1 2003", "price": 10.69},
+        {"symbol": "AAPL", "da.te": "Jan 1 2004", "price": 11.28},
+        {"symbol": "AAPL", "da.te": "Feb 1 2004", "price": 11.96},
+        {"symbol": "AAPL", "da.te": "Mar 1 2004", "price": 13.52},
+        {"symbol": "AAPL", "da.te": "Apr 1 2004", "price": 12.89},
+        {"symbol": "AAPL", "da.te": "May 1 2004", "price": 14.03},
+        {"symbol": "AAPL", "da.te": "Jun 1 2004", "price": 16.27},
+        {"symbol": "AAPL", "da.te": "Jul 1 2004", "price": 16.17},
+        {"symbol": "AAPL", "da.te": "Aug 1 2004", "price": 17.25},
+        {"symbol": "AAPL", "da.te": "Sep 1 2004", "price": 19.38},
+        {"symbol": "AAPL", "da.te": "Oct 1 2004", "price": 26.2},
+        {"symbol": "AAPL", "da.te": "Nov 1 2004", "price": 33.53},
+        {"symbol": "AAPL", "da.te": "Dec 1 2004", "price": 32.2},
+        {"symbol": "AAPL", "da.te": "Jan 1 2005", "price": 38.45},
+        {"symbol": "AAPL", "da.te": "Feb 1 2005", "price": 44.86},
+        {"symbol": "AAPL", "da.te": "Mar 1 2005", "price": 41.67},
+        {"symbol": "AAPL", "da.te": "Apr 1 2005", "price": 36.06},
+        {"symbol": "AAPL", "da.te": "May 1 2005", "price": 39.76},
+        {"symbol": "AAPL", "da.te": "Jun 1 2005", "price": 36.81},
+        {"symbol": "AAPL", "da.te": "Jul 1 2005", "price": 42.65},
+        {"symbol": "AAPL", "da.te": "Aug 1 2005", "price": 46.89},
+        {"symbol": "AAPL", "da.te": "Sep 1 2005", "price": 53.61},
+        {"symbol": "AAPL", "da.te": "Oct 1 2005", "price": 57.59},
+        {"symbol": "AAPL", "da.te": "Nov 1 2005", "price": 67.82},
+        {"symbol": "AAPL", "da.te": "Dec 1 2005", "price": 71.89},
+        {"symbol": "AAPL", "da.te": "Jan 1 2006", "price": 75.51},
+        {"symbol": "AAPL", "da.te": "Feb 1 2006", "price": 68.49},
+        {"symbol": "AAPL", "da.te": "Mar 1 2006", "price": 62.72},
+        {"symbol": "AAPL", "da.te": "Apr 1 2006", "price": 70.39},
+        {"symbol": "AAPL", "da.te": "May 1 2006", "price": 59.77},
+        {"symbol": "AAPL", "da.te": "Jun 1 2006", "price": 57.27},
+        {"symbol": "AAPL", "da.te": "Jul 1 2006", "price": 67.96},
+        {"symbol": "AAPL", "da.te": "Aug 1 2006", "price": 67.85},
+        {"symbol": "AAPL", "da.te": "Sep 1 2006", "price": 76.98},
+        {"symbol": "AAPL", "da.te": "Oct 1 2006", "price": 81.08},
+        {"symbol": "AAPL", "da.te": "Nov 1 2006", "price": 91.66},
+        {"symbol": "AAPL", "da.te": "Dec 1 2006", "price": 84.84},
+        {"symbol": "AAPL", "da.te": "Jan 1 2007", "price": 85.73},
+        {"symbol": "AAPL", "da.te": "Feb 1 2007", "price": 84.61},
+        {"symbol": "AAPL", "da.te": "Mar 1 2007", "price": 92.91},
+        {"symbol": "AAPL", "da.te": "Apr 1 2007", "price": 99.8},
+        {"symbol": "AAPL", "da.te": "May 1 2007", "price": 121.19},
+        {"symbol": "AAPL", "da.te": "Jun 1 2007", "price": 122.04},
+        {"symbol": "AAPL", "da.te": "Jul 1 2007", "price": 131.76},
+        {"symbol": "AAPL", "da.te": "Aug 1 2007", "price": 138.48},
+        {"symbol": "AAPL", "da.te": "Sep 1 2007", "price": 153.47},
+        {"symbol": "AAPL", "da.te": "Oct 1 2007", "price": 189.95},
+        {"symbol": "AAPL", "da.te": "Nov 1 2007", "price": 182.22},
+        {"symbol": "AAPL", "da.te": "Dec 1 2007", "price": 198.08},
+        {"symbol": "AAPL", "da.te": "Jan 1 2008", "price": 135.36},
+        {"symbol": "AAPL", "da.te": "Feb 1 2008", "price": 125.02},
+        {"symbol": "AAPL", "da.te": "Mar 1 2008", "price": 143.5},
+        {"symbol": "AAPL", "da.te": "Apr 1 2008", "price": 173.95},
+        {"symbol": "AAPL", "da.te": "May 1 2008", "price": 188.75},
+        {"symbol": "AAPL", "da.te": "Jun 1 2008", "price": 167.44},
+        {"symbol": "AAPL", "da.te": "Jul 1 2008", "price": 158.95},
+        {"symbol": "AAPL", "da.te": "Aug 1 2008", "price": 169.53},
+        {"symbol": "AAPL", "da.te": "Sep 1 2008", "price": 113.66},
+        {"symbol": "AAPL", "da.te": "Oct 1 2008", "price": 107.59},
+        {"symbol": "AAPL", "da.te": "Nov 1 2008", "price": 92.67},
+        {"symbol": "AAPL", "da.te": "Dec 1 2008", "price": 85.35},
+        {"symbol": "AAPL", "da.te": "Jan 1 2009", "price": 90.13},
+        {"symbol": "AAPL", "da.te": "Feb 1 2009", "price": 89.31},
+        {"symbol": "AAPL", "da.te": "Mar 1 2009", "price": 105.12},
+        {"symbol": "AAPL", "da.te": "Apr 1 2009", "price": 125.83},
+        {"symbol": "AAPL", "da.te": "May 1 2009", "price": 135.81},
+        {"symbol": "AAPL", "da.te": "Jun 1 2009", "price": 142.43},
+        {"symbol": "AAPL", "da.te": "Jul 1 2009", "price": 163.39},
+        {"symbol": "AAPL", "da.te": "Aug 1 2009", "price": 168.21},
+        {"symbol": "AAPL", "da.te": "Sep 1 2009", "price": 185.35},
+        {"symbol": "AAPL", "da.te": "Oct 1 2009", "price": 188.5},
+        {"symbol": "AAPL", "da.te": "Nov 1 2009", "price": 199.91},
+        {"symbol": "AAPL", "da.te": "Dec 1 2009", "price": 210.73},
+        {"symbol": "AAPL", "da.te": "Jan 1 2010", "price": 192.06},
+        {"symbol": "AAPL", "da.te": "Feb 1 2010", "price": 204.62},
+        {"symbol": "AAPL", "da.te": "Mar 1 2010", "price": 223.02}
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "df",
+      "transform": [
+        {"type": "formula", "expr": "toDate(datum[\"da.te\"])", "as": "da.te"},
+        {"type": "formula", "expr": "toDate(datum[\"da.te\"])", "as": "da.te"},
+        {"type": "filter", "expr": "isValid(datum[\"da.te\"])"},
+        {
+          "type": "aggregate",
+          "groupby": ["da\\.te"],
+          "ops": ["sum"],
+          "fields": ["price"],
+          "as": ["sum_price"]
+        },
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"da.te\"]) || (isValid(datum[\"da.te\"]) && isFinite(+datum[\"da.te\"]))) && isValid(datum[\"sum_price\"]) && isFinite(+datum[\"sum_price\"])"
+        }
+      ]
+    }
+  ],
+  "signals": [
+    {
+      "name": "width",
+      "init": "isFinite(containerSize()[0]) ? containerSize()[0] : 200",
+      "on": [
+        {
+          "update": "isFinite(containerSize()[0]) ? containerSize()[0] : 200",
+          "events": "window:resize"
+        }
+      ]
+    },
+    {
+      "name": "height",
+      "init": "isFinite(containerSize()[1]) ? containerSize()[1] : 200",
+      "on": [
+        {
+          "update": "isFinite(containerSize()[1]) ? containerSize()[1] : 200",
+          "events": "window:resize"
+        }
+      ]
+    },
+    {
+      "name": "unit",
+      "value": {},
+      "on": [
+        {"events": "pointermove", "update": "isTuple(group()) ? group() : unit"}
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0",
+      "update": "vlSelectionResolve(\"interval_intervalselection_0_store\", \"union\")"
+    },
+    {
+      "name": "click_pointselection_0",
+      "update": "vlSelectionResolve(\"click_pointselection_0_store\", \"union\", true, true)"
+    },
+    {
+      "name": "interval_intervalselection_0_x",
+      "value": [],
+      "on": [
+        {
+          "events": {
+            "source": "scope",
+            "type": "pointerdown",
+            "filter": [
+              "!event.item || event.item.mark.name !== \"interval_intervalselection_0_brush\""
+            ]
+          },
+          "update": "[x(unit), x(unit)]"
+        },
+        {
+          "events": {
+            "source": "window",
+            "type": "pointermove",
+            "consume": true,
+            "between": [
+              {
+                "source": "scope",
+                "type": "pointerdown",
+                "filter": [
+                  "!event.item || event.item.mark.name !== \"interval_intervalselection_0_brush\""
+                ]
+              },
+              {"source": "window", "type": "pointerup"}
+            ]
+          },
+          "update": "[interval_intervalselection_0_x[0], clamp(x(unit), 0, width)]"
+        },
+        {
+          "events": {"signal": "interval_intervalselection_0_scale_trigger"},
+          "update": "[scale(\"x\", interval_intervalselection_0_da__te[0]), scale(\"x\", interval_intervalselection_0_da__te[1])]"
+        },
+        {
+          "events": [{"source": "view", "type": "dblclick"}],
+          "update": "[0, 0]"
+        },
+        {
+          "events": {"signal": "interval_intervalselection_0_translate_delta"},
+          "update": "clampRange(panLinear(interval_intervalselection_0_translate_anchor.extent_x, interval_intervalselection_0_translate_delta.x / span(interval_intervalselection_0_translate_anchor.extent_x)), 0, width)"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_da__te",
+      "on": [
+        {
+          "events": {"signal": "interval_intervalselection_0_x"},
+          "update": "interval_intervalselection_0_x[0] === interval_intervalselection_0_x[1] ? null : invert(\"x\", interval_intervalselection_0_x)"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_scale_trigger",
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(interval_intervalselection_0_da__te) || (+invert(\"x\", interval_intervalselection_0_x)[0] === +interval_intervalselection_0_da__te[0] && +invert(\"x\", interval_intervalselection_0_x)[1] === +interval_intervalselection_0_da__te[1])) ? interval_intervalselection_0_scale_trigger : {}"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_tuple",
+      "on": [
+        {
+          "events": [{"signal": "interval_intervalselection_0_da__te"}],
+          "update": "interval_intervalselection_0_da__te ? {unit: \"layer_0_layer_0_layer_0\", fields: interval_intervalselection_0_tuple_fields, values: [interval_intervalselection_0_da__te]} : null"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_tuple_fields",
+      "value": [{"field": "da\\.te", "channel": "x", "type": "R"}]
+    },
+    {
+      "name": "interval_intervalselection_0_translate_anchor",
+      "value": {},
+      "on": [
+        {
+          "events": [
+            {
+              "source": "scope",
+              "type": "pointerdown",
+              "markname": "interval_intervalselection_0_brush"
+            }
+          ],
+          "update": "{x: x(unit), y: y(unit), extent_x: slice(interval_intervalselection_0_x)}"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_translate_delta",
+      "value": {},
+      "on": [
+        {
+          "events": [
+            {
+              "source": "window",
+              "type": "pointermove",
+              "consume": true,
+              "between": [
+                {
+                  "source": "scope",
+                  "type": "pointerdown",
+                  "markname": "interval_intervalselection_0_brush"
+                },
+                {"source": "window", "type": "pointerup"}
+              ]
+            }
+          ],
+          "update": "{x: interval_intervalselection_0_translate_anchor.x - x(unit), y: interval_intervalselection_0_translate_anchor.y - y(unit)}"
+        }
+      ]
+    },
+    {
+      "name": "interval_intervalselection_0_modify",
+      "on": [
+        {
+          "events": {"signal": "interval_intervalselection_0_tuple"},
+          "update": "modify(\"interval_intervalselection_0_store\", interval_intervalselection_0_tuple, true)"
+        }
+      ]
+    },
+    {
+      "name": "click_pointselection_0_tuple",
+      "on": [
+        {
+          "events": [{"source": "scope", "type": "click"}],
+          "update": "datum && item().mark.marktype !== 'group' && indexof(item().mark.role, 'legend') < 0 && indexof(item().mark.name, 'interval_intervalselection_0_brush') < 0 ? {unit: \"layer_0_layer_0_layer_0\", fields: click_pointselection_0_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"da\\\\.te\"]]} : null",
+          "force": true
+        },
+        {"events": [{"source": "view", "type": "dblclick"}], "update": "null"}
+      ]
+    },
+    {
+      "name": "click_pointselection_0_tuple_fields",
+      "value": [{"field": "da\\.te", "channel": "x", "type": "E"}]
+    },
+    {
+      "name": "click_pointselection_0_toggle",
+      "value": false,
+      "on": [
+        {
+          "events": [{"source": "scope", "type": "click"}],
+          "update": "event.shiftKey"
+        },
+        {"events": [{"source": "view", "type": "dblclick"}], "update": "false"}
+      ]
+    },
+    {
+      "name": "click_pointselection_0_modify",
+      "on": [
+        {
+          "events": {"signal": "click_pointselection_0_tuple"},
+          "update": "modify(\"click_pointselection_0_store\", click_pointselection_0_toggle ? null : click_pointselection_0_tuple, click_pointselection_0_toggle ? null : true, click_pointselection_0_toggle ? click_pointselection_0_tuple : null)"
+        }
+      ]
+    },
+    {
+      "name": "cursor",
+      "value": "default",
+      "on": [
+        {
+          "events": "mousemove",
+          "update": "if(isDefined((group()).bounds), if(item().mark.marktype != 'group', 'default', 'crosshair'), 'default')"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "interval_intervalselection_0_brush_bg",
+      "type": "rect",
+      "clip": true,
+      "encode": {
+        "enter": {"fill": {"value": "#669EFF"}, "fillOpacity": {"value": 0.07}},
+        "update": {
+          "x": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "signal": "interval_intervalselection_0_x[0]"
+            },
+            {"value": 0}
+          ],
+          "y": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "x2": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "signal": "interval_intervalselection_0_x[1]"
+            },
+            {"value": 0}
+          ],
+          "y2": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "field": {"group": "height"}
+            },
+            {"value": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "layer_0_layer_0_layer_0_marks",
+      "type": "rect",
+      "clip": true,
+      "style": ["bar"],
+      "interactive": true,
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "cursor": {"value": "pointer"},
+          "fill": {"value": "#4C78A8"},
+          "opacity": [
+            {
+              "test": "!((!length(data(\"interval_intervalselection_0_store\")) || vlSelectionTest(\"interval_intervalselection_0_store\", datum)) && (!length(data(\"click_pointselection_0_store\")) || vlSelectionTest(\"click_pointselection_0_store\", datum)))",
+              "value": 0.3
+            },
+            {"value": 1}
+          ],
+          "tooltip": {
+            "signal": "{\"da.te\": timeFormat(datum[\"da.te\"], '%b %d, %Y %H:%M:%S'), \"Sum of price\": datum[\"sum_price\"]}"
+          },
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"da.te: \" + (timeFormat(datum[\"da.te\"], '%b %d, %Y %H:%M:%S')) + \"; Sum of price: \" + (datum[\"sum_price\"])"
+          },
+          "xc": {"scale": "x", "field": "da\\.te"},
+          "width": {"value": 5},
+          "y": {"scale": "y", "field": "sum_price"},
+          "y2": {"scale": "y", "value": 0}
+        }
+      }
+    },
+    {
+      "name": "interval_intervalselection_0_brush",
+      "type": "rect",
+      "clip": true,
+      "encode": {
+        "enter": {"fill": {"value": "transparent"}},
+        "update": {
+          "x": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "signal": "interval_intervalselection_0_x[0]"
+            },
+            {"value": 0}
+          ],
+          "y": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "x2": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "signal": "interval_intervalselection_0_x[1]"
+            },
+            {"value": 0}
+          ],
+          "y2": [
+            {
+              "test": "data(\"interval_intervalselection_0_store\").length && data(\"interval_intervalselection_0_store\")[0].unit === \"layer_0_layer_0_layer_0\"",
+              "field": {"group": "height"}
+            },
+            {"value": 0}
+          ],
+          "stroke": [
+            {
+              "test": "interval_intervalselection_0_x[0] !== interval_intervalselection_0_x[1]",
+              "value": "#669EFF"
+            },
+            {"value": null}
+          ],
+          "strokeOpacity": [
+            {
+              "test": "interval_intervalselection_0_x[0] !== interval_intervalselection_0_x[1]",
+              "value": 0.4
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "time",
+      "domain": {"data": "data_0", "field": "da\\.te"},
+      "range": [0, {"signal": "width"}],
+      "padding": 5
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "data_0", "field": "sum_price"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": true,
+      "gridScale": "y",
+      "tickCount": {"signal": "ceil(width/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": true,
+      "gridScale": "x",
+      "tickCount": {"signal": "ceil(height/40)"},
+      "domain": false,
+      "labels": false,
+      "aria": false,
+      "maxExtent": 0,
+      "minExtent": 0,
+      "ticks": false,
+      "zindex": 0
+    },
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "da.te",
+      "labelFlush": false,
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(width/40)"},
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "Sum of price",
+      "labelFlush": false,
+      "labels": true,
+      "ticks": true,
+      "labelOverlap": true,
+      "tickCount": {"signal": "ceil(height/40)"},
+      "encode": {"labels": {"update": {"text": {"signal": "datum.value"}}}},
+      "zindex": 0
+    }
+  ],
+  "config": {
+    "customFormatTypes": true,
+    "tooltipFormat": {"timeFormat": "%b %d, %Y %H:%M:%S"},
+    "legend": {"orient": "right"},
+    "style": {
+      "guide-label": {
+        "font": "\"IBM Plex Sans\", system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+      },
+      "guide-title": {
+        "font": "\"IBM Plex Sans\", system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+      },
+      "group-title": {
+        "font": "\"IBM Plex Sans\", system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+      },
+      "group-subtitle": {
+        "font": "\"IBM Plex Sans\", system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+      },
+      "text": {
+        "font": "\"IBM Plex Sans\", system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+      }
+    }
+  },
+  "usermeta": {
+    "warnings": [],
+    "selectionConfigs": {
+      "interval_intervalselection_0": {
+        "type": "interval",
+        "datetimeFields": ["da\\.te"],
+        "derived": []
+      },
+      "click_pointselection_0": {
+        "type": "point",
+        "datetimeFields": ["da\\.te"],
+        "derived": []
+      }
+    }
+  }
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -151,7 +151,8 @@ mod test_custom_specs {
         case("custom/aggregate_with_threshold", 0.001, true),
         case("custom/facet_with_selections", 0.001, true),
         case("custom/facet_lift_area", 0.001, true),
-        case("custom/facet_lift_area_color", 0.001, true)
+        case("custom/facet_lift_area_color", 0.001, true),
+        case("custom/local_timezone_with_dot", 0.001, true),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");


### PR DESCRIPTION
The local datetime stringification planner step needs to unescape column names before constructing transforms