### PR TITLE
Strip description encoding channel for improved render performance

### DIFF
--- a/python/vegafusion/tests/test_input_utc.py
+++ b/python/vegafusion/tests/test_input_utc.py
@@ -172,378 +172,324 @@ def expected_spec():
       "name": "source_0",
       "values": [
         {
-          "__count": 10,
           "__count_end": 124,
           "__count_start": 114,
           "month_date": "2012-01-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 17,
           "__count_end": 114,
           "__count_start": 97,
           "month_date": "2012-01-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 61,
           "__count_end": 97,
           "__count_start": 36,
           "month_date": "2012-01-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 8,
           "__count_end": 36,
           "__count_start": 28,
           "month_date": "2012-01-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 28,
           "__count_end": 28,
           "__count_start": 0,
           "month_date": "2012-01-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 4,
           "__count_end": 113,
           "__count_start": 109,
           "month_date": "2012-02-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 3,
           "__count_end": 109,
           "__count_start": 106,
           "month_date": "2012-02-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 75,
           "__count_end": 106,
           "__count_start": 31,
           "month_date": "2012-02-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 4,
           "__count_end": 31,
           "__count_start": 27,
           "month_date": "2012-02-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 27,
           "__count_end": 27,
           "__count_start": 0,
           "month_date": "2012-02-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 3,
           "__count_end": 124,
           "__count_start": 121,
           "month_date": "2012-03-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 6,
           "__count_end": 121,
           "__count_start": 115,
           "month_date": "2012-03-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 73,
           "__count_end": 115,
           "__count_start": 42,
           "month_date": "2012-03-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 6,
           "__count_end": 42,
           "__count_start": 36,
           "month_date": "2012-03-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 36,
           "__count_end": 36,
           "__count_start": 0,
           "month_date": "2012-03-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 3,
           "__count_end": 120,
           "__count_start": 117,
           "month_date": "2012-04-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 3,
           "__count_end": 117,
           "__count_start": 114,
           "month_date": "2012-04-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 61,
           "__count_end": 114,
           "__count_start": 53,
           "month_date": "2012-04-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 1,
           "__count_end": 53,
           "__count_start": 52,
           "month_date": "2012-04-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 52,
           "__count_end": 52,
           "__count_start": 0,
           "month_date": "2012-04-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 1,
           "__count_end": 124,
           "__count_start": 123,
           "month_date": "2012-05-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 5,
           "__count_end": 123,
           "__count_start": 118,
           "month_date": "2012-05-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 40,
           "__count_end": 118,
           "__count_start": 78,
           "month_date": "2012-05-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 78,
           "__count_end": 78,
           "__count_start": 0,
           "month_date": "2012-05-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 2,
           "__count_end": 120,
           "__count_start": 118,
           "month_date": "2012-06-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 1,
           "__count_end": 118,
           "__count_start": 117,
           "month_date": "2012-06-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 42,
           "__count_end": 117,
           "__count_start": 75,
           "month_date": "2012-06-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 75,
           "__count_end": 75,
           "__count_start": 0,
           "month_date": "2012-06-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 8,
           "__count_end": 124,
           "__count_start": 116,
           "month_date": "2012-07-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 10,
           "__count_end": 116,
           "__count_start": 106,
           "month_date": "2012-07-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 16,
           "__count_end": 106,
           "__count_start": 90,
           "month_date": "2012-07-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 90,
           "__count_end": 90,
           "__count_start": 0,
           "month_date": "2012-07-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 8,
           "__count_end": 124,
           "__count_start": 116,
           "month_date": "2012-08-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 6,
           "__count_end": 116,
           "__count_start": 110,
           "month_date": "2012-08-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 24,
           "__count_end": 110,
           "__count_start": 86,
           "month_date": "2012-08-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 86,
           "__count_end": 86,
           "__count_start": 0,
           "month_date": "2012-08-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 5,
           "__count_end": 120,
           "__count_start": 115,
           "month_date": "2012-09-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 14,
           "__count_end": 115,
           "__count_start": 101,
           "month_date": "2012-09-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 36,
           "__count_end": 101,
           "__count_start": 65,
           "month_date": "2012-09-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 65,
           "__count_end": 65,
           "__count_start": 0,
           "month_date": "2012-09-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 4,
           "__count_end": 124,
           "__count_start": 120,
           "month_date": "2012-10-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 19,
           "__count_end": 120,
           "__count_start": 101,
           "month_date": "2012-10-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 62,
           "__count_end": 101,
           "__count_start": 39,
           "month_date": "2012-10-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 39,
           "__count_end": 39,
           "__count_start": 0,
           "month_date": "2012-10-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 3,
           "__count_end": 120,
           "__count_start": 117,
           "month_date": "2012-11-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 9,
           "__count_end": 117,
           "__count_start": 108,
           "month_date": "2012-11-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 75,
           "__count_end": 108,
           "__count_start": 33,
           "month_date": "2012-11-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 1,
           "__count_end": 33,
           "__count_start": 32,
           "month_date": "2012-11-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 32,
           "__count_end": 32,
           "__count_start": 0,
           "month_date": "2012-11-01T00:00:00.000",
           "weather": "sun"
         },
         {
-          "__count": 2,
           "__count_end": 124,
           "__count_start": 122,
           "month_date": "2012-12-01T00:00:00.000",
           "weather": "drizzle"
         },
         {
-          "__count": 8,
           "__count_end": 122,
           "__count_start": 114,
           "month_date": "2012-12-01T00:00:00.000",
           "weather": "fog"
         },
         {
-          "__count": 76,
           "__count_end": 114,
           "__count_start": 38,
           "month_date": "2012-12-01T00:00:00.000",
           "weather": "rain"
         },
         {
-          "__count": 6,
           "__count_end": 38,
           "__count_start": 32,
           "month_date": "2012-12-01T00:00:00.000",
           "weather": "snow"
         },
         {
-          "__count": 32,
           "__count_end": 32,
           "__count_start": 0,
           "month_date": "2012-12-01T00:00:00.000",
@@ -598,11 +544,7 @@ def expected_spec():
       "encode": {
         "update": {
           "x": {"field": "month_date", "scale": "x"},
-          "description": {
-            "signal": "\"Month of the year: \" + (timeFormat(datum[\"month_date\"], timeUnitSpecifier([\"month\"], {\"year-month\":\"%b %Y \",\"year-month-date\":\"%b %d, %Y \"}))) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\")) + \"; Weather type: \" + (isValid(datum[\"weather\"]) ? datum[\"weather\"] : \"\"+datum[\"weather\"])"
-          },
           "fill": {"field": "weather", "scale": "color"},
-          "ariaRoleDescription": {"value": "bar"},
           "width": {"signal": "max(0.25, bandwidth('x'))"},
           "y": {"field": "__count_end", "scale": "y"},
           "y2": {"field": "__count_start", "scale": "y"}

--- a/vegafusion-core/src/planning/mod.rs
+++ b/vegafusion-core/src/planning/mod.rs
@@ -8,5 +8,6 @@ pub mod projection_pushdown;
 pub mod split_domain_data;
 pub mod stitch;
 pub mod stringify_local_datetimes;
+pub mod strip_encodings;
 pub mod unsupported_data_warning;
 pub mod watch;

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -7,6 +7,7 @@ use crate::planning::projection_pushdown::projection_pushdown;
 use crate::planning::split_domain_data::split_domain_data;
 use crate::planning::stitch::{stitch_specs, CommPlan};
 use crate::planning::stringify_local_datetimes::stringify_local_datetimes;
+use crate::planning::strip_encodings::strip_encodings;
 use crate::planning::unsupported_data_warning::add_unsupported_data_warnings;
 use crate::proto::gen::pretransform::{
     pre_transform_spec_warning::WarningType, PlannerWarning, PreTransformSpecWarning,
@@ -91,6 +92,9 @@ pub struct PlannerConfig {
     pub lift_facet_aggregations: bool,
     pub client_only_vars: Vec<ScopedVariable>,
     pub keep_variables: Vec<ScopedVariable>,
+    pub strip_description_encoding: bool,
+    pub strip_aria_encoding: bool,
+    pub strip_tooltip_encoding: bool,
 }
 
 impl Default for PlannerConfig {
@@ -107,6 +111,9 @@ impl Default for PlannerConfig {
             lift_facet_aggregations: true,
             client_only_vars: Default::default(),
             keep_variables: Default::default(),
+            strip_description_encoding: true,
+            strip_aria_encoding: true,
+            strip_tooltip_encoding: false,
         }
     }
 }
@@ -216,6 +223,8 @@ impl SpecPlan {
                     &domain_dataset_fields,
                 )?;
             }
+
+            strip_encodings(&mut client_spec, config)?;
 
             Ok(Self {
                 server_spec,

--- a/vegafusion-core/src/planning/plan.rs
+++ b/vegafusion-core/src/planning/plan.rs
@@ -162,6 +162,9 @@ impl SpecPlan {
             lift_facet_aggregations(&mut client_spec, config)?;
         }
 
+        // Remove unused encodings
+        strip_encodings(&mut client_spec, config)?;
+
         // Attempt to limit the columns produced by each dataset to only include those
         // that are actually used downstream
         if config.projection_pushdown {
@@ -223,8 +226,6 @@ impl SpecPlan {
                     &domain_dataset_fields,
                 )?;
             }
-
-            strip_encodings(&mut client_spec, config)?;
 
             Ok(Self {
                 server_spec,

--- a/vegafusion-core/src/planning/strip_encodings.rs
+++ b/vegafusion-core/src/planning/strip_encodings.rs
@@ -1,0 +1,37 @@
+use crate::planning::plan::PlannerConfig;
+use crate::spec::chart::{ChartSpec, MutChartVisitor};
+use crate::spec::mark::MarkSpec;
+use vegafusion_common::error::Result;
+
+pub fn strip_encodings(client_spec: &mut ChartSpec, config: &PlannerConfig) -> Result<()> {
+    let mut visitor = StripEncodingsVisitor { config };
+    client_spec.walk_mut(&mut visitor)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct StripEncodingsVisitor<'a> {
+    pub config: &'a PlannerConfig,
+}
+
+impl<'a> MutChartVisitor for StripEncodingsVisitor<'a> {
+    fn visit_non_group_mark(&mut self, mark: &mut MarkSpec, _scope: &[u32]) -> Result<()> {
+        let Some(encode) = &mut mark.encode else {
+            return Ok(());
+        };
+        for (_, encodings) in encode.encodings.iter_mut() {
+            if self.config.strip_description_encoding {
+                encodings.channels.remove("description");
+            }
+
+            if self.config.strip_aria_encoding {
+                encodings.channels.remove("ariaRoleDescription");
+            }
+
+            if self.config.strip_tooltip_encoding {
+                encodings.channels.remove("tooltip");
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
In the course of doing some benchmarking of pan and zoom on large scatterplots, I found that the `description` encoding that Vega-Lite adds by default has a significant performance penalty.

Here are some chrome profile flamegraphs for a 40k row version of the Vega-Lite pan/zoom example at https://vega.github.io/vega-lite/examples/selection_translate_scatterplot_drag.html

Default canvas renderer

<img width="1505" alt="Screenshot 2024-03-12 at 7 56 15 AM" src="https://github.com/hex-inc/vegafusion/assets/15064365/8b00fb25-61f6-4e03-af99-6575864f4ffa">

With description and ariaRoleDescription encoding channels removed.

<img width="1323" alt="Screenshot 2024-03-12 at 7 55 34 AM" src="https://github.com/hex-inc/vegafusion/assets/15064365/7f8f88ff-566c-45db-9bc4-64fc85d490db">

These encoding channels have no effect when used with the canvas renderer, which is what Vega-Altair uses.

